### PR TITLE
init template: use globEager

### DIFF
--- a/packages/cli-common/resources/templates/template-project/admin/index.tsx
+++ b/packages/cli-common/resources/templates/template-project/admin/index.tsx
@@ -10,6 +10,6 @@ runReactApp(
 		sessionToken={import.meta.env.VITE_CONTEMBER_ADMIN_SESSION_TOKEN}
 		project={import.meta.env.VITE_CONTEMBER_ADMIN_PROJECT_NAME}
 		stage="live"
-		children={<Pages layout={Layout} children={import.meta.glob('./pages/**/*.tsx')} />}
+		children={<Pages layout={Layout} children={import.meta.globEager('./pages/**/*.tsx')} />}
 	/>,
 )


### PR DESCRIPTION
because glob is currently broken when built uses relative base

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/engine/277)
<!-- Reviewable:end -->
