### PR TITLE
CLI: fix passing require in eval executor

### DIFF
--- a/packages/cli/src/lib/js/EvalExecutor.ts
+++ b/packages/cli/src/lib/js/EvalExecutor.ts
@@ -2,7 +2,7 @@ import { JsExecutor } from './JsExecutor'
 
 export class EvalExecutor implements JsExecutor {
 	public async execute(code: string): Promise<unknown> {
-		const fn = new Function(`var module = {}; ((module) => { ${code} })(module); return module`)
-		return fn().exports
+		const fn = new Function('require', `var module = {}; ((module) => { ${code} })(module); return module`)
+		return fn(require).exports
 	}
 }


### PR DESCRIPTION
To allow requires in bundled schema definition