### PR TITLE
Tenant API: change structure of error response

### DIFF
--- a/packages/engine-system-api/src/model/events/DiffBuilder.ts
+++ b/packages/engine-system-api/src/model/events/DiffBuilder.ts
@@ -167,7 +167,7 @@ export enum DiffBuilderErrorCode {
 export class DiffBuilderErrorResponse {
 	public readonly ok: false = false
 
-	constructor(public readonly error: DiffBuilderErrorCode, public readonly message?: string) {}
+	constructor(public readonly error: DiffBuilderErrorCode, public readonly message: string) {}
 }
 
 export type EventWithDependencies = ContentEvent & { dependencies: string[] }

--- a/packages/engine-system-api/src/resolvers/helpers/StageFetchHelper.ts
+++ b/packages/engine-system-api/src/resolvers/helpers/StageFetchHelper.ts
@@ -38,7 +38,7 @@ export enum FetchStageErrors {
 export class FetchStageErrorResponse {
 	public readonly ok = false
 
-	constructor(public readonly error: FetchStageErrors, public readonly message?: string) {}
+	constructor(public readonly error: FetchStageErrors, public readonly message: string) {}
 }
 
 export class FetchStageOkResponse {

--- a/packages/engine-system-api/src/resolvers/mutation/MigrateMutationResolver.ts
+++ b/packages/engine-system-api/src/resolvers/mutation/MigrateMutationResolver.ts
@@ -26,7 +26,7 @@ export class MigrateMutationResolver implements MutationResolver<'migrate'> {
 					const error = {
 						code: e.code,
 						migration: e.version,
-						message: e.message,
+						developerMessage: e.message,
 					}
 					return {
 						ok: false,

--- a/packages/engine-system-api/src/resolvers/mutation/ReleaseMutationResolver.ts
+++ b/packages/engine-system-api/src/resolvers/mutation/ReleaseMutationResolver.ts
@@ -1,7 +1,7 @@
 import { GraphQLResolveInfo } from 'graphql'
 import { ResolverContext } from '../ResolverContext'
 import { MutationResolver } from '../Resolver'
-import { MutationReleaseArgs, ReleaseErrorCode, ReleaseResponse, ReleaseTreeErrorCode } from '../../schema'
+import { MutationReleaseArgs, ReleaseErrorCode, ReleaseResponse } from '../../schema'
 import { AuthorizationActions, RebaseExecutor, ReleaseExecutor, ReleaseExecutorErrorCode } from '../../model'
 import { FetchStageErrors, fetchStages } from '../helpers/StageFetchHelper'
 
@@ -26,7 +26,7 @@ export class ReleaseMutationResolver implements MutationResolver<'release'> {
 					errors: [code],
 					error: {
 						code,
-						message: stagesResult.message,
+						developerMessage: stagesResult.message,
 					},
 				}
 			}
@@ -56,10 +56,14 @@ export class ReleaseMutationResolver implements MutationResolver<'release'> {
 				const code = {
 					[ReleaseExecutorErrorCode.forbidden]: ReleaseErrorCode.Forbidden,
 				}[result.error]
+
 				return {
 					ok: false,
 					errors: [code],
-					error: { code },
+					error: {
+						code,
+						developerMessage: 'You are not allowed to release some of events.',
+					},
 				}
 			}
 

--- a/packages/engine-system-api/src/resolvers/mutation/ReleaseTreeMutationResolver.ts
+++ b/packages/engine-system-api/src/resolvers/mutation/ReleaseTreeMutationResolver.ts
@@ -38,7 +38,7 @@ export class ReleaseTreeMutationResolver implements MutationResolver<'releaseTre
 					errors: [code],
 					error: {
 						code,
-						message: stagesResult.message,
+						developerMessage: stagesResult.message,
 					},
 				}
 			}
@@ -72,7 +72,7 @@ export class ReleaseTreeMutationResolver implements MutationResolver<'releaseTre
 					errors: [code],
 					error: {
 						code,
-						message: diff.message,
+						developerMessage: diff.message,
 					},
 				}
 			}
@@ -97,7 +97,10 @@ export class ReleaseTreeMutationResolver implements MutationResolver<'releaseTre
 				return {
 					ok: false,
 					errors: [code],
-					error: { code },
+					error: {
+						code,
+						developerMessage: 'You are not allowed to release some of events.',
+					},
 				}
 			}
 

--- a/packages/engine-system-api/src/resolvers/query/DiffQueryResolver.ts
+++ b/packages/engine-system-api/src/resolvers/query/DiffQueryResolver.ts
@@ -29,7 +29,7 @@ export class DiffQueryResolver implements QueryResolver<'diff'> {
 					errors: [code],
 					error: {
 						code,
-						message: stagesResult.message,
+						developerMessage: stagesResult.message,
 					},
 				}
 			}
@@ -71,7 +71,7 @@ export class DiffQueryResolver implements QueryResolver<'diff'> {
 					errors: [code],
 					error: {
 						code,
-						message: diff.message,
+						developerMessage: diff.message,
 					},
 				}
 			}

--- a/packages/engine-system-api/src/resolvers/query/HistoryQueryResolver.ts
+++ b/packages/engine-system-api/src/resolvers/query/HistoryQueryResolver.ts
@@ -32,7 +32,7 @@ export class HistoryQueryResolver implements QueryResolver<'history'> {
 					errors: [HistoryErrorCode.StageNotFound],
 					error: {
 						code: HistoryErrorCode.StageNotFound,
-						message: `Stage ${args.stage} not found`,
+						developerMessage: `Stage ${args.stage} not found`,
 					},
 				}
 			}

