### PR TITLE
(1.3 perf) schema builder concurrency

### DIFF
--- a/packages/engine-http/src/content/ContentSchemaResolver.ts
+++ b/packages/engine-http/src/content/ContentSchemaResolver.ts
@@ -3,26 +3,47 @@ import { filterSchemaByStage } from '@contember/schema-utils'
 
 
 export class ContentSchemaResolver {
-	private baseSchemaCache: VersionedSchema | undefined
+	private prevSchema: VersionedSchema | undefined
+	private schemaPromise: Promise<VersionedSchema> | undefined
 	private stageSchemaCache: { [stage: string]: VersionedSchema } = {}
 
 	constructor(private readonly schemaVersionBuilder: SchemaVersionBuilder) {
 	}
 
 	public clearCache() {
-		this.baseSchemaCache = undefined
+		this.prevSchema = undefined
+		this.schemaPromise = undefined
 		this.stageSchemaCache = {}
 	}
 
 	public async getSchema(db: DatabaseContext, stage?: string): Promise<VersionedSchema> {
-		const prevBaseSchema = this.baseSchemaCache
-		this.baseSchemaCache = await this.schemaVersionBuilder.buildSchema(db, prevBaseSchema)
-		if (prevBaseSchema !== this.baseSchemaCache) {
+		const schema = await this.getBaseSchema(db)
+		if (!stage) {
+			return schema
+		}
+		return this.stageSchemaCache[stage] ??= filterSchemaByStage(schema, stage)
+	}
+
+	private async getBaseSchema(db: DatabaseContext): Promise<VersionedSchema> {
+		const prevSchema = this.prevSchema
+
+		if (!this.schemaPromise) {
+			this.schemaPromise = (async () => {
+				try {
+					const newSchema = await this.schemaVersionBuilder.buildSchema(db, prevSchema)
+					this.prevSchema = newSchema
+					return newSchema
+				} finally {
+					this.schemaPromise = undefined
+				}
+			})()
+		}
+
+		const newSchema = await this.schemaPromise
+
+		if (prevSchema !== newSchema) {
 			this.stageSchemaCache = {}
 		}
-		if (!stage) {
-			return this.baseSchemaCache
-		}
-		return this.stageSchemaCache[stage] ??= filterSchemaByStage(this.baseSchemaCache, stage)
+		return newSchema
 	}
 }

--- a/packages/engine-system-api/src/model/migrations/SchemaVersionBuilder.ts
+++ b/packages/engine-system-api/src/model/migrations/SchemaVersionBuilder.ts
@@ -20,15 +20,17 @@ export class SchemaVersionBuilder {
 		if (newMigrations.length === 0) {
 			return after ?? emptyVersionedSchema
 		}
+		let schema = after?.notNormalized ?? emptyVersionedSchema.notNormalized
 
-		const schema = newMigrations.reduce(
-			(schema, migration) => ({
+		for (const migration of newMigrations) {
+			schema = {
 				...this.schemaMigrator.applyModifications(schema, migration.modifications, migration.formatVersion),
 				version: migration.version,
 				id: migration.id,
-			}),
-			after?.notNormalized ?? emptyVersionedSchema.notNormalized,
-		)
+			}
+			await new Promise(resolve => setImmediate(resolve))
+		}
+
 		const normalized = normalizeSchema(schema)
 		return {
 			...normalized,


### PR DESCRIPTION
This PR addresses a concurrency problem within the ContentSchemaResolver class, where multiple simultaneous invocations of getSchema could lead to redundant buildSchema executions. By ensuring that only one buildSchema operation runs at a time and reusing its result for concurrent requests, we enhance both performance and reliability.

Also, setImmediate is added to SchemaVersionBuilder to free event loop.