### PR TITLE
shared graphql schema

### DIFF
--- a/packages/engine-http/src/content/ContentApiControllerFactory.ts
+++ b/packages/engine-http/src/content/ContentApiControllerFactory.ts
@@ -7,6 +7,7 @@ import { ContentGraphQLContextFactory } from './ContentGraphQLContextFactory'
 import { ContentQueryHandler, ContentQueryHandlerFactory } from './ContentQueryHandlerFactory'
 import { GraphQLSchema } from 'graphql'
 import { GraphQLKoaState } from '../graphql'
+import { GraphQlSchemaFactory } from './GraphQlSchemaFactory'
 
 const debugHeader = 'x-contember-debug'
 
@@ -16,6 +17,7 @@ export class ContentApiControllerFactory {
 		private readonly contentGraphqlContextFactory: ContentGraphQLContextFactory,
 		private readonly handlerFactory: ContentQueryHandlerFactory,
 		private readonly projectContextResolver: ProjectContextResolver,
+		private readonly graphQlSchemaFactory: GraphQlSchemaFactory,
 	) {
 	}
 
@@ -79,9 +81,9 @@ export class ContentApiControllerFactory {
 
 			const { schema: graphQlSchema, permissions } = await timer(
 				'GraphQLSchemaCreate',
-				() => projectContainer.graphQlSchemaFactory.create(schema, {
+				() => this.graphQlSchemaFactory.create(schema, {
 					projectRoles: projectRoles,
-				}),
+				}, project),
 			)
 
 

--- a/packages/engine-http/src/content/ContentGraphQLContextFactory.ts
+++ b/packages/engine-http/src/content/ContentGraphQLContextFactory.ts
@@ -11,6 +11,7 @@ import { ProjectConfig } from '../project/config'
 export type ExtendedGraphqlContext = Context & {
 	identityId: string
 	requestDebug: boolean
+	project: { slug: string }
 }
 
 export class ContentGraphQLContextFactory {
@@ -63,6 +64,7 @@ export class ContentGraphQLContextFactory {
 			executionContainer,
 			timer,
 			requestDebug,
+			project,
 		}
 	}
 }

--- a/packages/engine-http/src/content/GraphQLSchemaContributor.ts
+++ b/packages/engine-http/src/content/GraphQLSchemaContributor.ts
@@ -1,9 +1,15 @@
 import { Schema } from '@contember/schema'
 import { GraphQLSchema, GraphQLSchemaConfig } from 'graphql'
 import { Identity } from './Identity'
+import { ProjectConfig } from '../project/config'
 
-export type GraphQLSchemaContributorContext = { schema: Schema; identity: Identity }
+export type GraphQLSchemaContributorContext = {
+	schema: Schema
+	identity: Identity
+	project: ProjectConfig
+}
 
 export interface GraphQLSchemaContributor {
+	getCacheKey?: (context: GraphQLSchemaContributorContext) => string
 	createSchema(context: GraphQLSchemaContributorContext): undefined | GraphQLSchema | GraphQLSchemaConfig
 }

--- a/packages/engine-http/src/plugin/Plugin.ts
+++ b/packages/engine-http/src/plugin/Plugin.ts
@@ -4,11 +4,9 @@ import { ConfigProcessor } from '../config/ConfigProcessor'
 import * as Typesafe from '@contember/typesafe'
 import { GraphQLSchemaContributor } from '../content'
 import { Providers } from '../providers'
-import { ProjectConfig } from '../project/config'
 import { MasterContainerHook } from '../MasterContainer'
 
