### PR TITLE
feat(content-api): add connectOrCreate for has-many update

### DIFF
--- a/packages/engine-content-api/src/inputProcessing/UpdateInputVisitor.ts
+++ b/packages/engine-content-api/src/inputProcessing/UpdateInputVisitor.ts
@@ -124,6 +124,9 @@ export class UpdateInputVisitor<Result> implements
 			if (isIt<Input.CreateRelationInput>(element, 'create')) {
 				result = processor.create({ ...context, input: element.create, index: i, alias })
 			}
+			if (isIt<Input.ConnectOrCreateRelationInput>(element, 'connectOrCreate')) {
+				result = processor.connectOrCreate({ ...context, input: element.connectOrCreate, index: i, alias })
+			}
 			if (isIt<Input.DeleteSpecifiedRelationInput>(element, 'delete')) {
 				result = processor.delete({ ...context, input: element.delete, index: i, alias })
 			}

--- a/packages/engine-content-api/src/schema/mutations/UpdateEntityRelationInputFieldVisitor.ts
+++ b/packages/engine-content-api/src/schema/mutations/UpdateEntityRelationInputFieldVisitor.ts
@@ -123,11 +123,16 @@ export class UpdateEntityRelationInputFieldVisitor implements Model.ColumnVisito
 			}
 			: undefined
 