--- a/packages/engine-system-api/src/schema/system.graphql.ts
+++ b/packages/engine-system-api/src/schema/system.graphql.ts
@@ -51,7 +51,7 @@ const schema: DocumentNode = gql`
 
 	type HistoryError {
 		code: HistoryErrorCode!
-		developerMessage: String
+		developerMessage: String!
 	}
 
 	type HistoryResponse {
@@ -143,7 +143,7 @@ const schema: DocumentNode = gql`
 
 	type DiffError {
 		code: DiffErrorCode!
-		developerMessage: String
+		developerMessage: String!
 	}
 
 	type DiffResponse {
@@ -201,7 +201,7 @@ const schema: DocumentNode = gql`
 	}
 
 	type MigrateResult {
-		developerMessage: String!
+		message: String!
 	}
 
 	# === release ===
@@ -214,7 +214,7 @@ const schema: DocumentNode = gql`
 
 	type ReleaseError {
 		code: ReleaseErrorCode!
-		developerMessage: String
+		developerMessage: String!
 	}
 
 	type ReleaseResponse {
@@ -235,7 +235,7 @@ const schema: DocumentNode = gql`
 
 	type ReleaseTreeError {
 		code: ReleaseTreeErrorCode!
-		developerMessage: String
+		developerMessage: String!
 	}
 
 	type ReleaseTreeResponse {

--- a/packages/engine-system-api/src/schema/system.graphql.ts
+++ b/packages/engine-system-api/src/schema/system.graphql.ts
@@ -51,7 +51,7 @@ const schema: DocumentNode = gql`
 
 	type HistoryError {
 		code: HistoryErrorCode!
-		message: String
+		developerMessage: String
 	}
 
 	type HistoryResponse {
@@ -143,7 +143,7 @@ const schema: DocumentNode = gql`
 
 	type DiffError {
 		code: DiffErrorCode!
-		message: String
+		developerMessage: String
 	}
 
 	type DiffResponse {
@@ -190,7 +190,7 @@ const schema: DocumentNode = gql`
 	type MigrateError {
 		code: MigrateErrorCode!
 		migration: String!
-		message: String!
+		developerMessage: String!
 	}
 
 	type MigrateResponse {
@@ -201,7 +201,7 @@ const schema: DocumentNode = gql`
 	}
 
 	type MigrateResult {
-		message: String!
+		developerMessage: String!
 	}
 
 	# === release ===
@@ -214,7 +214,7 @@ const schema: DocumentNode = gql`
 
 	type ReleaseError {
 		code: ReleaseErrorCode!
-		message: String
+		developerMessage: String
 	}
 
 	type ReleaseResponse {
@@ -235,7 +235,7 @@ const schema: DocumentNode = gql`
 
 	type ReleaseTreeError {
 		code: ReleaseTreeErrorCode!
-		message: String
+		developerMessage: String
 	}
 
 	type ReleaseTreeResponse {

--- a/packages/engine-system-api/src/schema/types.ts
+++ b/packages/engine-system-api/src/schema/types.ts
@@ -89,7 +89,7 @@ export enum HistoryErrorCode {
 export type HistoryError = {
 	readonly __typename?: 'HistoryError'
 	readonly code: HistoryErrorCode
-	readonly message?: Maybe<Scalars['String']>
+	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export type HistoryResponse = {
@@ -187,7 +187,7 @@ export enum DiffErrorCode {
 export type DiffError = {
 	readonly __typename?: 'DiffError'
 	readonly code: DiffErrorCode
-	readonly message?: Maybe<Scalars['String']>
+	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export type DiffResponse = {
@@ -235,7 +235,7 @@ export type MigrateError = {
 	readonly __typename?: 'MigrateError'
 	readonly code: MigrateErrorCode
 	readonly migration: Scalars['String']
-	readonly message: Scalars['String']
+	readonly developerMessage: Scalars['String']
 }
 
 export type MigrateResponse = {
@@ -249,7 +249,7 @@ export type MigrateResponse = {
 
 export type MigrateResult = {
 	readonly __typename?: 'MigrateResult'
-	readonly message: Scalars['String']
+	readonly developerMessage: Scalars['String']
 }
 
 export enum ReleaseErrorCode {
@@ -262,7 +262,7 @@ export enum ReleaseErrorCode {
 export type ReleaseError = {
 	readonly __typename?: 'ReleaseError'
 	readonly code: ReleaseErrorCode
-	readonly message?: Maybe<Scalars['String']>
+	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export type ReleaseResponse = {
@@ -284,7 +284,7 @@ export enum ReleaseTreeErrorCode {
 export type ReleaseTreeError = {
 	readonly __typename?: 'ReleaseTreeError'
 	readonly code: ReleaseTreeErrorCode
-	readonly message?: Maybe<Scalars['String']>
+	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export type ReleaseTreeResponse = {
@@ -606,7 +606,7 @@ export type HistoryErrorResolvers<
 	ParentType extends ResolversParentTypes['HistoryError'] = ResolversParentTypes['HistoryError']
 > = {
 	code?: Resolver<ResolversTypes['HistoryErrorCode'], ParentType, ContextType>
-	message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -718,7 +718,7 @@ export type DiffErrorResolvers<
 	ParentType extends ResolversParentTypes['DiffError'] = ResolversParentTypes['DiffError']
 > = {
 	code?: Resolver<ResolversTypes['DiffErrorCode'], ParentType, ContextType>
-	message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -762,7 +762,7 @@ export type MigrateErrorResolvers<
 > = {
 	code?: Resolver<ResolversTypes['MigrateErrorCode'], ParentType, ContextType>
 	migration?: Resolver<ResolversTypes['String'], ParentType, ContextType>
-	message?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -781,7 +781,7 @@ export type MigrateResultResolvers<
 	ContextType = any,
 	ParentType extends ResolversParentTypes['MigrateResult'] = ResolversParentTypes['MigrateResult']
 > = {
-	message?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -790,7 +790,7 @@ export type ReleaseErrorResolvers<
 	ParentType extends ResolversParentTypes['ReleaseError'] = ResolversParentTypes['ReleaseError']
 > = {
 	code?: Resolver<ResolversTypes['ReleaseErrorCode'], ParentType, ContextType>
-	message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -809,7 +809,7 @@ export type ReleaseTreeErrorResolvers<
 	ParentType extends ResolversParentTypes['ReleaseTreeError'] = ResolversParentTypes['ReleaseTreeError']
 > = {
 	code?: Resolver<ResolversTypes['ReleaseTreeErrorCode'], ParentType, ContextType>
-	message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 

--- a/packages/engine-system-api/src/schema/types.ts
+++ b/packages/engine-system-api/src/schema/types.ts
@@ -89,7 +89,7 @@ export enum HistoryErrorCode {
 export type HistoryError = {
 	readonly __typename?: 'HistoryError'
 	readonly code: HistoryErrorCode
-	readonly developerMessage?: Maybe<Scalars['String']>
+	readonly developerMessage: Scalars['String']
 }
 
 export type HistoryResponse = {
@@ -187,7 +187,7 @@ export enum DiffErrorCode {
 export type DiffError = {
 	readonly __typename?: 'DiffError'
 	readonly code: DiffErrorCode
-	readonly developerMessage?: Maybe<Scalars['String']>
+	readonly developerMessage: Scalars['String']
 }
 
 export type DiffResponse = {
@@ -249,7 +249,7 @@ export type MigrateResponse = {
 
 export type MigrateResult = {
 	readonly __typename?: 'MigrateResult'
-	readonly developerMessage: Scalars['String']
+	readonly message: Scalars['String']
 }
 
 export enum ReleaseErrorCode {
@@ -262,7 +262,7 @@ export enum ReleaseErrorCode {
 export type ReleaseError = {
 	readonly __typename?: 'ReleaseError'
 	readonly code: ReleaseErrorCode
-	readonly developerMessage?: Maybe<Scalars['String']>
+	readonly developerMessage: Scalars['String']
 }
 
 export type ReleaseResponse = {
@@ -284,7 +284,7 @@ export enum ReleaseTreeErrorCode {
 export type ReleaseTreeError = {
 	readonly __typename?: 'ReleaseTreeError'
 	readonly code: ReleaseTreeErrorCode
-	readonly developerMessage?: Maybe<Scalars['String']>
+	readonly developerMessage: Scalars['String']
 }
 
 export type ReleaseTreeResponse = {
@@ -606,7 +606,7 @@ export type HistoryErrorResolvers<
 	ParentType extends ResolversParentTypes['HistoryError'] = ResolversParentTypes['HistoryError']
 > = {
 	code?: Resolver<ResolversTypes['HistoryErrorCode'], ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -718,7 +718,7 @@ export type DiffErrorResolvers<
 	ParentType extends ResolversParentTypes['DiffError'] = ResolversParentTypes['DiffError']
 > = {
 	code?: Resolver<ResolversTypes['DiffErrorCode'], ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -781,7 +781,7 @@ export type MigrateResultResolvers<
 	ContextType = any,
 	ParentType extends ResolversParentTypes['MigrateResult'] = ResolversParentTypes['MigrateResult']
 > = {
-	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	message?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -790,7 +790,7 @@ export type ReleaseErrorResolvers<
 	ParentType extends ResolversParentTypes['ReleaseError'] = ResolversParentTypes['ReleaseError']
 > = {
 	code?: Resolver<ResolversTypes['ReleaseErrorCode'], ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -809,7 +809,7 @@ export type ReleaseTreeErrorResolvers<
 	ParentType extends ResolversParentTypes['ReleaseTreeError'] = ResolversParentTypes['ReleaseTreeError']
 > = {
 	code?: Resolver<ResolversTypes['ReleaseTreeErrorCode'], ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 

--- a/packages/engine-system-api/tests/cases/integration/systemApi/diff.test.ts
+++ b/packages/engine-system-api/tests/cases/integration/systemApi/diff.test.ts
@@ -115,7 +115,7 @@ diffTest('invalid filter', async () => {
 			diff(stage: "preview", filter: [{entity: "User", id: "${testUuid(1)}"}]) {
 				error {
 					code
-					message
+					developerMessage
 				}
 			}
 		}`)
@@ -124,7 +124,7 @@ diffTest('invalid filter', async () => {
 			diff: {
 				error: {
 					code: 'INVALID_FILTER',
-					message: 'User: entity not found',
+					developerMessage: 'User: entity not found',
 				},
 			},
 		},
@@ -135,7 +135,7 @@ diffTest('invalid filter', async () => {
 			)}", relations: [{name: "articles", relations: []}]}]) {
 				error {
 					code
-					message
+					developerMessage
 				}
 			}
 		}`)
@@ -144,7 +144,7 @@ diffTest('invalid filter', async () => {
 			diff: {
 				error: {
 					code: 'INVALID_FILTER',
-					message: 'Author.articles: field not found',
+					developerMessage: 'Author.articles: field not found',
 				},
 			},
 		},

--- a/packages/engine-tenant-api/src/model/commands/ApiKeyHelper.ts
+++ b/packages/engine-tenant-api/src/model/commands/ApiKeyHelper.ts
@@ -3,7 +3,7 @@ import { Providers } from '../providers'
 import { plusMinutes } from '../utils/time'
 
 const DEFAULT_EXPIRATION = 30
-class ApiKeyHelper {
+export class ApiKeyHelper {
 	public static getExpiration(providers: Providers, type: ApiKey.Type, expiration?: number): Date | null {
 		switch (type) {
 			case ApiKey.Type.PERMANENT:
@@ -17,5 +17,3 @@ class ApiKeyHelper {
 		}
 	}
 }
-
-export { ApiKeyHelper }

--- a/packages/engine-tenant-api/src/model/commands/ChangePasswordCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/ChangePasswordCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from './Command'
 import { UpdateBuilder } from '@contember/database'
 
-class ChangePasswordCommand implements Command<void> {
+export class ChangePasswordCommand implements Command<void> {
 	constructor(private readonly personId: string, private readonly password: string) {}
 
 	async execute({ db, providers }: Command.Args): Promise<void> {
@@ -16,5 +16,3 @@ class ChangePasswordCommand implements Command<void> {
 			.execute(db)
 	}
 }
-
-export { ChangePasswordCommand }

--- a/packages/engine-tenant-api/src/model/commands/CreateApiKeyCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/CreateApiKeyCommand.ts
@@ -4,7 +4,7 @@ import { ApiKeyHelper } from './ApiKeyHelper'
 import { InsertBuilder } from '@contember/database'
 import { computeTokenHash, generateToken } from '../utils'
 
-class CreateApiKeyCommand implements Command<CreateApiKeyCommand.Result> {
+export class CreateApiKeyCommand implements Command<CreateApiKeyCommandResult> {
 	private readonly type: ApiKey.Type
 	private readonly identityId: string
 	private readonly expiration: number | undefined
@@ -17,7 +17,7 @@ class CreateApiKeyCommand implements Command<CreateApiKeyCommand.Result> {
 		this.expiration = expiration
 	}
 
-	async execute({ db, providers }: Command.Args): Promise<CreateApiKeyCommand.Result> {
+	async execute({ db, providers }: Command.Args): Promise<CreateApiKeyCommandResult> {
 		const apiKeyId = providers.uuid()
 		const token = await generateToken(providers)
 		const tokenHash = computeTokenHash(token)
@@ -36,14 +36,9 @@ class CreateApiKeyCommand implements Command<CreateApiKeyCommand.Result> {
 			})
 			.execute(db)
 
-		return new CreateApiKeyCommand.Result(apiKeyId, token)
+		return new CreateApiKeyCommandResult(apiKeyId, token)
 	}
 }
-
-namespace CreateApiKeyCommand {
-	export class Result {
-		constructor(public readonly id: string, public readonly token: string) {}
-	}
+export class CreateApiKeyCommandResult {
+	constructor(public readonly id: string, public readonly token: string) {}
 }
-
-export { CreateApiKeyCommand }

--- a/packages/engine-tenant-api/src/model/commands/CreateIdentityCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/CreateIdentityCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from './Command'
 import { InsertBuilder } from '@contember/database'
 
-class CreateIdentityCommand implements Command<string> {
+export class CreateIdentityCommand implements Command<string> {
 	constructor(private readonly roles: string[], private readonly description?: string) {}
 
 	public async execute({ db, providers }: Command.Args): Promise<string> {
@@ -20,5 +20,3 @@ class CreateIdentityCommand implements Command<string> {
 		return identityId
 	}
 }
-
-export { CreateIdentityCommand }

--- a/packages/engine-tenant-api/src/model/commands/CreateOrUpdateProjectCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/CreateOrUpdateProjectCommand.ts
@@ -2,7 +2,7 @@ import { ConflictActionType, InsertBuilder, Operator } from '@contember/database
 import { Command } from './Command'
 import { Project } from '../type'
 
-class CreateOrUpdateProjectCommand implements Command<boolean> {
+export class CreateOrUpdateProjectCommand implements Command<boolean> {
 	constructor(private readonly project: Pick<Project, 'name' | 'slug'>) {}
 
 	public async execute({ db, providers }: Command.Args): Promise<boolean> {
@@ -25,5 +25,3 @@ class CreateOrUpdateProjectCommand implements Command<boolean> {
 		return result > 0
 	}
 }
-
-export { CreateOrUpdateProjectCommand }

--- a/packages/engine-tenant-api/src/model/commands/CreatePersonCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/CreatePersonCommand.ts
@@ -2,7 +2,7 @@ import { Command } from './Command'
 import { PersonRow } from '../queries'
 import { InsertBuilder } from '@contember/database'
 
-class CreatePersonCommand implements Command<Omit<PersonRow, 'roles'>> {
+export class CreatePersonCommand implements Command<Omit<PersonRow, 'roles'>> {
 	constructor(private readonly identityId: string, private readonly email: string, private readonly password: string) {}
 
 	async execute({ db, providers }: Command.Args): Promise<Omit<PersonRow, 'roles'>> {
@@ -22,5 +22,3 @@ class CreatePersonCommand implements Command<Omit<PersonRow, 'roles'>> {
 		return { id, email: this.email, password_hash, identity_id: this.identityId, otp_uri: null, otp_activated_at: null }
 	}
 }
-
-export { CreatePersonCommand }

--- a/packages/engine-tenant-api/src/model/commands/DisableApiKeyCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/DisableApiKeyCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from './Command'
 import { UpdateBuilder } from '@contember/database'
 
-class DisableApiKeyCommand implements Command<boolean> {
+export class DisableApiKeyCommand implements Command<boolean> {
 	constructor(private readonly apiKeyId: string) {}
 
 	async execute({ db }: Command.Args): Promise<boolean> {
@@ -15,5 +15,3 @@ class DisableApiKeyCommand implements Command<boolean> {
 		return (await qb.execute(db)) > 0
 	}
 }
-
-export { DisableApiKeyCommand }

--- a/packages/engine-tenant-api/src/model/commands/DisableIdentityApiKeysCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/DisableIdentityApiKeysCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from './Command'
 import { UpdateBuilder } from '@contember/database'
 
-class DisableIdentityApiKeysCommand implements Command<void> {
+export class DisableIdentityApiKeysCommand implements Command<void> {
 	constructor(private readonly identityId: string) {}
 
 	async execute({ db }: Command.Args): Promise<void> {
@@ -15,5 +15,3 @@ class DisableIdentityApiKeysCommand implements Command<void> {
 		await qb.execute(db)
 	}
 }
-
-export { DisableIdentityApiKeysCommand }

--- a/packages/engine-tenant-api/src/model/commands/DisableOneOffApiKeyCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/DisableOneOffApiKeyCommand.ts
@@ -2,7 +2,7 @@ import { Command } from './Command'
 import { ApiKey } from '../type'
 import { UpdateBuilder } from '@contember/database'
 
-class DisableOneOffApiKeyCommand implements Command<void> {
+export class DisableOneOffApiKeyCommand implements Command<void> {
 	constructor(private readonly apiKeyId: string) {}
 
 	async execute({ db }: Command.Args): Promise<void> {
@@ -17,5 +17,3 @@ class DisableOneOffApiKeyCommand implements Command<void> {
 		await qb.execute(db)
 	}
 }
-
-export { DisableOneOffApiKeyCommand }

--- a/packages/engine-tenant-api/src/model/commands/ProlongApiKeyCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/ProlongApiKeyCommand.ts
@@ -3,7 +3,7 @@ import { ApiKey } from '../type'
 import { ApiKeyHelper } from './ApiKeyHelper'
 import { UpdateBuilder } from '@contember/database'
 
-class ProlongApiKeyCommand implements Command<void> {
+export class ProlongApiKeyCommand implements Command<void> {
 	constructor(private readonly id: string, private readonly type: ApiKey.Type, private readonly expiration?: number) {}
 
 	async execute({ db, providers }: Command.Args): Promise<void> {
@@ -20,5 +20,3 @@ class ProlongApiKeyCommand implements Command<void> {
 		await qb.execute(db)
 	}
 }
-
-export { ProlongApiKeyCommand }

--- a/packages/engine-tenant-api/src/model/commands/membership/AddProjectMemberCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/membership/AddProjectMemberCommand.ts
@@ -23,7 +23,10 @@ export class AddProjectMemberCommand implements Command<CommandResponse> {
 			})
 			.getResult(db)
 		if (result.length > 0) {
-			return new ResponseError(AddProjectMemberCommandError.alreadyMember)
+			return new ResponseError(
+				AddProjectMemberCommandError.alreadyMember,
+				`This identity is already a project member. Use updateProjectMember mutation to change memberships.`,
+			)
 		}
 
 		try {
@@ -34,9 +37,9 @@ export class AddProjectMemberCommand implements Command<CommandResponse> {
 		} catch (e) {
 			switch (e.constraint) {
 				case 'project_membership_project':
-					return new ResponseError(AddProjectMemberCommandError.projectNotFound)
+					return new ResponseError(AddProjectMemberCommandError.projectNotFound, 'Project not found')
 				case 'project_membership_identity':
-					return new ResponseError(AddProjectMemberCommandError.identityNotfound)
+					return new ResponseError(AddProjectMemberCommandError.identityNotfound, 'Identity not found')
 				default:
 					throw e
 			}

--- a/packages/engine-tenant-api/src/model/commands/membership/RemoveProjectMemberCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/membership/RemoveProjectMemberCommand.ts
@@ -1,11 +1,12 @@
 import { Command } from '../Command'
 import { RemoveProjectMemberErrorCode } from '../../../schema'
 import { DeleteBuilder } from '@contember/database'
+import { Response, ResponseError, ResponseOk } from '../../utils/Response'
 
-class RemoveProjectMemberCommand implements Command<RemoveProjectMemberCommand.RemoveProjectMemberResponse> {
+export class RemoveProjectMemberCommand implements Command<RemoveProjectMemberResponse> {
 	constructor(private readonly projectId: string, private readonly identityId: string) {}
 
-	async execute({ db, bus }: Command.Args): Promise<RemoveProjectMemberCommand.RemoveProjectMemberResponse> {
+	async execute({ db, bus }: Command.Args): Promise<RemoveProjectMemberResponse> {
 		const memberWhere = {
 			project_id: this.projectId,
 			identity_id: this.identityId,
@@ -16,27 +17,10 @@ class RemoveProjectMemberCommand implements Command<RemoveProjectMemberCommand.R
 			.execute(db)
 
 		if (result === 0) {
-			return new RemoveProjectMemberCommand.RemoveProjectMemberResponseError([RemoveProjectMemberErrorCode.NotMember])
+			return new ResponseError(RemoveProjectMemberErrorCode.NotMember, 'Not a project member')
 		}
-
-		return new RemoveProjectMemberCommand.RemoveProjectMemberResponseOk()
+		return new ResponseOk(null)
 	}
 }
 
-namespace RemoveProjectMemberCommand {
-	export type RemoveProjectMemberResponse = RemoveProjectMemberResponseOk | RemoveProjectMemberResponseError
-
-	export class RemoveProjectMemberResponseOk {
-		readonly ok = true
-
-		constructor() {}
-	}
-
-	export class RemoveProjectMemberResponseError {
-		readonly ok = false
-
-		constructor(public readonly errors: Array<RemoveProjectMemberErrorCode>) {}
-	}
-}
-
-export { RemoveProjectMemberCommand }
+export type RemoveProjectMemberResponse = Response<null, RemoveProjectMemberErrorCode>

--- a/packages/engine-tenant-api/src/model/commands/membership/RemoveProjectMembershipsCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/membership/RemoveProjectMembershipsCommand.ts
@@ -1,6 +1,5 @@
 import { Command } from '../Command'
 import { DeleteBuilder } from '@contember/database'
-import { MembershipInput } from './types'
 
 export class RemoveProjectMembershipCommand implements Command<void> {
 	constructor(private readonly projectId: string, private readonly identityId: string, private readonly role: string) {}

--- a/packages/engine-tenant-api/src/model/commands/membership/variables/PatchProjectMembershipVariableValuesCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/membership/variables/PatchProjectMembershipVariableValuesCommand.ts
@@ -1,7 +1,7 @@
 import { Command } from '../../Command'
 import { ConflictActionType, InsertBuilder, Literal } from '@contember/database'
 
-class PatchProjectMembershipVariableValuesCommand implements Command<string[]> {
+export class PatchProjectMembershipVariableValuesCommand implements Command<string[]> {
 	constructor(
 		private readonly membershipId: string,
 		private readonly name: string,
@@ -44,5 +44,3 @@ class PatchProjectMembershipVariableValuesCommand implements Command<string[]> {
 		return result as string[]
 	}
 }
-
-export { PatchProjectMembershipVariableValuesCommand }

--- a/packages/engine-tenant-api/src/model/commands/membership/variables/PatchProjectMembershipVariablesCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/membership/variables/PatchProjectMembershipVariablesCommand.ts
@@ -3,7 +3,7 @@ import { SetProjectMembershipVariableValuesCommand } from './SetProjectMembershi
 import { PatchProjectMembershipVariableValuesCommand } from './PatchProjectMembershipVariableValuesCommand'
 import { VariableUpdateInput } from '../types'
 
-class PatchProjectMembershipVariablesCommand implements Command<Record<string, string[]>> {
+export class PatchProjectMembershipVariablesCommand implements Command<Record<string, string[]>> {
 	constructor(private readonly membershipId: string, private readonly variables: readonly VariableUpdateInput[]) {}
 
 	async execute({ db, providers, bus }: Command.Args): Promise<Record<string, string[]>> {
@@ -26,5 +26,3 @@ class PatchProjectMembershipVariablesCommand implements Command<Record<string, s
 		return Object.fromEntries(results)
 	}
 }
-
-export { PatchProjectMembershipVariablesCommand }

--- a/packages/engine-tenant-api/src/model/commands/passwordReset/CreatePasswordResetRequestCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/passwordReset/CreatePasswordResetRequestCommand.ts
@@ -5,10 +5,10 @@ import { plusMinutes } from '../../utils/time'
 
 const PASSWORD_RESET_EXPIRATION = 60
 
-class CreatePasswordResetRequestCommand implements Command<CreatePasswordResetRequestCommand.Result> {
+export class CreatePasswordResetRequestCommand implements Command<CreatePasswordResetRequestResult> {
 	constructor(private readonly personId: string) {}
 
-	async execute({ db, providers }: Command.Args): Promise<CreatePasswordResetRequestCommand.Result> {
+	async execute({ db, providers }: Command.Args): Promise<CreatePasswordResetRequestResult> {
 		const token = await generateToken(providers)
 		const tokenHash = computeTokenHash(token)
 
@@ -24,14 +24,9 @@ class CreatePasswordResetRequestCommand implements Command<CreatePasswordResetRe
 			})
 			.execute(db)
 
-		return new CreatePasswordResetRequestCommand.Result(token)
+		return new CreatePasswordResetRequestResult(token)
 	}
 }
-
-namespace CreatePasswordResetRequestCommand {
-	export class Result {
-		constructor(public readonly token: string) {}
-	}
+export class CreatePasswordResetRequestResult {
+	constructor(public readonly token: string) {}
 }
-
-export { CreatePasswordResetRequestCommand }

--- a/packages/engine-tenant-api/src/model/commands/passwordReset/ResetPasswordCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/passwordReset/ResetPasswordCommand.ts
@@ -23,14 +23,20 @@ export class ResetPasswordCommand implements Command<ResetPasswordCommandRespons
 					.getResult(db)
 			)[0] || null
 		if (!result) {
-			return new ResponseError(ResetPasswordCommandErrorCode.TOKEN_NOT_FOUND)
+			return new ResponseError(ResetPasswordCommandErrorCode.TOKEN_NOT_FOUND, 'Token was not found')
 		}
 		if (result.used_at) {
-			return new ResponseError(ResetPasswordCommandErrorCode.TOKEN_USED)
+			return new ResponseError(
+				ResetPasswordCommandErrorCode.TOKEN_USED,
+				`Token was used at ${result.used_at.toISOString()}`,
+			)
 		}
 		const now = providers.now()
 		if (result.expires_at < now) {
-			return new ResponseError(ResetPasswordCommandErrorCode.TOKEN_EXPIRED)
+			return new ResponseError(
+				ResetPasswordCommandErrorCode.TOKEN_EXPIRED,
+				`Token expired at ${result.expires_at.toISOString()}`,
+			)
 		}
 		const count = await UpdateBuilder.create()
 			.table('person_password_reset')

--- a/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
+++ b/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
@@ -35,7 +35,7 @@ class IDPSignInManager {
 			)
 			const personRow = await this.queryHandler.fetch(PersonQuery.byEmail(claim.email))
 			if (!personRow) {
-				return new ResponseError(SignInIdpErrorCode.PersonNotFound)
+				return new ResponseError(SignInIdpErrorCode.PersonNotFound, `Person ${claim.email} not found`)
 			}
 
 			const sessionToken = await this.apiKeyManager.createSessionApiKey(personRow.identity_id, expiration)
@@ -54,7 +54,7 @@ class IDPSignInManager {
 	async initSignInIDP(idpSlug: string, redirectUrl: string): Promise<IDPSignInManager.InitSignInIDPResponse> {
 		const provider = await this.queryHandler.fetch(new IdentityProviderQuery(idpSlug))
 		if (!provider) {
-			return new ResponseError(InitSignInIdpErrorCode.ProviderNotFound)
+			return new ResponseError(InitSignInIdpErrorCode.ProviderNotFound, `IDP provider ${idpSlug} was not found`)
 		}
 		const initResponse = await this.idpManager.initAuth(provider.type, provider.configuration, redirectUrl)
 		return new ResponseOk(initResponse)

--- a/packages/engine-tenant-api/src/model/service/InviteManager.ts
+++ b/packages/engine-tenant-api/src/model/service/InviteManager.ts
@@ -9,6 +9,7 @@ import { UserMailer } from '../mailing'
 import { Project } from '../type'
 import { createAppendMembershipVariables } from './membershipUtils'
 import { CreateOrUpdateProjectMembershipCommand } from '../commands/membership/CreateOrUpdateProjectMembershipCommand'
+import { Response, ResponseOk } from '../utils/Response'
 
 export interface InviteOptions {
 	noEmail?: boolean
@@ -56,21 +57,13 @@ export class InviteManager {
 					await this.mailer.sendExistingUserInvitedEmail({ email, project: project.name }, customMailOptions)
 				}
 			}
-			return new InviteResponseOk(person, isNew)
+			return new ResponseOk(new InviteResult(person, isNew))
 		})
 	}
 }
 
-export type InviteResponse = InviteResponseOk | InviteResponseError
+export type InviteResponse = Response<InviteResult, InviteErrorCode>
 
-export class InviteResponseOk {
-	readonly ok = true
-
+export class InviteResult {
 	constructor(public readonly person: Omit<PersonRow, 'roles'>, public readonly isNew: boolean) {}
-}
-
-export class InviteResponseError {
-	readonly ok = false
-
-	constructor(public readonly errors: Array<InviteErrorCode>) {}
 }

--- a/packages/engine-tenant-api/src/model/service/MembershipValidator.ts
+++ b/packages/engine-tenant-api/src/model/service/MembershipValidator.ts
@@ -33,10 +33,6 @@ export class MembershipValidator {
 				const inputVariable = membership.variables.find(it => it.name === variable)
 				if (!inputVariable || inputVariable.values.length === 0) {
 					errors.push(
-						new MembershipValidationError(membership.role, MembershipValidationErrorType.VARIABLE_NOT_SET, variable),
-					)
-				} else if (inputVariable.values.length === 0) {
-					errors.push(
 						new MembershipValidationError(membership.role, MembershipValidationErrorType.VARIABLE_EMPTY, variable),
 					)
 				}
@@ -57,6 +53,5 @@ export class MembershipValidationError {
 export enum MembershipValidationErrorType {
 	ROLE_NOT_FOUND = 'roleNotFound',
 	VARIABLE_NOT_FOUND = 'variableNotFound',
-	VARIABLE_NOT_SET = 'variableEmpty',
 	VARIABLE_EMPTY = 'variableEmpty',
 }

--- a/packages/engine-tenant-api/src/model/service/PasswordChangeManager.ts
+++ b/packages/engine-tenant-api/src/model/service/PasswordChangeManager.ts
@@ -1,32 +1,25 @@
 import { ChangePasswordErrorCode } from '../../schema'
-import { ChangePasswordCommand } from '../commands'
-import { CommandBus } from '../commands'
-import { isWeakPassword } from '../utils/password'
+import { ChangePasswordCommand, CommandBus } from '../commands'
+import { isWeakPassword, MIN_PASSWORD_LENGTH } from '../utils/password'
+import { Response, ResponseError, ResponseOk } from '../utils/Response'
 
 class PasswordChangeManager {
 	constructor(private readonly commandBus: CommandBus) {}
 
-	async changePassword(personId: string, password: string): Promise<PasswordChangeManager.PasswordChangeResult> {
+	async changePassword(personId: string, password: string): Promise<PasswordChangeManager.PasswordChangeResponse> {
 		if (isWeakPassword(password)) {
-			return new PasswordChangeManager.PasswordChangeResultError([ChangePasswordErrorCode.TooWeak])
+			return new ResponseError(
+				ChangePasswordErrorCode.TooWeak,
+				`Password is too weak. Minimum length is ${MIN_PASSWORD_LENGTH}`,
+			)
 		}
 		await this.commandBus.execute(new ChangePasswordCommand(personId, password))
-		return new PasswordChangeManager.PasswordChangeResultOk()
+		return new ResponseOk(null)
 	}
 }
 
 namespace PasswordChangeManager {
-	export type PasswordChangeResult = PasswordChangeResultOk | PasswordChangeResultError
-
-	export class PasswordChangeResultOk {
-		readonly ok = true
-	}
-
-	export class PasswordChangeResultError {
-		readonly ok = false
-
-		constructor(public readonly errors: Array<ChangePasswordErrorCode>) {}
-	}
+	export type PasswordChangeResponse = Response<null, ChangePasswordErrorCode>
 }
 
 export { PasswordChangeManager }

--- a/packages/engine-tenant-api/src/model/service/PasswordResetManager.ts
+++ b/packages/engine-tenant-api/src/model/service/PasswordResetManager.ts
@@ -5,11 +5,12 @@ import {
 	ResetPasswordCommandErrorCode,
 } from '../commands'
 import { Response, ResponseError } from '../utils/Response'
-import { isWeakPassword } from '../utils/password'
+import { isWeakPassword, MIN_PASSWORD_LENGTH } from '../utils/password'
 import { UserMailer } from '../mailing'
 import { PersonRow } from '../queries'
 import { PermissionContextFactory } from '../authorization'
 import { ProjectManager } from './ProjectManager'
+import { ChangePasswordErrorCode } from '../../schema'
 
 interface MailOptions {
 	project?: string
@@ -55,7 +56,10 @@ export class PasswordResetManager {
 
 	public async resetPassword(token: string, password: string): Promise<ResetPasswordResponse> {
 		if (isWeakPassword(password)) {
-			return new ResponseError(ResetPasswordErrorCode.PASSWORD_TOO_WEAK)
+			return new ResponseError(
+				ResetPasswordErrorCode.PASSWORD_TOO_WEAK,
+				`Password is too weak. Minimum length is ${MIN_PASSWORD_LENGTH}`,
+			)
 		}
 		return await this.commandBus.execute(new ResetPasswordCommand(token, password))
 	}

--- a/packages/engine-tenant-api/src/model/utils/Response.ts
+++ b/packages/engine-tenant-api/src/model/utils/Response.ts
@@ -1,4 +1,4 @@
-export type Response<Result, Error> = ResponseOk<Result> | ResponseError<Error>
+export type Response<Result, Error> = ResponseOk<Result> | (Error extends never ? never : ResponseError<Error>)
 
 export class ResponseOk<Result> {
 	public readonly ok = true
@@ -9,5 +9,5 @@ export class ResponseOk<Result> {
 export class ResponseError<Error> {
 	public readonly ok = false
 
-	constructor(public readonly error: Error, public readonly errorMessage?: string) {}
+	constructor(public readonly error: Error, public readonly errorMessage: string) {}
 }

--- a/packages/engine-tenant-api/src/model/utils/password.ts
+++ b/packages/engine-tenant-api/src/model/utils/password.ts
@@ -1,1 +1,2 @@
-export const isWeakPassword = (password: string) => password.length < 6
+export const MIN_PASSWORD_LENGTH = 6
+export const isWeakPassword = (password: string) => password.length < MIN_PASSWORD_LENGTH

--- a/packages/engine-tenant-api/src/resolvers/errorUtils.ts
+++ b/packages/engine-tenant-api/src/resolvers/errorUtils.ts
@@ -1,0 +1,8 @@
+type Error<T> = { code: T; developerMessage: string }
+type ErrorResponse<T> = { ok: false; error: Error<T>; errors: [Error<T>] }
+export const createErrorResponse = <T>(code: T, developerMessage: string): ErrorResponse<T> => {
+	const error = { code, developerMessage }
+	return { ok: false, error, errors: [error] }
+}
+export const createProjectNotFoundResponse = <T>(code: T, projectSlug: string): ErrorResponse<T> =>
+	createErrorResponse(code, `Project ${projectSlug} was not found or you are not allowed to access it.`)

--- a/packages/engine-tenant-api/src/resolvers/membershipUtils.ts
+++ b/packages/engine-tenant-api/src/resolvers/membershipUtils.ts
@@ -43,7 +43,10 @@ export const createMembershipValidationErrorResult = <Code>(
 	return [
 		{
 			code: (MembershipErrorCode.InvalidMembership as unknown) as Code,
-			developerMessage: legacyErrors.map(it => it.developerMessage).join('. '),
+			developerMessage:
+				'Provided membership is invalid: ' +
+				legacyErrors.map(it => it.developerMessage).join('. ') +
+				'. You can also check membershipValidation field for structured details.',
 			membershipValidation: result.map(it => {
 				switch (it.error) {
 					case MembershipValidationErrorType.ROLE_NOT_FOUND:

--- a/packages/engine-tenant-api/src/resolvers/mutation/apiKey/DisableApiKeyMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/apiKey/DisableApiKeyMutationResolver.ts
@@ -7,6 +7,7 @@ import {
 import { GraphQLResolveInfo } from 'graphql'
 import { ResolverContext } from '../../ResolverContext'
 import { PermissionActions, ApiKeyManager } from '../../../model'
+import { createErrorResponse } from '../../errorUtils'
 
 export class DisableApiKeyMutationResolver implements MutationResolvers {
 	constructor(private readonly apiKeyManager: ApiKeyManager) {}
@@ -25,10 +26,7 @@ export class DisableApiKeyMutationResolver implements MutationResolvers {
 		const result = await this.apiKeyManager.disableApiKey(id)
 
 		if (!result) {
-			return {
-				ok: false,
-				errors: [{ code: DisableApiKeyErrorCode.KeyNotFound }],
-			}
+			return createErrorResponse(DisableApiKeyErrorCode.KeyNotFound, 'API key not found')
 		}
 
 		return {

--- a/packages/engine-tenant-api/src/resolvers/mutation/mailTemplates/MailTemplateMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/mailTemplates/MailTemplateMutationResolver.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../schema'
 import { ResolverContext } from '../../ResolverContext'
 import { MailTemplateManager, MailType, PermissionActions, ProjectManager } from '../../../model'
+import { createErrorResponse, createProjectNotFoundResponse } from '../../errorUtils'
 
 export class MailTemplateMutationResolver implements MutationResolvers {
 	constructor(
@@ -29,10 +30,7 @@ export class MailTemplateMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to add a mail template',
 		})
 		if (!project) {
-			return {
-				ok: false,
-				errors: [{ code: AddMailTemplateErrorCode.ProjectNotFound }],
-			}
+			return createProjectNotFoundResponse(AddMailTemplateErrorCode.ProjectNotFound, projectSlug)
 		}
 
 		await this.mailTemplateManager.addMailTemplate({
@@ -62,10 +60,7 @@ export class MailTemplateMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to remove a mail template',
 		})
 		if (!project) {
-			return {
-				ok: false,
-				errors: [{ code: RemoveMailTemplateErrorCode.ProjectNotFound }],
-			}
+			return createProjectNotFoundResponse(RemoveMailTemplateErrorCode.ProjectNotFound, projectSlug)
 		}
 
 		const removed = await this.mailTemplateManager.removeMailTemplate({
@@ -74,10 +69,7 @@ export class MailTemplateMutationResolver implements MutationResolvers {
 			type: this.mapMailType(type),
 		})
 		if (!removed) {
-			return {
-				ok: false,
-				errors: [{ code: RemoveMailTemplateErrorCode.TemplateNotFound }],
-			}
+			return createErrorResponse(RemoveMailTemplateErrorCode.TemplateNotFound, 'Mail template not found')
 		}
 
 		return {

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/ChangePasswordMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/ChangePasswordMutationResolver.ts
@@ -9,6 +9,7 @@ import { ResolverContext } from '../../ResolverContext'
 import { QueryHandler } from '@contember/queryable'
 import { DatabaseQueryable } from '@contember/database'
 import { PermissionActions, IdentityScope, PasswordChangeManager, PersonQuery } from '../../../model'
+import { createErrorResponse } from '../../errorUtils'
 
 export class ChangePasswordMutationResolver implements MutationResolvers {
 	constructor(
@@ -24,10 +25,7 @@ export class ChangePasswordMutationResolver implements MutationResolvers {
 	): Promise<ChangePasswordResponse> {
 		const person = await this.queryHandler.fetch(PersonQuery.byId(args.personId))
 		if (!person) {
-			return {
-				ok: false,
-				errors: [{ code: ChangePasswordErrorCode.PersonNotFound }],
-			}
+			return createErrorResponse(ChangePasswordErrorCode.PersonNotFound, 'Person not found')
 		}
 
 		await context.requireAccess({
@@ -38,10 +36,7 @@ export class ChangePasswordMutationResolver implements MutationResolvers {
 		const result = await this.passwordChangeManager.changePassword(args.personId, args.password)
 
 		if (!result.ok) {
-			return {
-				ok: false,
-				errors: result.errors.map(errorCode => ({ code: errorCode })),
-			}
+			return createErrorResponse(result.error, result.errorMessage)
 		}
 
 		return { ok: true, errors: [] }

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/IDPMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/IDPMutationResolver.ts
@@ -9,6 +9,7 @@ import { ResolverContext } from '../../ResolverContext'
 import { IDPSignInManager, PermissionActions, PermissionContextFactory } from '../../../model'
 import { createResolverContext } from '../../ResolverContextFactory'
 import { IdentityTypeResolver } from '../../types'
+import { createErrorResponse } from '../../errorUtils'
 
 export class IDPMutationResolver implements MutationResolvers {
 	constructor(
@@ -28,7 +29,7 @@ export class IDPMutationResolver implements MutationResolvers {
 		})
 		const result = await this.idpSignInManager.initSignInIDP(args.identityProvider, args.redirectUrl)
 		if (!result.ok) {
-			return { ok: false, errors: [{ code: result.error }] }
+			return createErrorResponse(result.error, result.errorMessage)
 		}
 		return { ok: true, errors: [], result: result.result }
 	}
@@ -46,7 +47,7 @@ export class IDPMutationResolver implements MutationResolvers {
 			args.expiration ?? undefined,
 		)
 		if (!signIn.ok) {
-			return { ok: false, errors: [{ code: signIn.error, developerMessage: signIn.errorMessage }] }
+			return createErrorResponse(signIn.error, signIn.errorMessage)
 		}
 		const result = signIn.result
 		const identityId = result.person.identity_id

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/InviteMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/InviteMutationResolver.ts
@@ -9,8 +9,9 @@ import {
 import { ResolverContext } from '../../ResolverContext'
 import { PermissionActions, ProjectManager, Project, InviteOptions } from '../../../model'
 import { InviteManager } from '../../../model/service'
-import { createMembershipValidationErrorResult } from '../../utils'
-import { MembershipValidator } from '../../../model/service/MembershipValidator'
+import { createMembershipValidationErrorResult } from '../../membershipUtils'
+import { MembershipValidator } from '../../../model/service'
+import { createErrorResponse, createProjectNotFoundResponse } from '../../errorUtils'
 
 export class InviteMutationResolver implements MutationResolvers {
 	constructor(
@@ -30,6 +31,9 @@ export class InviteMutationResolver implements MutationResolvers {
 			action: PermissionActions.PERSON_INVITE(memberships),
 			message: 'You are not allowed to invite a person',
 		})
+		if (!project) {
+			return createProjectNotFoundResponse(InviteErrorCode.ProjectNotFound, projectSlug)
+		}
 		return this.doInvite(project, memberships, email, {
 			emailVariant: options?.mailVariant || '',
 		})
@@ -46,6 +50,9 @@ export class InviteMutationResolver implements MutationResolvers {
 			action: PermissionActions.PERSON_INVITE_UNMANAGED(memberships),
 			message: 'You are not allowed to unmanaged person invite',
 		})
+		if (!project) {
+			return createProjectNotFoundResponse(InviteErrorCode.ProjectNotFound, projectSlug)
+		}
 		return this.doInvite(project, memberships, email, {
 			noEmail: true,
 			password,
@@ -53,32 +60,26 @@ export class InviteMutationResolver implements MutationResolvers {
 	}
 
 	private async doInvite(
-		project: Project | null,
+		project: Project,
 		memberships: ReadonlyArray<MembershipInput>,
 		email: string,
 		inviteOptions: InviteOptions = {},
 	): Promise<InviteResponse> {
-		if (!project) {
-			return {
-				ok: false,
-				errors: [{ code: InviteErrorCode.ProjectNotFound }],
-			}
-		}
 		const validationResult = await this.membershipValidator.validate(project.slug, memberships)
 		if (validationResult.length > 0) {
+			const errors = createMembershipValidationErrorResult<InviteErrorCode>(validationResult)
 			return {
 				ok: false,
-				errors: createMembershipValidationErrorResult(validationResult),
+				errors: errors,
+				error: errors[0],
 			}
 		}
-		const result = await this.inviteManager.invite(email, project, memberships, inviteOptions)
+		const response = await this.inviteManager.invite(email, project, memberships, inviteOptions)
 
-		if (!result.ok) {
-			return {
-				ok: false,
-				errors: result.errors.map(errorCode => ({ code: errorCode })),
-			}
+		if (!response.ok) {
+			return createErrorResponse(response.error, response.errorMessage)
 		}
+		const result = response.result
 
 		const person = {
 			id: result.person.id,

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/SignOutMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/SignOutMutationResolver.ts
@@ -3,6 +3,7 @@ import { ResolverContext } from '../../ResolverContext'
 import { QueryHandler } from '@contember/queryable'
 import { DatabaseQueryable } from '@contember/database'
 import { PermissionActions, ApiKeyManager, PersonQuery } from '../../../model'
+import { createErrorResponse } from '../../errorUtils'
 
 export class SignOutMutationResolver implements MutationResolvers {
 	constructor(
@@ -13,7 +14,7 @@ export class SignOutMutationResolver implements MutationResolvers {
 	async signOut(parent: any, args: MutationSignOutArgs, context: ResolverContext): Promise<SignOutResponse> {
 		const person = await this.queryHandler.fetch(PersonQuery.byIdentity(context.identity.id))
 		if (!person) {
-			return { ok: false, errors: [{ code: SignOutErrorCode.NotAPerson }] }
+			return createErrorResponse(SignOutErrorCode.NotAPerson, 'Only a person can sign out')
 		}
 
 		await context.requireAccess({

--- a/packages/engine-tenant-api/src/resolvers/mutation/projectMember/RemoveProjectMemberMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/projectMember/RemoveProjectMemberMutationResolver.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../schema'
 import { ResolverContext } from '../../ResolverContext'
 import { PermissionActions, ProjectManager, ProjectMemberManager } from '../../../model'
+import { createErrorResponse, createProjectNotFoundResponse } from '../../errorUtils'
 
 export class RemoveProjectMemberMutationResolver implements MutationResolvers {
 	constructor(
@@ -25,10 +26,7 @@ export class RemoveProjectMemberMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to remove a project member',
 		})
 		if (!project) {
-			return {
-				ok: false,
-				errors: [{ code: RemoveProjectMemberErrorCode.ProjectNotFound }],
-			}
+			return createProjectNotFoundResponse(RemoveProjectMemberErrorCode.ProjectNotFound, projectSlug)
 		}
 		const memberships = await this.projectMemberManager.getProjectMemberships(
 			{ id: project.id },
@@ -44,10 +42,7 @@ export class RemoveProjectMemberMutationResolver implements MutationResolvers {
 		const result = await this.projectMemberManager.removeProjectMember(project.id, identityId)
 
 		if (!result.ok) {
-			return {
-				ok: false,
-				errors: result.errors.map(errorCode => ({ code: errorCode })),
-			}
+			return createErrorResponse(result.error, result.errorMessage)
 		}
 
 		return {

--- a/packages/engine-tenant-api/src/resolvers/mutation/setup/SetupMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/setup/SetupMutationResolver.ts
@@ -20,9 +20,9 @@ export class SetupMutationResolver implements MutationResolvers {
 		})
 
 		const { email, password } = args.superadmin
-		const result = await this.signUpManager.signUp(email, password, [TenantRole.SUPER_ADMIN])
+		const response = await this.signUpManager.signUp(email, password, [TenantRole.SUPER_ADMIN])
 
-		if (!result.ok) {
+		if (!response.ok) {
 			throw new ImplementationException()
 		}
 
@@ -30,9 +30,9 @@ export class SetupMutationResolver implements MutationResolvers {
 
 		await this.apiKeyManager.disableOneOffApiKey(context.apiKeyId)
 
+		const result = response.result
 		return {
 			ok: true,
-			errors: [],
 			result: {
 				loginKey: {
 					id: loginToken.apiKey.id,

--- a/packages/engine-tenant-api/src/schema/index.ts
+++ b/packages/engine-tenant-api/src/schema/index.ts
@@ -186,15 +186,18 @@ export type SetupResult = {
 export type SignUpResponse = {
 	readonly __typename?: 'SignUpResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<SignUpError>
+	readonly error?: Maybe<SignUpError>
 	readonly result?: Maybe<SignUpResult>
 }
 
 export type SignUpError = {
 	readonly __typename?: 'SignUpError'
 	readonly code: SignUpErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endPersonMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum SignUpErrorCode {
@@ -210,15 +213,18 @@ export type SignUpResult = {
 export type SignInResponse = {
 	readonly __typename?: 'SignInResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<SignInError>
+	readonly error?: Maybe<SignInError>
 	readonly result?: Maybe<SignInResult>
 }
 
 export type SignInError = {
 	readonly __typename?: 'SignInError'
 	readonly code: SignInErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum SignInErrorCode {
@@ -237,14 +243,17 @@ export type SignInResult = {
 export type SignOutResponse = {
 	readonly __typename?: 'SignOutResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<SignOutError>
+	readonly error?: Maybe<SignOutError>
 }
 
 export type SignOutError = {
 	readonly __typename?: 'SignOutError'
 	readonly code: SignOutErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum SignOutErrorCode {
@@ -254,14 +263,17 @@ export enum SignOutErrorCode {
 export type ChangePasswordResponse = {
 	readonly __typename?: 'ChangePasswordResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<ChangePasswordError>
+	readonly error?: Maybe<ChangePasswordError>
 }
 
 export type ChangePasswordError = {
 	readonly __typename?: 'ChangePasswordError'
 	readonly code: ChangePasswordErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum ChangePasswordErrorCode {
@@ -272,7 +284,9 @@ export enum ChangePasswordErrorCode {
 export type InitSignInIdpResponse = {
 	readonly __typename?: 'InitSignInIDPResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<InitSignInIdpError>
+	readonly error?: Maybe<InitSignInIdpError>
 	readonly result?: Maybe<InitSignInIdpResult>
 }
 
@@ -285,8 +299,9 @@ export type InitSignInIdpResult = {
 export type InitSignInIdpError = {
 	readonly __typename?: 'InitSignInIDPError'
 	readonly code: InitSignInIdpErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum InitSignInIdpErrorCode {
@@ -300,15 +315,18 @@ export type IdpResponseInput = {
 export type SignInIdpResponse = {
 	readonly __typename?: 'SignInIDPResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<SignInIdpError>
+	readonly error?: Maybe<SignInIdpError>
 	readonly result?: Maybe<SignInIdpResult>
 }
 
 export type SignInIdpError = {
 	readonly __typename?: 'SignInIDPError'
 	readonly code: SignInIdpErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum SignInIdpErrorCode {
@@ -326,23 +344,28 @@ export type SignInIdpResult = {
 export type InviteResponse = {
 	readonly __typename?: 'InviteResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<InviteError>
+	readonly error?: Maybe<InviteError>
 	readonly result?: Maybe<InviteResult>
 }
 
 export type InviteError = {
 	readonly __typename?: 'InviteError'
 	readonly code: InviteErrorCode
+	readonly developerMessage: Scalars['String']
+	readonly membershipValidation?: Maybe<ReadonlyArray<MembershipValidationError>>
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum InviteErrorCode {
 	ProjectNotFound = 'PROJECT_NOT_FOUND',
+	AlreadyMember = 'ALREADY_MEMBER',
+	InvalidMembership = 'INVALID_MEMBERSHIP',
 	RoleNotFound = 'ROLE_NOT_FOUND',
 	VariableNotFound = 'VARIABLE_NOT_FOUND',
 	VariableEmpty = 'VARIABLE_EMPTY',
-	AlreadyMember = 'ALREADY_MEMBER',
 }
 
 export type InviteResult = {
@@ -359,56 +382,67 @@ export type AddProjectMemberResponse = {
 	readonly __typename?: 'AddProjectMemberResponse'
 	readonly ok: Scalars['Boolean']
 	readonly errors: ReadonlyArray<AddProjectMemberError>
+	readonly error?: Maybe<AddProjectMemberError>
 }
 
 export type AddProjectMemberError = {
 	readonly __typename?: 'AddProjectMemberError'
 	readonly code: AddProjectMemberErrorCode
+	readonly membershipValidation?: Maybe<ReadonlyArray<MembershipValidationError>>
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum AddProjectMemberErrorCode {
 	ProjectNotFound = 'PROJECT_NOT_FOUND',
 	IdentityNotFound = 'IDENTITY_NOT_FOUND',
+	AlreadyMember = 'ALREADY_MEMBER',
+	InvalidMembership = 'INVALID_MEMBERSHIP',
 	RoleNotFound = 'ROLE_NOT_FOUND',
 	VariableEmpty = 'VARIABLE_EMPTY',
 	VariableNotFound = 'VARIABLE_NOT_FOUND',
-	AlreadyMember = 'ALREADY_MEMBER',
 }
 
 export type UpdateProjectMemberResponse = {
 	readonly __typename?: 'UpdateProjectMemberResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<UpdateProjectMemberError>
+	readonly error?: Maybe<UpdateProjectMemberError>
 }
 
 export type UpdateProjectMemberError = {
 	readonly __typename?: 'UpdateProjectMemberError'
 	readonly code: UpdateProjectMemberErrorCode
+	readonly developerMessage: Scalars['String']
+	readonly membershipValidation?: Maybe<ReadonlyArray<MembershipValidationError>>
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum UpdateProjectMemberErrorCode {
 	ProjectNotFound = 'PROJECT_NOT_FOUND',
-	VariableNotFound = 'VARIABLE_NOT_FOUND',
+	NotMember = 'NOT_MEMBER',
+	InvalidMembership = 'INVALID_MEMBERSHIP',
 	RoleNotFound = 'ROLE_NOT_FOUND',
 	VariableEmpty = 'VARIABLE_EMPTY',
-	NotMember = 'NOT_MEMBER',
+	VariableNotFound = 'VARIABLE_NOT_FOUND',
 }
 
 export type RemoveProjectMemberResponse = {
 	readonly __typename?: 'RemoveProjectMemberResponse'
 	readonly ok: Scalars['Boolean']
 	readonly errors: ReadonlyArray<RemoveProjectMemberError>
+	readonly error?: Maybe<RemoveProjectMemberError>
 }
 
 export type RemoveProjectMemberError = {
 	readonly __typename?: 'RemoveProjectMemberError'
 	readonly code: RemoveProjectMemberErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum RemoveProjectMemberErrorCode {
@@ -419,19 +453,24 @@ export enum RemoveProjectMemberErrorCode {
 export type CreateApiKeyResponse = {
 	readonly __typename?: 'CreateApiKeyResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<CreateApiKeyError>
+	readonly error?: Maybe<CreateApiKeyError>
 	readonly result?: Maybe<CreateApiKeyResult>
 }
 
 export type CreateApiKeyError = {
 	readonly __typename?: 'CreateApiKeyError'
 	readonly code: CreateApiKeyErrorCode
+	readonly developerMessage: Scalars['String']
+	readonly membershipValidation?: Maybe<ReadonlyArray<MembershipValidationError>>
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum CreateApiKeyErrorCode {
 	ProjectNotFound = 'PROJECT_NOT_FOUND',
+	InvalidMembership = 'INVALID_MEMBERSHIP',
 	VariableNotFound = 'VARIABLE_NOT_FOUND',
 	RoleNotFound = 'ROLE_NOT_FOUND',
 	VariableEmpty = 'VARIABLE_EMPTY',
@@ -445,14 +484,17 @@ export type CreateApiKeyResult = {
 export type DisableApiKeyResponse = {
 	readonly __typename?: 'DisableApiKeyResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<DisableApiKeyError>
+	readonly error?: Maybe<DisableApiKeyError>
 }
 
 export type DisableApiKeyError = {
 	readonly __typename?: 'DisableApiKeyError'
 	readonly code: DisableApiKeyErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum DisableApiKeyErrorCode {
@@ -479,6 +521,19 @@ export type Membership = {
 	readonly __typename?: 'Membership'
 	readonly role: Scalars['String']
 	readonly variables: ReadonlyArray<VariableEntry>
+}
+
+export type MembershipValidationError = {
+	readonly __typename?: 'MembershipValidationError'
+	readonly code: MembershipValidationErrorCode
+	readonly role: Scalars['String']
+	readonly variable?: Maybe<Scalars['String']>
+}
+
+export enum MembershipValidationErrorCode {
+	RoleNotFound = 'ROLE_NOT_FOUND',
+	VariableNotFound = 'VARIABLE_NOT_FOUND',
+	VariableEmpty = 'VARIABLE_EMPTY',
 }
 
 export type Person = {
@@ -570,14 +625,17 @@ export type PrepareOtpResult = {
 export type ConfirmOtpResponse = {
 	readonly __typename?: 'ConfirmOtpResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<ConfirmOtpError>
+	readonly error?: Maybe<ConfirmOtpError>
 }
 
 export type ConfirmOtpError = {
 	readonly __typename?: 'ConfirmOtpError'
 	readonly code: ConfirmOtpErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum ConfirmOtpErrorCode {
@@ -588,14 +646,17 @@ export enum ConfirmOtpErrorCode {
 export type DisableOtpResponse = {
 	readonly __typename?: 'DisableOtpResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<DisableOtpError>
+	readonly error?: Maybe<DisableOtpError>
 }
 
 export type DisableOtpError = {
 	readonly __typename?: 'DisableOtpError'
 	readonly code: DisableOtpErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum DisableOtpErrorCode {
@@ -627,14 +688,17 @@ export type MailTemplateIdentifier = {
 export type AddMailTemplateResponse = {
 	readonly __typename?: 'AddMailTemplateResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<AddMailTemplateError>
+	readonly error?: Maybe<AddMailTemplateError>
 }
 
 export type AddMailTemplateError = {
 	readonly __typename?: 'AddMailTemplateError'
 	readonly code: AddMailTemplateErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum AddMailTemplateErrorCode {
@@ -646,13 +710,15 @@ export type RemoveMailTemplateResponse = {
 	readonly __typename?: 'RemoveMailTemplateResponse'
 	readonly ok: Scalars['Boolean']
 	readonly errors: ReadonlyArray<RemoveMailTemplateError>
+	readonly error?: Maybe<RemoveMailTemplateError>
 }
 
 export type RemoveMailTemplateError = {
 	readonly __typename?: 'RemoveMailTemplateError'
 	readonly code: RemoveMailTemplateErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum RemoveMailTemplateErrorCode {
@@ -675,14 +741,17 @@ export enum CheckResetPasswordTokenCode {
 export type CreatePasswordResetRequestResponse = {
 	readonly __typename?: 'CreatePasswordResetRequestResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<CreatePasswordResetRequestError>
+	readonly error?: Maybe<CreatePasswordResetRequestError>
 }
 
 export type CreatePasswordResetRequestError = {
 	readonly __typename?: 'CreatePasswordResetRequestError'
 	readonly code: CreatePasswordResetRequestErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum CreatePasswordResetRequestErrorCode {
@@ -692,14 +761,17 @@ export enum CreatePasswordResetRequestErrorCode {
 export type ResetPasswordResponse = {
 	readonly __typename?: 'ResetPasswordResponse'
 	readonly ok: Scalars['Boolean']
+	/** @deprecated Field no longer supported */
 	readonly errors: ReadonlyArray<ResetPasswordError>
+	readonly error?: Maybe<ResetPasswordError>
 }
 
 export type ResetPasswordError = {
 	readonly __typename?: 'ResetPasswordError'
 	readonly code: ResetPasswordErrorCode
+	readonly developerMessage: Scalars['String']
+	/** @deprecated Field no longer supported */
 	readonly endUserMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
 }
 
 export enum ResetPasswordErrorCode {
@@ -852,6 +924,8 @@ export type ResolversTypes = {
 	VariableEntry: ResolverTypeWrapper<VariableEntry>
 	MembershipInput: MembershipInput
 	Membership: ResolverTypeWrapper<Membership>
+	MembershipValidationError: ResolverTypeWrapper<MembershipValidationError>
+	MembershipValidationErrorCode: MembershipValidationErrorCode
 	Person: ResolverTypeWrapper<Person>
 	ApiKey: ResolverTypeWrapper<ApiKey>
 	ApiKeyWithToken: ResolverTypeWrapper<ApiKeyWithToken>
@@ -938,6 +1012,7 @@ export type ResolversParentTypes = {
 	VariableEntry: VariableEntry
 	MembershipInput: MembershipInput
 	Membership: Membership
+	MembershipValidationError: MembershipValidationError
 	Person: Person
 	ApiKey: ApiKey
 	ApiKeyWithToken: ApiKeyWithToken
@@ -1149,6 +1224,7 @@ export type SignUpResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['SignUpError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['SignUpError']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['SignUpResult']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -1158,8 +1234,8 @@ export type SignUpErrorResolvers<
 	ParentType extends ResolversParentTypes['SignUpError'] = ResolversParentTypes['SignUpError']
 > = {
 	code?: Resolver<ResolversTypes['SignUpErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endPersonMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1177,6 +1253,7 @@ export type SignInResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['SignInError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['SignInError']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['SignInResult']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -1186,8 +1263,8 @@ export type SignInErrorResolvers<
 	ParentType extends ResolversParentTypes['SignInError'] = ResolversParentTypes['SignInError']
 > = {
 	code?: Resolver<ResolversTypes['SignInErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1206,6 +1283,7 @@ export type SignOutResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['SignOutError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['SignOutError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1214,8 +1292,8 @@ export type SignOutErrorResolvers<
 	ParentType extends ResolversParentTypes['SignOutError'] = ResolversParentTypes['SignOutError']
 > = {
 	code?: Resolver<ResolversTypes['SignOutErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1225,6 +1303,7 @@ export type ChangePasswordResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['ChangePasswordError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['ChangePasswordError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1233,8 +1312,8 @@ export type ChangePasswordErrorResolvers<
 	ParentType extends ResolversParentTypes['ChangePasswordError'] = ResolversParentTypes['ChangePasswordError']
 > = {
 	code?: Resolver<ResolversTypes['ChangePasswordErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1244,6 +1323,7 @@ export type InitSignInIdpResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['InitSignInIDPError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['InitSignInIDPError']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['InitSignInIDPResult']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -1262,8 +1342,8 @@ export type InitSignInIdpErrorResolvers<
 	ParentType extends ResolversParentTypes['InitSignInIDPError'] = ResolversParentTypes['InitSignInIDPError']
 > = {
 	code?: Resolver<ResolversTypes['InitSignInIDPErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1273,6 +1353,7 @@ export type SignInIdpResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['SignInIDPError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['SignInIDPError']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['SignInIDPResult']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -1282,8 +1363,8 @@ export type SignInIdpErrorResolvers<
 	ParentType extends ResolversParentTypes['SignInIDPError'] = ResolversParentTypes['SignInIDPError']
 > = {
 	code?: Resolver<ResolversTypes['SignInIDPErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1302,6 +1383,7 @@ export type InviteResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['InviteError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['InviteError']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['InviteResult']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -1311,8 +1393,13 @@ export type InviteErrorResolvers<
 	ParentType extends ResolversParentTypes['InviteError'] = ResolversParentTypes['InviteError']
 > = {
 	code?: Resolver<ResolversTypes['InviteErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	membershipValidation?: Resolver<
+		Maybe<ReadonlyArray<ResolversTypes['MembershipValidationError']>>,
+		ParentType,
+		ContextType
+	>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1331,6 +1418,7 @@ export type AddProjectMemberResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['AddProjectMemberError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['AddProjectMemberError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1339,8 +1427,13 @@ export type AddProjectMemberErrorResolvers<
 	ParentType extends ResolversParentTypes['AddProjectMemberError'] = ResolversParentTypes['AddProjectMemberError']
 > = {
 	code?: Resolver<ResolversTypes['AddProjectMemberErrorCode'], ParentType, ContextType>
+	membershipValidation?: Resolver<
+		Maybe<ReadonlyArray<ResolversTypes['MembershipValidationError']>>,
+		ParentType,
+		ContextType
+	>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1350,6 +1443,7 @@ export type UpdateProjectMemberResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['UpdateProjectMemberError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['UpdateProjectMemberError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1358,8 +1452,13 @@ export type UpdateProjectMemberErrorResolvers<
 	ParentType extends ResolversParentTypes['UpdateProjectMemberError'] = ResolversParentTypes['UpdateProjectMemberError']
 > = {
 	code?: Resolver<ResolversTypes['UpdateProjectMemberErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	membershipValidation?: Resolver<
+		Maybe<ReadonlyArray<ResolversTypes['MembershipValidationError']>>,
+		ParentType,
+		ContextType
+	>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1369,6 +1468,7 @@ export type RemoveProjectMemberResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['RemoveProjectMemberError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['RemoveProjectMemberError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1377,8 +1477,8 @@ export type RemoveProjectMemberErrorResolvers<
 	ParentType extends ResolversParentTypes['RemoveProjectMemberError'] = ResolversParentTypes['RemoveProjectMemberError']
 > = {
 	code?: Resolver<ResolversTypes['RemoveProjectMemberErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1388,6 +1488,7 @@ export type CreateApiKeyResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['CreateApiKeyError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['CreateApiKeyError']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['CreateApiKeyResult']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -1397,8 +1498,13 @@ export type CreateApiKeyErrorResolvers<
 	ParentType extends ResolversParentTypes['CreateApiKeyError'] = ResolversParentTypes['CreateApiKeyError']
 > = {
 	code?: Resolver<ResolversTypes['CreateApiKeyErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	membershipValidation?: Resolver<
+		Maybe<ReadonlyArray<ResolversTypes['MembershipValidationError']>>,
+		ParentType,
+		ContextType
+	>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1416,6 +1522,7 @@ export type DisableApiKeyResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['DisableApiKeyError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['DisableApiKeyError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1424,8 +1531,8 @@ export type DisableApiKeyErrorResolvers<
 	ParentType extends ResolversParentTypes['DisableApiKeyError'] = ResolversParentTypes['DisableApiKeyError']
 > = {
 	code?: Resolver<ResolversTypes['DisableApiKeyErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1444,6 +1551,16 @@ export type MembershipResolvers<
 > = {
 	role?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	variables?: Resolver<ReadonlyArray<ResolversTypes['VariableEntry']>, ParentType, ContextType>
+	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}
+
+export type MembershipValidationErrorResolvers<
+	ContextType = any,
+	ParentType extends ResolversParentTypes['MembershipValidationError'] = ResolversParentTypes['MembershipValidationError']
+> = {
+	code?: Resolver<ResolversTypes['MembershipValidationErrorCode'], ParentType, ContextType>
+	role?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	variable?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1572,6 +1689,7 @@ export type ConfirmOtpResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['ConfirmOtpError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['ConfirmOtpError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1580,8 +1698,8 @@ export type ConfirmOtpErrorResolvers<
 	ParentType extends ResolversParentTypes['ConfirmOtpError'] = ResolversParentTypes['ConfirmOtpError']
 > = {
 	code?: Resolver<ResolversTypes['ConfirmOtpErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1591,6 +1709,7 @@ export type DisableOtpResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['DisableOtpError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['DisableOtpError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1599,8 +1718,8 @@ export type DisableOtpErrorResolvers<
 	ParentType extends ResolversParentTypes['DisableOtpError'] = ResolversParentTypes['DisableOtpError']
 > = {
 	code?: Resolver<ResolversTypes['DisableOtpErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1610,6 +1729,7 @@ export type AddMailTemplateResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['AddMailTemplateError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['AddMailTemplateError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1618,8 +1738,8 @@ export type AddMailTemplateErrorResolvers<
 	ParentType extends ResolversParentTypes['AddMailTemplateError'] = ResolversParentTypes['AddMailTemplateError']
 > = {
 	code?: Resolver<ResolversTypes['AddMailTemplateErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1629,6 +1749,7 @@ export type RemoveMailTemplateResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['RemoveMailTemplateError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['RemoveMailTemplateError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1637,8 +1758,8 @@ export type RemoveMailTemplateErrorResolvers<
 	ParentType extends ResolversParentTypes['RemoveMailTemplateError'] = ResolversParentTypes['RemoveMailTemplateError']
 > = {
 	code?: Resolver<ResolversTypes['RemoveMailTemplateErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1656,6 +1777,7 @@ export type CreatePasswordResetRequestResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['CreatePasswordResetRequestError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['CreatePasswordResetRequestError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1664,8 +1786,8 @@ export type CreatePasswordResetRequestErrorResolvers<
 	ParentType extends ResolversParentTypes['CreatePasswordResetRequestError'] = ResolversParentTypes['CreatePasswordResetRequestError']
 > = {
 	code?: Resolver<ResolversTypes['CreatePasswordResetRequestErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1675,6 +1797,7 @@ export type ResetPasswordResponseResolvers<
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	errors?: Resolver<ReadonlyArray<ResolversTypes['ResetPasswordError']>, ParentType, ContextType>
+	error?: Resolver<Maybe<ResolversTypes['ResetPasswordError']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1683,8 +1806,8 @@ export type ResetPasswordErrorResolvers<
 	ParentType extends ResolversParentTypes['ResetPasswordError'] = ResolversParentTypes['ResetPasswordError']
 > = {
 	code?: Resolver<ResolversTypes['ResetPasswordErrorCode'], ParentType, ContextType>
+	developerMessage?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	endUserMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1726,6 +1849,7 @@ export type Resolvers<ContextType = any> = {
 	DisableApiKeyError?: DisableApiKeyErrorResolvers<ContextType>
 	VariableEntry?: VariableEntryResolvers<ContextType>
 	Membership?: MembershipResolvers<ContextType>
+	MembershipValidationError?: MembershipValidationErrorResolvers<ContextType>
 	Person?: PersonResolvers<ContextType>
 	ApiKey?: ApiKeyResolvers<ContextType>
 	ApiKeyWithToken?: ApiKeyWithTokenResolvers<ContextType>

--- a/packages/engine-tenant-api/src/schema/index.ts
+++ b/packages/engine-tenant-api/src/schema/index.ts
@@ -174,19 +174,7 @@ export type AdminCredentials = {
 export type SetupResponse = {
 	readonly __typename?: 'SetupResponse'
 	readonly ok: Scalars['Boolean']
-	readonly errors: ReadonlyArray<SetupErrorCode>
 	readonly result?: Maybe<SetupResult>
-}
-
-export type SetupError = {
-	readonly __typename?: 'SetupError'
-	readonly code: SetupErrorCode
-	readonly endPersonMessage?: Maybe<Scalars['String']>
-	readonly developerMessage?: Maybe<Scalars['String']>
-}
-
-export enum SetupErrorCode {
-	SetupAlreadyDone = 'SETUP_ALREADY_DONE',
 }
 
 export type SetupResult = {
@@ -815,8 +803,6 @@ export type ResolversTypes = {
 	Boolean: ResolverTypeWrapper<Scalars['Boolean']>
 	AdminCredentials: AdminCredentials
 	SetupResponse: ResolverTypeWrapper<SetupResponse>
-	SetupError: ResolverTypeWrapper<SetupError>
-	SetupErrorCode: SetupErrorCode
 	SetupResult: ResolverTypeWrapper<SetupResult>
 	SignUpResponse: ResolverTypeWrapper<SignUpResponse>
 	SignUpError: ResolverTypeWrapper<SignUpError>
@@ -915,7 +901,6 @@ export type ResolversParentTypes = {
 	Boolean: Scalars['Boolean']
 	AdminCredentials: AdminCredentials
 	SetupResponse: SetupResponse
-	SetupError: SetupError
 	SetupResult: SetupResult
 	SignUpResponse: SignUpResponse
 	SignUpError: SignUpError
@@ -1145,18 +1130,7 @@ export type SetupResponseResolvers<
 	ParentType extends ResolversParentTypes['SetupResponse'] = ResolversParentTypes['SetupResponse']
 > = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
-	errors?: Resolver<ReadonlyArray<ResolversTypes['SetupErrorCode']>, ParentType, ContextType>
 	result?: Resolver<Maybe<ResolversTypes['SetupResult']>, ParentType, ContextType>
-	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
-}
-
-export type SetupErrorResolvers<
-	ContextType = any,
-	ParentType extends ResolversParentTypes['SetupError'] = ResolversParentTypes['SetupError']
-> = {
-	code?: Resolver<ResolversTypes['SetupErrorCode'], ParentType, ContextType>
-	endPersonMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
-	developerMessage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 
@@ -1719,7 +1693,6 @@ export type Resolvers<ContextType = any> = {
 	Query?: QueryResolvers<ContextType>
 	Mutation?: MutationResolvers<ContextType>
 	SetupResponse?: SetupResponseResolvers<ContextType>
-	SetupError?: SetupErrorResolvers<ContextType>
 	SetupResult?: SetupResultResolvers<ContextType>
 	SignUpResponse?: SignUpResponseResolvers<ContextType>
 	SignUpError?: SignUpErrorResolvers<ContextType>

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -86,18 +86,7 @@ const schema: DocumentNode = gql`
 
 	type SetupResponse {
 		ok: Boolean!
-		errors: [SetupErrorCode!]!
 		result: SetupResult
-	}
-
-	type SetupError {
-		code: SetupErrorCode!
-		endPersonMessage: String
-		developerMessage: String
-	}
-
-	enum SetupErrorCode {
-		SETUP_ALREADY_DONE
 	}
 
 	type SetupResult {

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -97,14 +97,15 @@ const schema: DocumentNode = gql`
 	# === signUp ===
 	type SignUpResponse {
 		ok: Boolean!
-		errors: [SignUpError!]!
+		errors: [SignUpError!]! @deprecated
+		error: SignUpError
 		result: SignUpResult
 	}
 
 	type SignUpError {
 		code: SignUpErrorCode!
-		endPersonMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endPersonMessage: String @deprecated
 	}
 
 	enum SignUpErrorCode {
@@ -119,14 +120,15 @@ const schema: DocumentNode = gql`
 	# === signIn ===
 	type SignInResponse {
 		ok: Boolean!
-		errors: [SignInError!]!
+		errors: [SignInError!]! @deprecated
+		error: SignInError
 		result: SignInResult
 	}
 
 	type SignInError {
 		code: SignInErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum SignInErrorCode {
@@ -145,13 +147,14 @@ const schema: DocumentNode = gql`
 
 	type SignOutResponse {
 		ok: Boolean!
-		errors: [SignOutError!]!
+		errors: [SignOutError!]! @deprecated
+		error: SignOutError
 	}
 
 	type SignOutError {
 		code: SignOutErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum SignOutErrorCode {
@@ -162,13 +165,14 @@ const schema: DocumentNode = gql`
 
 	type ChangePasswordResponse {
 		ok: Boolean!
-		errors: [ChangePasswordError!]!
+		errors: [ChangePasswordError!]! @deprecated
+		error: ChangePasswordError
 	}
 
 	type ChangePasswordError {
 		code: ChangePasswordErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum ChangePasswordErrorCode {
@@ -180,7 +184,8 @@ const schema: DocumentNode = gql`
 
 	type InitSignInIDPResponse {
 		ok: Boolean!
-		errors: [InitSignInIDPError!]!
+		errors: [InitSignInIDPError!]! @deprecated
+		error: InitSignInIDPError
 		result: InitSignInIDPResult
 	}
 
@@ -191,8 +196,8 @@ const schema: DocumentNode = gql`
 
 	type InitSignInIDPError {
 		code: InitSignInIDPErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum InitSignInIDPErrorCode {
@@ -205,14 +210,15 @@ const schema: DocumentNode = gql`
 
 	type SignInIDPResponse {
 		ok: Boolean!
-		errors: [SignInIDPError!]!
+		errors: [SignInIDPError!]! @deprecated
+		error: SignInIDPError
 		result: SignInIDPResult
 	}
 
 	type SignInIDPError {
 		code: SignInIDPErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum SignInIDPErrorCode {
@@ -231,22 +237,26 @@ const schema: DocumentNode = gql`
 
 	type InviteResponse {
 		ok: Boolean!
-		errors: [InviteError!]!
+		errors: [InviteError!]! @deprecated
+		error: InviteError
 		result: InviteResult
 	}
 
 	type InviteError {
 		code: InviteErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		membershipValidation: [MembershipValidationError!]
+		endUserMessage: String @deprecated
 	}
 
 	enum InviteErrorCode {
 		PROJECT_NOT_FOUND
-		ROLE_NOT_FOUND
-		VARIABLE_NOT_FOUND
-		VARIABLE_EMPTY
 		ALREADY_MEMBER
+		INVALID_MEMBERSHIP
+
+		ROLE_NOT_FOUND @deprecated
+		VARIABLE_NOT_FOUND @deprecated
+		VARIABLE_EMPTY @deprecated
 	}
 
 	type InviteResult {
@@ -263,42 +273,50 @@ const schema: DocumentNode = gql`
 	type AddProjectMemberResponse {
 		ok: Boolean!
 		errors: [AddProjectMemberError!]!
+		error: AddProjectMemberError
 	}
 
 	type AddProjectMemberError {
 		code: AddProjectMemberErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		membershipValidation: [MembershipValidationError!]
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum AddProjectMemberErrorCode {
 		PROJECT_NOT_FOUND
 		IDENTITY_NOT_FOUND
-		ROLE_NOT_FOUND
-		VARIABLE_EMPTY
-		VARIABLE_NOT_FOUND
 		ALREADY_MEMBER
+		INVALID_MEMBERSHIP
+
+		ROLE_NOT_FOUND @deprecated
+		VARIABLE_EMPTY @deprecated
+		VARIABLE_NOT_FOUND @deprecated
 	}
 
 	# === updateProjectMember ===
 
 	type UpdateProjectMemberResponse {
 		ok: Boolean!
-		errors: [UpdateProjectMemberError!]!
+		errors: [UpdateProjectMemberError!]! @deprecated
+		error: UpdateProjectMemberError
 	}
 
 	type UpdateProjectMemberError {
 		code: UpdateProjectMemberErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		membershipValidation: [MembershipValidationError!]
+		endUserMessage: String @deprecated
 	}
 
 	enum UpdateProjectMemberErrorCode {
 		PROJECT_NOT_FOUND
-		VARIABLE_NOT_FOUND
-		ROLE_NOT_FOUND
-		VARIABLE_EMPTY
 		NOT_MEMBER
+		INVALID_MEMBERSHIP
+
+		ROLE_NOT_FOUND @deprecated
+		VARIABLE_EMPTY @deprecated
+		VARIABLE_NOT_FOUND @deprecated
 	}
 
 	# === removeProjectMember ===
@@ -306,12 +324,13 @@ const schema: DocumentNode = gql`
 	type RemoveProjectMemberResponse {
 		ok: Boolean!
 		errors: [RemoveProjectMemberError!]!
+		error: RemoveProjectMemberError
 	}
 
 	type RemoveProjectMemberError {
 		code: RemoveProjectMemberErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum RemoveProjectMemberErrorCode {
@@ -323,21 +342,25 @@ const schema: DocumentNode = gql`
 
 	type CreateApiKeyResponse {
 		ok: Boolean!
-		errors: [CreateApiKeyError!]!
+		errors: [CreateApiKeyError!]! @deprecated
+		error: CreateApiKeyError
 		result: CreateApiKeyResult
 	}
 
 	type CreateApiKeyError {
 		code: CreateApiKeyErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		membershipValidation: [MembershipValidationError!]
+		endUserMessage: String @deprecated
 	}
 
 	enum CreateApiKeyErrorCode {
 		PROJECT_NOT_FOUND
-		VARIABLE_NOT_FOUND
-		ROLE_NOT_FOUND
-		VARIABLE_EMPTY
+		INVALID_MEMBERSHIP
+
+		VARIABLE_NOT_FOUND @deprecated
+		ROLE_NOT_FOUND @deprecated
+		VARIABLE_EMPTY @deprecated
 	}
 
 	type CreateApiKeyResult {
@@ -348,13 +371,14 @@ const schema: DocumentNode = gql`
 
 	type DisableApiKeyResponse {
 		ok: Boolean!
-		errors: [DisableApiKeyError!]!
+		errors: [DisableApiKeyError!]! @deprecated
+		error: DisableApiKeyError
 	}
 
 	type DisableApiKeyError {
 		code: DisableApiKeyErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum DisableApiKeyErrorCode {
@@ -385,6 +409,18 @@ const schema: DocumentNode = gql`
 	type Membership {
 		role: String!
 		variables: [VariableEntry!]!
+	}
+
+	type MembershipValidationError {
+		code: MembershipValidationErrorCode!
+		role: String!
+		variable: String
+	}
+
+	enum MembershipValidationErrorCode {
+		ROLE_NOT_FOUND
+		VARIABLE_NOT_FOUND
+		VARIABLE_EMPTY
 	}
 
 	# === person ====
@@ -470,13 +506,14 @@ const schema: DocumentNode = gql`
 
 	type ConfirmOtpResponse {
 		ok: Boolean!
-		errors: [ConfirmOtpError!]!
+		errors: [ConfirmOtpError!]! @deprecated
+		error: ConfirmOtpError
 	}
 
 	type ConfirmOtpError {
 		code: ConfirmOtpErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum ConfirmOtpErrorCode {
@@ -486,13 +523,14 @@ const schema: DocumentNode = gql`
 
 	type DisableOtpResponse {
 		ok: Boolean!
-		errors: [DisableOtpError!]!
+		errors: [DisableOtpError!]! @deprecated
+		error: DisableOtpError
 	}
 
 	type DisableOtpError {
 		code: DisableOtpErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum DisableOtpErrorCode {
@@ -525,13 +563,14 @@ const schema: DocumentNode = gql`
 
 	type AddMailTemplateResponse {
 		ok: Boolean!
-		errors: [AddMailTemplateError!]!
+		errors: [AddMailTemplateError!]! @deprecated
+		error: AddMailTemplateError
 	}
 
 	type AddMailTemplateError {
 		code: AddMailTemplateErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum AddMailTemplateErrorCode {
@@ -542,12 +581,13 @@ const schema: DocumentNode = gql`
 	type RemoveMailTemplateResponse {
 		ok: Boolean!
 		errors: [RemoveMailTemplateError!]!
+		error: RemoveMailTemplateError
 	}
 
 	type RemoveMailTemplateError {
 		code: RemoveMailTemplateErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum RemoveMailTemplateErrorCode {
@@ -570,13 +610,14 @@ const schema: DocumentNode = gql`
 
 	type CreatePasswordResetRequestResponse {
 		ok: Boolean!
-		errors: [CreatePasswordResetRequestError!]!
+		errors: [CreatePasswordResetRequestError!]! @deprecated
+		error: CreatePasswordResetRequestError
 	}
 
 	type CreatePasswordResetRequestError {
 		code: CreatePasswordResetRequestErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum CreatePasswordResetRequestErrorCode {
@@ -585,12 +626,13 @@ const schema: DocumentNode = gql`
 
 	type ResetPasswordResponse {
 		ok: Boolean!
-		errors: [ResetPasswordError!]!
+		errors: [ResetPasswordError!]! @deprecated
+		error: ResetPasswordError
 	}
 	type ResetPasswordError {
 		code: ResetPasswordErrorCode!
-		endUserMessage: String
-		developerMessage: String
+		developerMessage: String!
+		endUserMessage: String @deprecated
 	}
 
 	enum ResetPasswordErrorCode {


### PR DESCRIPTION
ref #119 
- deprecate `errors` field in favor of nullable `error` field
- deprecate `endUserMessage`, `endPersonMessage` and `developerMessage` in favor of generic `message`
- add `membershipValidation` with detailed validation info for new `INVALID_MEMBERSHIP` error code