### PR TITLE
binding: fix mapping has-many after persist to existing state

### DIFF
--- a/packages/playground/admin/app/components/navigation.tsx
+++ b/packages/playground/admin/app/components/navigation.tsx
@@ -40,6 +40,7 @@ export const Navigation = () => {
 				<MenuItem icon={<GripVertical size={16} />} label={'Repeater'}>
 					<MenuItem icon={line} label={'Sortable repeater'} to={'repeater'} />
 					<MenuItem icon={line} label={'Non-sortable repeater'} to={'repeater/nonSortable'} />
+					<MenuItem icon={line} label={'Repeater on relation'} to={'repeater/onRelation'} />
 					<MenuItem icon={line} label={'Block repeater'} to={'blocks'} />
 					<MenuItem icon={line} label={'Block repeater w/o dual render'} to={'blocks/withoutDualRender'} />
 				</MenuItem>

--- a/packages/playground/admin/app/pages/repeater.tsx
+++ b/packages/playground/admin/app/pages/repeater.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import { Binding, DeleteEntityDialog, PersistButton } from '@app/lib/binding'
 import { Slots } from '@app/lib/layout'
-import { Field } from '@contember/interface'
+import { EntitySubTree, Field } from '@contember/interface'
 import { DefaultRepeater, RepeaterItemActions, RepeaterRemoveItemButton } from '@app/lib/repeater'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, DropDownTriggerButton } from '@app/lib/ui/dropdown'