+		const connectOrCreateInput = createInput && whereInputType
+			? { type: this.connectOrCreateRelationInputProvider.getInput(entity.name, relation.name) }
+			: undefined
+
 		const fields = {
 			[Input.UpdateRelationOperation.create]: createInput,
 			[Input.UpdateRelationOperation.update]: updateSpecifiedInput,
 			[Input.UpdateRelationOperation.upsert]: upsertInput,
 			[Input.UpdateRelationOperation.connect]: whereInput,
+			[Input.UpdateRelationOperation.connectOrCreate]: connectOrCreateInput,
 			[Input.UpdateRelationOperation.disconnect]: whereInput,
 			[Input.UpdateRelationOperation.delete]: whereInput,
 		}

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/manyHasManyOwning/connectOrCreate.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/manyHasManyOwning/connectOrCreate.test.ts
@@ -1,0 +1,100 @@
+import { test } from 'vitest'
+import { execute, sqlTransaction } from '../../../../../src/test'
+import { GQL, SQL } from '../../../../../src/tags'
+import { testUuid } from '../../../../../src/testUuid'
+import { postWithCategories } from './schema'
+
+test('connectOrCreate - exists', async () => {
+	await execute({
+		schema: postWithCategories,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(2)}"},
+            data: {categories: [{connectOrCreate: {connect: {id: "${testUuid(1)}"}, create: {name: "Ipsum"}}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(2)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`insert into "public"."post_categories" ("post_id", "category_id")
+              values (?, ?)
+              on conflict do nothing`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rowCount: 1 },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+test('connectOrCreate - not exists', async () => {
+	await execute({
+		schema: postWithCategories,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(2)}"},
+            data: {categories: [{connectOrCreate: {connect: {id: "${testUuid(1)}"}, create: {name: "Ipsum"}}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(2)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [] },
+				},
+				{
+					sql: SQL`with "root_" as
+							(select ? :: uuid as "id", ? :: text as "name")
+							insert into "public"."category" ("id", "name")
+							select "root_"."id", "root_"."name"
+              from "root_"
+							returning "id"`,
+					parameters: [testUuid(1), 'Ipsum'],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`insert into "public"."post_categories" ("post_id", "category_id")
+              values (?, ?)
+              on conflict do nothing`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rowCount: 1 },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/oneHasMany/connectOrCreate.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/oneHasMany/connectOrCreate.test.ts
@@ -1,0 +1,90 @@
+import { test } from 'vitest'
+import { execute, sqlTransaction } from '../../../../../src/test'
+import { GQL, SQL } from '../../../../../src/tags'
+import { testUuid } from '../../../../../src/testUuid'
+import { postWithLocale } from './schema'
+
+test('connectOrCreate - exists', async () => {
+	await execute({
+		schema: postWithLocale,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(2)}"},
+            data: {locales: [{connectOrCreate: {connect: {id: "${testUuid(10)}"}, create: {title: "World"}}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(2)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id"  from "public"."post_locale" as "root_"  where "root_"."id" = ?`,
+					parameters: [testUuid(10)],
+					response: { rows: [{ id: testUuid(10) }] },
+				},
+				{
+					sql: SQL`with "newData_" as (select ? :: uuid as "post_id", "root_"."post_id" as "post_id_old__", "root_"."id", "root_"."title", "root_"."locale"  from "public"."post_locale" as "root_"  where "root_"."id" = ?) update  "public"."post_locale" set  "post_id" =  "newData_"."post_id"   from "newData_"  where "post_locale"."id" = "newData_"."id"  returning "post_id_old__"`,
+					parameters: [testUuid(2), testUuid(10)],
+					response: { rows: [{ post_id_old__: testUuid(1) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+test('upsert - not exists (composed unique)', async () => {
+	await execute({
+		schema: postWithLocale,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(2)}"},
+            data: {locales: [{connectOrCreate: {connect: {id: "${testUuid(10)}"}, create: {title: "World"}}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(2)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id"  from "public"."post_locale" as "root_"  where "root_"."id" = ?`,
+					parameters: [testUuid(10)],
+					response: { rows: [] },
+				},
+				{
+					sql: SQL`with "root_" as
+							(select ? :: uuid as "id", ? :: text as "title", ? :: text as "locale", ? :: uuid as "post_id")
+							insert into "public"."post_locale" ("id", "title", "locale", "post_id")
+							select "root_"."id", "root_"."title", "root_"."locale", "root_"."post_id"
+              from "root_"
+							returning "id"`,
+					parameters: [testUuid(1), 'World', null, testUuid(2)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-allowed.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-allowed.gql
@@ -263,6 +263,7 @@ input RootUpdateREntityRelationInput {
   update: RootUpdateRRelationInput
   upsert: RootUpsertRRelationInput
   connect: OneHasManyEntityUniqueWhere
+  connectOrCreate: RootConnectOrCreateRRelationInput
   disconnect: OneHasManyEntityUniqueWhere
   delete: OneHasManyEntityUniqueWhere
   alias: String

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-delete.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-acl-restricted-delete.gql
@@ -255,6 +255,7 @@ input RootUpdateREntityRelationInput {
   update: RootUpdateRRelationInput
   upsert: RootUpsertRRelationInput
   connect: OneHasManyEntityUniqueWhere
+  connectOrCreate: RootConnectOrCreateRRelationInput
   disconnect: OneHasManyEntityUniqueWhere
   alias: String
 }

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-basic.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-basic.gql
@@ -379,6 +379,7 @@ input AuthorUpdatePostsEntityRelationInput {
   update: AuthorUpdatePostsRelationInput
   upsert: AuthorUpsertPostsRelationInput
   connect: PostUniqueWhere
+  connectOrCreate: AuthorConnectOrCreatePostsRelationInput
   disconnect: PostUniqueWhere
   delete: PostUniqueWhere
   alias: String
@@ -401,6 +402,7 @@ input PostUpdateLocalesEntityRelationInput {
   update: PostUpdateLocalesRelationInput
   upsert: PostUpsertLocalesRelationInput
   connect: PostLocaleUniqueWhere
+  connectOrCreate: PostConnectOrCreateLocalesRelationInput
   disconnect: PostLocaleUniqueWhere
   delete: PostLocaleUniqueWhere
   alias: String
@@ -427,6 +429,7 @@ input PostUpdateCategoriesEntityRelationInput {
   update: PostUpdateCategoriesRelationInput
   upsert: PostUpsertCategoriesRelationInput
   connect: CategoryUniqueWhere
+  connectOrCreate: PostConnectOrCreateCategoriesRelationInput
   disconnect: CategoryUniqueWhere
   delete: CategoryUniqueWhere
   alias: String
@@ -506,6 +509,7 @@ input CategoryUpdatePostsEntityRelationInput {
   update: CategoryUpdatePostsRelationInput
   upsert: CategoryUpsertPostsRelationInput
   connect: PostUniqueWhere
+  connectOrCreate: CategoryConnectOrCreatePostsRelationInput
   disconnect: PostUniqueWhere
   delete: PostUniqueWhere
   alias: String

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-bug-66.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-bug-66.gql
@@ -312,6 +312,7 @@ input FrontPageUpdateInHouseVideosEntityRelationInput {
   update: FrontPageUpdateInHouseVideosRelationInput
   upsert: FrontPageUpsertInHouseVideosRelationInput
   connect: VideoUniqueWhere
+  connectOrCreate: FrontPageConnectOrCreateInHouseVideosRelationInput
   disconnect: VideoUniqueWhere
   delete: VideoUniqueWhere
   alias: String

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-custom-primary.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-custom-primary.gql
@@ -383,6 +383,7 @@ input AuthorUpdatePostsEntityRelationInput {
   update: AuthorUpdatePostsRelationInput
   upsert: AuthorUpsertPostsRelationInput
   connect: PostUniqueWhere
+  connectOrCreate: AuthorConnectOrCreatePostsRelationInput
   disconnect: PostUniqueWhere
   delete: PostUniqueWhere
   alias: String
@@ -405,6 +406,7 @@ input PostUpdateLocalesEntityRelationInput {
   update: PostUpdateLocalesRelationInput
   upsert: PostUpsertLocalesRelationInput
   connect: PostLocaleUniqueWhere
+  connectOrCreate: PostConnectOrCreateLocalesRelationInput
   disconnect: PostLocaleUniqueWhere
   delete: PostLocaleUniqueWhere
   alias: String
@@ -431,6 +433,7 @@ input PostUpdateCategoriesEntityRelationInput {
   update: PostUpdateCategoriesRelationInput
   upsert: PostUpsertCategoriesRelationInput
   connect: CategoryUniqueWhere
+  connectOrCreate: PostConnectOrCreateCategoriesRelationInput
   disconnect: CategoryUniqueWhere
   delete: CategoryUniqueWhere
   alias: String
@@ -513,6 +516,7 @@ input CategoryUpdatePostsEntityRelationInput {
   update: CategoryUpdatePostsRelationInput
   upsert: CategoryUpsertPostsRelationInput
   connect: PostUniqueWhere
+  connectOrCreate: CategoryConnectOrCreatePostsRelationInput
   disconnect: PostUniqueWhere
   delete: PostUniqueWhere
   alias: String

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-has-many-reduction.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-has-many-reduction.gql
@@ -295,6 +295,7 @@ input PostUpdateLocalesEntityRelationInput {
   update: PostUpdateLocalesRelationInput
   upsert: PostUpsertLocalesRelationInput
   connect: PostLocaleUniqueWhere
+  connectOrCreate: PostConnectOrCreateLocalesRelationInput
   disconnect: PostLocaleUniqueWhere
   delete: PostLocaleUniqueWhere
   alias: String

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-new-builder.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-new-builder.gql
@@ -440,6 +440,7 @@ input AuthorUpdatePostsEntityRelationInput {
   update: AuthorUpdatePostsRelationInput
   upsert: AuthorUpsertPostsRelationInput
   connect: PostUniqueWhere
+  connectOrCreate: AuthorConnectOrCreatePostsRelationInput
   disconnect: PostUniqueWhere
   delete: PostUniqueWhere
   alias: String
@@ -463,6 +464,7 @@ input PostUpdateCategoriesEntityRelationInput {
   update: PostUpdateCategoriesRelationInput
   upsert: PostUpsertCategoriesRelationInput
   connect: CategoryUniqueWhere
+  connectOrCreate: PostConnectOrCreateCategoriesRelationInput
   disconnect: CategoryUniqueWhere
   delete: CategoryUniqueWhere
   alias: String
@@ -489,6 +491,7 @@ input PostUpdateLocalesEntityRelationInput {
   update: PostUpdateLocalesRelationInput
   upsert: PostUpsertLocalesRelationInput
   connect: PostLocaleUniqueWhere
+  connectOrCreate: PostConnectOrCreateLocalesRelationInput
   disconnect: PostLocaleUniqueWhere
   delete: PostLocaleUniqueWhere
   alias: String
@@ -664,6 +667,7 @@ input CategoryUpdatePostsEntityRelationInput {
   update: CategoryUpdatePostsRelationInput
   upsert: CategoryUpsertPostsRelationInput
   connect: PostUniqueWhere
+  connectOrCreate: CategoryConnectOrCreatePostsRelationInput
   disconnect: PostUniqueWhere
   delete: PostUniqueWhere
   alias: String


### PR DESCRIPTION
`connectOrCreate` support was missing for many-has-many and one-has-many relations. For many-has-many, the behaviour is almost identical to the upsert with empty update