### PR TITLE
feat(tenant-api): optionally return full OIDC callback result

### DIFF
--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
@@ -25,7 +25,7 @@ export const initOIDCAuth = async (client: Client, { redirectUrl, scope, respons
 	}
 }
 
-export const handleOIDCResponse = async (client: Client, { sessionData, redirectUrl, ...otherData }: OIDCResponseData, fetchUserInfo?: boolean): Promise<IDPResponse> => {
+export const handleOIDCResponse = async (client: Client, { sessionData, redirectUrl, ...otherData }: OIDCResponseData, fetchUserInfo?: boolean, returnOIDCResult?: boolean): Promise<IDPResponse> => {
 	const params = 'parameters' in otherData ? otherData.parameters : client.callbackParams(otherData.url)
 	if (params.state && !sessionData?.state) {
 		throw new IDPValidationError(`state is present in parameters, but missing in session data`)
@@ -35,9 +35,11 @@ export const handleOIDCResponse = async (client: Client, { sessionData, redirect
 		const claims = result.claims()
 		const { at_hash, c_hash, nonce, ...claimsWithoutHashes } = claims
 		const userInfo = result.access_token && fetchUserInfo ? await client.userinfo(result) : {}
-
+		const oidcResult = returnOIDCResult ? result : {}
+		
 		return {
 			externalIdentifier: claims.sub,
+			...oidcResult,
 			...claimsWithoutHashes,
 			...userInfo,
 		}

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCProvider.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCProvider.ts
@@ -24,7 +24,12 @@ export class OIDCProvider implements IdentityProviderHandler<OIDCConfiguration> 
 	public async processResponse(configuration: OIDCConfiguration, data: unknown): Promise<IDPResponse> {
 		const responseData = catchTypesafe(OIDCResponseData, IDPValidationError)(data)
 		const client = await this.createOIDCClient(configuration)
-		return await handleOIDCResponse(client, responseData, configuration.fetchUserInfo)
+		return await handleOIDCResponse(
+			client,
+			responseData,
+			configuration.fetchUserInfo,
+			configuration.returnOIDCResult,
+		)
 	}
 
 

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
@@ -13,6 +13,7 @@ export const OIDCConfigurationOptions = Typesafe.partial({
 	additionalAuthorizedParties: Typesafe.array(Typesafe.string),
 	idTokenSignedResponseAlg: Typesafe.string,
 	fetchUserInfo: Typesafe.boolean,
+	returnOIDCResult: Typesafe.boolean,
 })
 export const BaseOIDCConfiguration = Typesafe.intersection(
 	Typesafe.object({


### PR DESCRIPTION
Because BankID does not fully respect the OIDC specification about data retrieval, I need to be able to make additional request to their endpoint with their access token. I understand that this poses a vulnerability as the token should not leave contember but due to this contstraint I have no other choice.