### PR TITLE
Fix range validation

### DIFF
--- a/packages/schema-utils/src/validation/ValidationValidator.ts
+++ b/packages/schema-utils/src/validation/ValidationValidator.ts
@@ -181,7 +181,7 @@ export class ValidationValidator {
 			case 'range':
 				const rangeArgA = this.validateLiteralArgument(errorBuilder.for('min'), validatorCast.args[0])
 				const rangeArgB = this.validateLiteralArgument(errorBuilder.for('max'), validatorCast.args[1])
-				if (lengthArgA === undefined || lengthArgB === undefined) {
+				if (rangeArgA === undefined || rangeArgB === undefined) {
 					return undefined
 				}
 				return {


### PR DESCRIPTION
```
  ReferenceError: Cannot access 'lengthArgA' before initialization
      at ValidationValidator.validateValidator (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:184:5)
      at ValidationValidator.validateValidatorArgument (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:278:26)
      at /home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:140:31
      at Array.map (<anonymous>)
      at ValidationValidator.validateValidator (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:140:7)
      at ValidationValidator.validateValidatorArgument (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:278:26)
      at ValidationValidator.validateValidator (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:150:23)
      at ValidationValidator.validateFieldRule (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:98:31)
      at ValidationValidator.validateFieldRules (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:64:22)
      at ValidationValidator.validateEntityRules (/home/vojta/projects/mango/contember-mangoweb-workspace/node_modules/@contember/schema-utils/src/validation/ValidationValidator.ts:46:34)
      
```