### PR TITLE
allow to set precision for dateTimeColumn + validate columnType

### DIFF
--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
@@ -24,6 +24,9 @@ export class FieldsVisitor implements Model.RelationByTypeVisitor<void>, Model.C
 		if (column.type === Model.ColumnType.Date && this.settings.shortDateResponse) {
 			selectFrom += '::text'
 		}
+		if (column.type === Model.ColumnType.DateTime && this.settings.fullDateTimeResponse) {
+			selectFrom += '::text'
+		}
 
 		this.executionContext.addColumn({
 			query: qb => qb.select(new Literal(selectFrom), columnAlias),

--- a/packages/playground/api/index.ts
+++ b/packages/playground/api/index.ts
@@ -14,5 +14,5 @@ export default createSchema(model, schema => ({
 			},
 		},
 	},
-	settings: settingsPresets['v1.3'],
+	settings: settingsPresets['v2.0'],
 }))

--- a/packages/playground/api/migrations/2024-10-08-134532-settings.json
+++ b/packages/playground/api/migrations/2024-10-08-134532-settings.json
@@ -1,0 +1,20 @@
+{
+	"formatVersion": 5,
+	"modifications": [
+		{
+			"modification": "updateSettings",
+			"op": "unset",
+			"key": "useExistsInHasManyFilter"
+		},
+		{
+			"modification": "updateSettings",
+			"op": "set",
+			"key": "content",
+			"value": {
+				"useExistsInHasManyFilter": true,
+				"fullDateTimeResponse": true,
+				"shortDateResponse": true
+			}
+		}
+	]
+}

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ColumnDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ColumnDefinition.ts
@@ -113,8 +113,12 @@ export function dateColumn(): ColumnDefinition {
 	return column(Model.ColumnType.Date)
 }
 
