### PR TITLE
Fix SQL-related errors affecting Actions

### DIFF
--- a/packages/database/src/client/Connection.ts
+++ b/packages/database/src/client/Connection.ts
@@ -140,6 +140,7 @@ namespace Connection {
 	}
 
 	export interface Result<Row extends Record<string, any> = Record<string, any>> {
+		readonly command?: string
 		readonly rowCount: number
 		readonly rows: Row[]
 		readonly timing?: {

--- a/packages/database/src/client/errors.ts
+++ b/packages/database/src/client/errors.ts
@@ -1,5 +1,3 @@
-import { ClientErrorCodes } from './errorCodes'
-
 export class DatabaseError extends Error {
 	public readonly code?: string
 	public readonly originalMessage?: string
@@ -56,5 +54,7 @@ export class SerializationFailureError extends QueryError {}
 export class InvalidDataError extends QueryError {}
 
 export class TransactionAbortedError extends QueryError {}
+
+export class CannotCommitError extends DatabaseError {}
 
 

--- a/packages/database/tests/cases/unit/connection.test.ts
+++ b/packages/database/tests/cases/unit/connection.test.ts
@@ -16,7 +16,7 @@ it('support nested scope', async () => {
 
 it('another scope acquires new connection', async () => {
 	const [connection, end] = createConnectionMockAlt(
-		[{ sql: 'SELECT 1', timeout: 5 }, { sql: 'SELECT 2', timeout: 5 }],
+		[{ sql: 'SELECT 1', timeout: 5  }, { sql: 'SELECT 2', timeout: 5 }],
 		[{ sql: 'SELECT 3', timeout: 5 }],
 	)
 
@@ -55,7 +55,7 @@ it('another nested scope waits for connection in a transaction', async () => {
 			{ sql: 'SELECT 1', timeout: 5 },
 			{ sql: 'SELECT 2', timeout: 5 },
 			{ sql: 'SELECT 3', timeout: 5 },
-			{ sql: 'COMMIT', timeout: 5 },
+			{ sql: 'COMMIT', timeout: 5, result: { command: 'COMMIT' } },
 		],
 	)
 	await connection.transaction(async c1 => {
@@ -111,7 +111,7 @@ it('support nested transaction / savepoints', async () => {
 		{ sql: 'SELECT 8' },
 		{ sql: 'RELEASE SAVEPOINT "savepoint_3"' },
 		{ sql: 'SELECT 9' },
-		{ sql: 'COMMIT' },
+		{ sql: 'COMMIT', result: { command: 'COMMIT' } },
 	],
 	)
 

--- a/packages/database/tests/cases/unit/createConnectionMockAlt.ts
+++ b/packages/database/tests/cases/unit/createConnectionMockAlt.ts
@@ -3,7 +3,7 @@ import { PgClient } from '../../../src/client/PgClient'
 import EventEmitter from 'node:events'
 import { expect } from 'vitest'
 
-export const createConnectionMockAlt = (...queries: { sql: string; timeout?: number }[][]): [Connection, () => void] => {
+export const createConnectionMockAlt = (...queries: { sql: string; timeout?: number; result?: any }[][]): [Connection, () => void] => {
 	const connectionMocks: (PgClient & { assertEmpty: () => void })[] = []
 	for (const queriesSet of queries) {
 		connectionMocks.push(new class extends EventEmitter {
@@ -21,7 +21,7 @@ export const createConnectionMockAlt = (...queries: { sql: string; timeout?: num
 				expect(sql).toEqual(query?.sql)
 				await new Promise<void>(resolve => setTimeout(resolve, query?.timeout ?? 1))
 
-				return sql as any
+				return query?.result
 			}
 
 			assertEmpty() {

--- a/packages/database/tests/cases/unit/eventManager.test.ts
+++ b/packages/database/tests/cases/unit/eventManager.test.ts
@@ -27,7 +27,7 @@ test('event manager: connection and client with transaction', async () => {
 	const [connection, end] = createConnectionMockAlt([
 		{ sql: 'BEGIN' },
 		{ sql: 'SELECT 1' },
-		{ sql: 'COMMIT' },
+		{ sql: 'COMMIT', result: { command: 'COMMIT' } },
 		{ sql: 'SELECT 2' },
 		{ sql: 'SELECT 3' },
 	])
@@ -96,7 +96,7 @@ test('event manager: connection and client with transaction and savepoint', asyn
 		{ sql: 'SAVEPOINT "savepoint_1"' },
 		{ sql: 'SELECT 2' },
 		{ sql: 'RELEASE SAVEPOINT "savepoint_1"' },
-		{ sql: 'COMMIT' },
+		{ sql: 'COMMIT', result: { command: 'COMMIT' } },
 		{ sql: 'SELECT 3' },
 		{ sql: 'SELECT 4' },
 	])

--- a/packages/engine-content-api/src/mapper/ErrorUtils.ts
+++ b/packages/engine-content-api/src/mapper/ErrorUtils.ts
@@ -134,7 +134,7 @@ export const convertError = (
 	if (e instanceof Database.TransactionAbortedError) {
 		return new MutationSqlError([], e.originalMessage, [MutationResultHint.subSequentSqlError])
 	}
-	if (e instanceof Database.QueryError) {
+	if (e instanceof Database.QueryError || e instanceof Database.CannotCommitError) {
 		logger.error(e, { loc: 'convertError' })
 		return new MutationSqlError([], e.originalMessage, [MutationResultHint.sqlError])
 	}

--- a/packages/engine-content-api/src/mapper/EventManager.ts
+++ b/packages/engine-content-api/src/mapper/EventManager.ts
@@ -1,7 +1,6 @@
 import { Input, Model, Value } from '@contember/schema'
 import { ResolvedColumnValue } from './ColumnValue'
 import { Mapper } from './Mapper'
-import { logger } from '@contember/logger'
 
 export class BeforeInsertEvent {
 	public type = 'BeforeInsertEvent' as const
@@ -148,11 +147,8 @@ export class EventManager {
 	}
 
 	public async fire<K extends keyof EventMap>(event: EventMap[K]) {
-		(await Promise.allSettled(this.listeners[event.type].map(it => (it as EventListener<K>)(event, this.mapper))))
-			.map(it => {
-				if (it.status === 'rejected') {
-					logger.error(it.reason)
-				}
-			})
+		for (const listener of this.listeners[event.type]) {
+			await listener(event, this.mapper)
+		}
 	}
 }


### PR DESCRIPTION
- `commit` postgres may silently rollback, when previous error was ignored, so we check actual result of commit command
- execute Content API events serially, do not catch errors inside event handlers
- improve error handling during mutation commit