+import { InputField, SelectField } from '@app/lib/form'
 
 const repeaterDropdown = (
 	<DropdownMenu>
@@ -25,13 +26,38 @@ export default <>
 	<Binding>
 		<Slots.Actions><PersistButton /></Slots.Actions>
 		<DefaultRepeater entities={'RepeaterItem'} sortableBy={'order'} title="Foo items" addButtonPosition="around">
-			<Field field={'title'} />
+			<InputField field={'title'} />
+			<SelectField field={'relation'} >
+				<Field field={'id'} /> /
+				<Field field={'name'} />
+			</SelectField>
 
 			<RepeaterItemActions>
 				{repeaterDropdown}
 				<RepeaterRemoveItemButton />
 			</RepeaterItemActions>
 		</DefaultRepeater>
+	</Binding>
+</>
+
+export const onRelation = <>
+	<Binding>
+		<Slots.Actions><PersistButton /></Slots.Actions>
+		<EntitySubTree entity="RepeaterRoot(unique=unique)" setOnCreate="(unique=unique)">
+			<DefaultRepeater field={'items'} sortableBy={'order'} title="Foo items" addButtonPosition="around">
+				<Field field={'id'} /><br/>
+				<InputField field={'title'} />
+				<SelectField field={'relation'}>
+					<Field field={'id'} /> /
+					<Field field={'name'} />
+				</SelectField>
+
+				<RepeaterItemActions>
+					{repeaterDropdown}
+					<RepeaterRemoveItemButton />
+				</RepeaterItemActions>
+			</DefaultRepeater>
+		</EntitySubTree>
 	</Binding>
 </>
 

--- a/packages/playground/api/migrations/2024-10-17-114124-repeater-rel.json
+++ b/packages/playground/api/migrations/2024-10-17-114124-repeater-rel.json
@@ -1,0 +1,216 @@
+{
+	"formatVersion": 5,
+	"modifications": [
+		{
+			"modification": "createEnum",
+			"enumName": "RepeaterRootUnique",
+			"values": [
+				"unique"
+			]
+		},
+		{
+			"modification": "createEntity",
+			"entity": {
+				"eventLog": {
+					"enabled": true
+				},
+				"name": "RepeaterRelation",
+				"primary": "id",
+				"primaryColumn": "id",
+				"tableName": "repeater_relation",
+				"fields": {
+					"id": {
+						"name": "id",
+						"columnName": "id",
+						"columnType": "uuid",
+						"nullable": false,
+						"type": "Uuid"
+					}
+				},
+				"unique": [],
+				"indexes": []
+			}
+		},
+		{
+			"modification": "createEntity",
+			"entity": {
+				"eventLog": {
+					"enabled": true
+				},
+				"name": "RepeaterRoot",
+				"primary": "id",
+				"primaryColumn": "id",
+				"tableName": "repeater_root",
+				"fields": {
+					"id": {
+						"name": "id",
+						"columnName": "id",
+						"columnType": "uuid",
+						"nullable": false,
+						"type": "Uuid"
+					}
+				},
+				"unique": [],
+				"indexes": []
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "RepeaterRelation",
+			"field": {
+				"name": "name",
+				"columnName": "name",
+				"columnType": "text",
+				"nullable": false,
+				"type": "String"
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "RepeaterRoot",
+			"field": {
+				"name": "unique",
+				"columnName": "unique",
+				"columnType": "RepeaterRootUnique",
+				"nullable": false,
+				"type": "Enum"
+			}
+		},
+		{
+			"modification": "createRelation",
+			"entityName": "RepeaterItem",
+			"owningSide": {
+				"type": "ManyHasOne",
+				"name": "relation",
+				"target": "RepeaterRelation",
+				"joiningColumn": {
+					"columnName": "relation_id",
+					"onDelete": "restrict"
+				},
+				"nullable": true
+			}
+		},
+		{
+			"modification": "createRelation",
+			"entityName": "RepeaterItem",
+			"owningSide": {
+				"type": "ManyHasOne",
+				"name": "root",
+				"target": "RepeaterRoot",
+				"joiningColumn": {
+					"columnName": "root_id",
+					"onDelete": "restrict"
+				},
+				"nullable": true,
+				"inversedBy": "items"
+			},
+			"inverseSide": {
+				"type": "OneHasMany",
+				"name": "items",
+				"target": "RepeaterItem",
+				"ownedBy": "root",
+				"orderBy": [
+					{
+						"path": [
+							"order"
+						],
+						"direction": "asc"
+					}
+				]
+			}
+		},
+		{
+			"modification": "createUniqueConstraint",
+			"entityName": "RepeaterRoot",
+			"unique": {
+				"fields": [
+					"unique"
+				]
+			}
+		},
+		{
+			"modification": "patchAclSchema",
+			"patch": [
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterRelation",
+					"value": {
+						"predicates": {},
+						"operations": {
+							"read": {
+								"id": true,
+								"name": true
+							},
+							"create": {
+								"id": true,
+								"name": true
+							},
+							"update": {
+								"id": true,
+								"name": true
+							},
+							"delete": true,
+							"customPrimary": true
+						}
+					}
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterRoot",
+					"value": {
+						"predicates": {},
+						"operations": {
+							"read": {
+								"id": true,
+								"unique": true,
+								"items": true
+							},
+							"create": {
+								"id": true,
+								"unique": true,
+								"items": true
+							},
+							"update": {
+								"id": true,
+								"unique": true,
+								"items": true
+							},
+							"delete": true,
+							"customPrimary": true
+						}
+					}
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterItem/operations/read/relation",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterItem/operations/read/root",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterItem/operations/create/relation",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterItem/operations/create/root",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterItem/operations/update/relation",
+					"value": true
+				},
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/RepeaterItem/operations/update/root",
+					"value": true
+				}
+			]
+		}
+	]
+}

--- a/packages/playground/api/model/Repeater.ts
+++ b/packages/playground/api/model/Repeater.ts
@@ -1,6 +1,16 @@
 import { c } from '@contember/schema-definition'
 
+export class RepeaterRoot {
+	unique = c.enumColumn(c.createEnum('unique')).unique().notNull()
+	items = c.oneHasMany(RepeaterItem, 'root').orderBy('order')
+}
+
 export class RepeaterItem {
+	root = c.manyHasOne(RepeaterRoot, 'items')
 	title = c.stringColumn().notNull()
+	relation = c.manyHasOne(RepeaterRelation)
 	order = c.intColumn()
+}
+export class RepeaterRelation {
+	name = c.stringColumn().notNull()
 }


### PR DESCRIPTION
This PR fixes a bug in the binding mechanism where newly persisted IDs were incorrectly mapped to existing binding states based on their order of reception. This approach could lead to mismatches and unintended overwrites, breaking data integrity and consistency within the application.