-export function dateTimeColumn(): ColumnDefinition {
-	return column(Model.ColumnType.DateTime)
+export function dateTimeColumn(args?: { precision?: number }): ColumnDefinition {
+	const col = column(Model.ColumnType.DateTime)
+	if (!args?.precision) {
+		return col
+	}
+	return col.columnType(`${resolveDefaultColumnType(Model.ColumnType.DateTime)}(${args.precision})`)
 }
 
 export function jsonColumn(): ColumnDefinition {

--- a/packages/schema-definition/src/presets.ts
+++ b/packages/schema-definition/src/presets.ts
@@ -18,7 +18,19 @@ const v1_4preset: Settings.Schema = {
 	},
 }
 
+const v2_0preset: Settings.Schema = {
+	tenant: {
+		inviteExpirationMinutes: 60 * 24 * 7, // 7 days
+	},
+	content: {
+		shortDateResponse: true,
+		fullDateTimeResponse: true,
+		useExistsInHasManyFilter: true,
+	},
+}
+
 export const settingsPresets = {
 	'v1.3': v1_3preset,
 	'v1.4': v1_4preset,
+	'v2.0': v2_0preset,
 }

--- a/packages/schema-utils/src/type-schema/model.ts
+++ b/packages/schema-utils/src/type-schema/model.ts
@@ -1,5 +1,6 @@
 import * as Typesafe from '@contember/typesafe'
 import { Model } from '@contember/schema'
+import { ParseError } from '@contember/typesafe'
 
 const orderBySchema = Typesafe.array(Typesafe.object({
 	path: Typesafe.array(Typesafe.string),
@@ -118,7 +119,12 @@ const columnSchema = Typesafe.intersection(
 	Typesafe.object({
 		name: Typesafe.string,
 		columnName: Typesafe.string,
-		columnType: Typesafe.string,
+		columnType: Typesafe.transform(Typesafe.string, (it, raw, path) => {
+			if (!it.replaceAll(/\s+/g, '').match(/^[\w_]+(?:\(\w+(?:,\w+)*\))?\w*(?:"[^"]+")?(\[])*$/)) {
+				throw ParseError.format(it, path, 'valid column type')
+			}
+			return it
+		}),
 		nullable: Typesafe.boolean,
 		type: Typesafe.enumeration<Model.ColumnType>(...Object.values(Model.ColumnType)),
 	}),

--- a/packages/schema-utils/src/type-schema/settings.ts
+++ b/packages/schema-utils/src/type-schema/settings.ts
@@ -9,6 +9,7 @@ export const settingsSchema = Typesafe.partial({
 	}),
 	content: Typesafe.partial({
 		useExistsInHasManyFilter: Typesafe.boolean,
+		fullDateTimeResponse: Typesafe.boolean,
 		shortDateResponse: Typesafe.boolean,
 	}),
 })

--- a/packages/schema-utils/tests/cases/unit/modelSchema.test.ts
+++ b/packages/schema-utils/tests/cases/unit/modelSchema.test.ts
@@ -1,0 +1,88 @@
+import { assert, describe, test } from 'vitest'
+import { modelSchema } from '../../../src/type-schema'
+import { Model } from '@contember/schema'
+
+describe('model schema', () => {
+	const validDataTypes = [
+		'integer',
+		'double precision',
+		'character varying(255)',
+		'numeric(10, 2)',
+		'timestamp(3) with time zone',
+		'geometry(Point, 4326)',
+		'character(10)[]',
+		'bit varying(5)',
+		'VARCHAR(255) COLLATE "de_DE"',
+	]
+
+	// Array of invalid PostgreSQL data type examples
+	const invalidDataTypes = [
+		'varchar(255',           // Missing closing parenthesis
+		'character(10))',        // Extra closing parenthesis
+		'numeric(,2)',           // Missing first parameter
+		'geometry(Point,4326))', // Extra closing parenthesis
+		'VARCHAR(255) COLLATE "de_DE" (extra text)', // Extra text outside the valid pattern
+		'VARCHAR(255) COLLATE "de_DE', // Missing closing quote
+	]
+
+	for (const dataType of validDataTypes) {
+		test(`accept valid data type ${dataType}`, () => {
+			const column: Model.AnyColumn = {
+				type: Model.ColumnType.String,
+				columnName: 'column',
+				name: 'column',
+				columnType: dataType,
+				nullable: false,
+			}
+			const model: Model.Schema = {
+				entities: {
+					Test: {
+						tableName: 'test',
+						primary: 'id',
+						primaryColumn: 'id',
+						unique: [],
+						indexes: [],
+						eventLog: { enabled: false },
+						name: 'Test',
+						fields: {
+							column,
+						},
+					},
+				},
+				enums: {},
+			}
+			assert.deepStrictEqual(modelSchema(model), model)
+		})
+	}
+
+	for (const dataType of invalidDataTypes) {
+		test(`reject invalid data type ${dataType}`, () => {
+			const column: Model.AnyColumn = {
+				type: Model.ColumnType.String,
+				columnName: 'column',
+				name: 'column',
+				columnType: dataType,
+				nullable: false,
+			}
+			const model: Model.Schema = {
+				entities: {
+					Test: {
+						tableName: 'test',
+						primary: 'id',
+						primaryColumn: 'id',
+						unique: [],
+						indexes: [],
+						eventLog: { enabled: false },
+						name: 'Test',
+						fields: {
+							column,
+						},
+					},
+				},
+				enums: {},
+			}
+			assert.throw(() => modelSchema(model), `value at path /entities/Test/fields/column: all variants of union has failed:
+            value at path /entities/Test/fields/column/columnType: must be valid column type, "${dataType.replaceAll('"', '\\"')}" given`)
+		})
+	}
+})

--- a/packages/schema/src/schema/settings.ts
+++ b/packages/schema/src/schema/settings.ts
@@ -5,6 +5,7 @@ export namespace Settings {
 
 	export type ContentSettings = {
 		readonly shortDateResponse?: boolean
+		readonly fullDateTimeResponse?: boolean
 		readonly useExistsInHasManyFilter?: boolean
 	}
 

--- a/packages/typesafe/src/index.ts
+++ b/packages/typesafe/src/index.ts
@@ -381,8 +381,8 @@ export const preprocess = <Input extends Json>(inner: Type<Input>, transform: (i
 	return inner(transform(input), path)
 }
 
-export const transform = <Input extends Json, Result extends Json>(inner: Type<Input>, transform: (value: Input, input: unknown) => Result) => (input: unknown, path: PropertyKey[] = []): Result => {
-	return transform(inner(input, path), input)
+export const transform = <Input extends Json, Result extends Json>(inner: Type<Input>, transform: (value: Input, input: unknown, path: PropertyKey[]) => Result) => (input: unknown, path: PropertyKey[] = []): Result => {
+	return transform(inner(input, path), input, path)
 }
 
 export const coalesce = <T extends Json, F extends Json>(inner: Type<T>, fallback: F): Type<T | F> => {


### PR DESCRIPTION
- this PR adds a shortcut for defining custom precision of timestamp
- also, user-defined columnType is fuzzy-validated
- add `content.fullDateTimeResponse` settings option, which will prevent JS Date object from stripping microseconds