### PR TITLE
support nulls not distinct for unique constraints

### DIFF
--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ColumnDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ColumnDefinition.ts
@@ -38,7 +38,7 @@ export class ColumnDefinition extends FieldDefinition<ColumnDefinitionOptions> {
 		return this.withOption('sequence', { precedence: 'BY DEFAULT', ...options })
 	}
 
-	public unique(options: { timing?: Model.ConstraintTiming } = {}): Interface<ColumnDefinition> {
+	public unique(options: { timing?: Model.ConstraintTiming; nulls?: Model.UniqueDistinctBehaviour } = {}): Interface<ColumnDefinition> {
 		return this.withOption('unique', options)
 	}
 

--- a/packages/schema-migrations/src/modifications/constraints/CreateUniqueConstraintModification.ts
+++ b/packages/schema-migrations/src/modifications/constraints/CreateUniqueConstraintModification.ts
@@ -37,7 +37,9 @@ export class CreateUniqueConstraintModificationHandler implements ModificationHa
 			checkModifier = ' DEFERRABLE'
 		}
 
-		builder.sql(`ALTER TABLE ${tableNameId} ADD UNIQUE (${columnNameIds.join(', ')})${checkModifier}`)
+		const nullsModifier = this.data.unique.nulls === 'not distinct' ? 'NULLS NOT DISTINCT ' : ''
+
+		builder.sql(`ALTER TABLE ${tableNameId} ADD UNIQUE ${nullsModifier}(${columnNameIds.join(', ')})${checkModifier}`)
 
 		invalidateDatabaseMetadata()
 	}

--- a/packages/schema-migrations/src/modifications/constraints/RemoveUniqueConstraintModification.ts
+++ b/packages/schema-migrations/src/modifications/constraints/RemoveUniqueConstraintModification.ts
@@ -96,7 +96,7 @@ export class RemoveUniqueConstraintDiffer implements Differ {
 					if (!updatedEntity) {
 						return false
 					}
-					return !updatedEntity.unique.find(uniq => deepEqual(uniq.fields, it.fields) && it.timing === uniq.timing)
+					return !updatedEntity.unique.find(uniq => deepEqual(uniq.fields, it.fields) && it.timing === uniq.timing && it.nulls === uniq.nulls)
 				})
 				.map(unique =>
 					removeUniqueConstraintModification.createModification({

--- a/packages/schema-utils/src/type-schema/model.ts
+++ b/packages/schema-utils/src/type-schema/model.ts
@@ -174,6 +174,7 @@ const uniqueConstraint = Typesafe.intersection(
 	indexLike,
 	Typesafe.partial({
 		timing: Typesafe.enumeration('deferrable', 'deferred'),
+		nulls: Typesafe.enumeration('distinct', 'not distinct'),
 	}),
 )
 const uniqueConstraintCheck: Typesafe.Equals<Model.UniqueConstraint, ReturnType<typeof uniqueConstraint>> = true

--- a/packages/schema/src/schema/model.ts
+++ b/packages/schema/src/schema/model.ts
@@ -203,10 +203,12 @@ export namespace Model {
 	export type UniqueConstraints = readonly UniqueConstraint[]
 
 	export type ConstraintTiming = 'deferrable' | 'deferred'
+	export type UniqueDistinctBehaviour = 'distinct' | 'not distinct'
 	export type UniqueConstraint = {
 		readonly fields: readonly string[]
 		readonly timing?: ConstraintTiming // empty means not deferrable
 		readonly name?: string
+		readonly nulls?: UniqueDistinctBehaviour // empty means distinct
 	}
 
 	export type Indexes = readonly Index[]


### PR DESCRIPTION
This pull request introduces the option to configure null behavior in unique indexes—specifically, whether nulls should be distinct. This feature is available starting from PostgreSQL version 15.

Initially, I thought this would be a straightforward enhancement. However, we encountered a significant challenge: our current implementation relies on **unique constraints, which do not support variations in null behavior**; this capability is exclusive to unique indexes. Additionally, unique indexes lack support for timing options like deferrable constraints.

Moreover, our internal metadata is structured around the use of unique constraints rather than indexes.

To address this, we can either provide an option that allows users to explicitly choose between using an index or a constraint, or we could automate this decision based on the parameters provided. If a user's requirements for timing and null behavior conflict, the operation should fail. 