-export interface SchemaContributorArgs<CustomConfig extends Typesafe.JsonObject = Typesafe.JsonObject> {
-	project: ProjectConfig & CustomConfig
+export interface SchemaContributorArgs {
 	providers: Providers
 }
 
@@ -17,7 +15,7 @@ export interface Plugin<CustomConfig extends Typesafe.JsonObject = Typesafe.Json
 
 	getConfigProcessor?(): ConfigProcessor<CustomConfig>
 
-	getSchemaContributor?(args: SchemaContributorArgs<CustomConfig>): GraphQLSchemaContributor | undefined
+	getSchemaContributor?(args: SchemaContributorArgs): GraphQLSchemaContributor | undefined
 
 	getSystemMigrations?(): MigrationGroup<unknown>
 

--- a/packages/engine-http/src/system/ContentQueryExecutor.ts
+++ b/packages/engine-http/src/system/ContentQueryExecutor.ts
@@ -40,6 +40,7 @@ export class ContentQueryExecutorImpl implements ContentQueryExecutor {
 		})
 
 		const ctx: ExtendedGraphqlContext = {
+			project,
 			db: db.client.forSchema(stage.schema),
 			identityVariables: {},
 			identityId,

--- a/packages/engine-http/src/utils/memoizeObject.ts
+++ b/packages/engine-http/src/utils/memoizeObject.ts
@@ -1,0 +1,38 @@
+
+export const createMemoizer = <T extends object>(canonicalizeValue: (value: T) => string) => {
+	const cache = new Map<string, WeakRef<T>>()
+	const canonicalValueCache = new WeakMap<T, string>()
+
+	const finalizer = new FinalizationRegistry<string>(key => {
+		cache.delete(key)
+	})
+
+	return (value: T): T => {
+		if (typeof value !== 'object' || value === null) {
+			throw new TypeError('Value must be a non-null object')
+		}
+		let key = canonicalValueCache.get(value)
+		if (!key) {
+			key = canonicalizeValue(value)
+			canonicalValueCache.set(value, key)
+		}
+
+		const entry = cache.get(key)
+		if (entry) {
+			const obj = entry.deref()
+			if (obj !== undefined) {
+				return obj as T
+			}
+		}
+
+		const stableObj = value
+		const weakRef = new WeakRef(stableObj)
+
+		finalizer.register(stableObj, key)
+
+		cache.set(key, weakRef)
+
+		return stableObj
+	}
+
+}

--- a/packages/engine-s3-plugin/src/index.ts
+++ b/packages/engine-s3-plugin/src/index.ts
@@ -15,11 +15,8 @@ export default class S3 implements Plugin<Project3Config> {
 		return new S3ConfigProcessor()
 	}
 
-	getSchemaContributor({ project, providers }: SchemaContributorArgs<Project3Config>) {
-		if (!project.s3) {
-			return undefined
-		}
+	getSchemaContributor({ providers }: SchemaContributorArgs) {
 		const s3ServiceFactory = new S3ServiceFactory()
-		return new S3SchemaContributor(project.s3, s3ServiceFactory, providers)
+		return new S3SchemaContributor(s3ServiceFactory, providers)
 	}
 }

--- a/packages/engine-vimeo-plugin/src/index.ts
+++ b/packages/engine-vimeo-plugin/src/index.ts
@@ -14,11 +14,8 @@ export default class VimeoPlugin implements Plugin<ProjectVimeoConfig> {
 		return new VimeoConfigProcessor()
 	}
 
-	getSchemaContributor({ project }: SchemaContributorArgs<ProjectVimeoConfig>) {
-		if (!project.vimeo) {
-			return undefined
-		}
+	getSchemaContributor() {
 		const vimeoServiceFactory = new VimeoServiceFactory()
-		return new VimeoSchemaContributor(project.vimeo, vimeoServiceFactory)
+		return new VimeoSchemaContributor(vimeoServiceFactory)
 	}
 }


### PR DESCRIPTION
This PR updates the caching mechanism for the GraphQL schema, expanding its scope to a global level. By enabling different projects with the same schema to share a single instance of the GraphQL schema object, it reduces cold start times and lowers memory usage.

Changes have been made to the schema extensions plugins to remove dependencies on project-specific configurations, ensuring compatibility across different projects. If some plugin depends on project config, it should return a cache key using getCacheKey in schema contributor.

