### PR TITLE
feat(cli-common): introduce findPackageRoot func

### DIFF
--- a/packages/cli-common/src/index.ts
+++ b/packages/cli-common/src/index.ts
@@ -1,3 +1,4 @@
 export type { CommandFactoryList } from './application'
 export { Application, Input, Command, CommandManager, CommandConfiguration } from './application'
 export * from './npm'
+export * from './utils'

--- a/packages/cli-common/src/utils/findPackageRoot.ts
+++ b/packages/cli-common/src/utils/findPackageRoot.ts
@@ -1,0 +1,20 @@
+import { existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+export const findPackageRoot = (startPath: string) => {
+	let currentPath = startPath
+
+	while (true) {
+		const packageJsonPath = join(currentPath, 'package.json')
+		if (existsSync(packageJsonPath)) {
+			return currentPath
+		}
+
+		const parentPath = dirname(currentPath)
+		if (parentPath === currentPath) {
+			throw new Error('Package root not found')
+		}
+
+		currentPath = parentPath
+	}
+}

--- a/packages/cli-common/src/utils/index.ts
+++ b/packages/cli-common/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './findPackageRoot'

--- a/packages/cli/src/consts.ts
+++ b/packages/cli/src/consts.ts
@@ -1,5 +1,7 @@
-import { join } from 'node:path'
+import { findPackageRoot } from '@contember/cli-common'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-export const packageRoot = process.env.CONTEMBER_CLI_PACKAGE_ROOT || join(dirname(fileURLToPath(import.meta.url)), '../')
+
+const currentFilePath = dirname(fileURLToPath(import.meta.url))
+export const packageRoot = process.env.CONTEMBER_CLI_PACKAGE_ROOT || findPackageRoot(currentFilePath)
 export const contemberDockerImages = ['contember/engine', 'contember/engine-ee', 'contember/cli']

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -10,27 +10,7 @@
     "js-yaml": "^4.1.0"
   },
   "type": "module",
-  "main": "./dist/production/index.js",
-  "typings": "./dist/types/index.d.ts",
   "scripts": {
     "pre-build": "rm -rf rm ./resources/templates/template-workspace/admin/lib && cp -r ../react-ui-lib/src ./resources/templates/template-workspace/admin/lib && rm ./resources/templates/template-workspace/admin/lib/index.ts ./resources/templates/template-workspace/admin/lib/tsconfig.json"
-  },
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/types/index.d.ts",
-        "development": "./dist/development/index.js",
-        "production": "./dist/production/index.js",
-        "typescript": "./src/index.ts",
-        "default": "./dist/production/index.js"
-      },
-      "require": {
-        "types": "./dist/types/index.d.ts",
-        "development": "./dist/development/index.cjs",
-        "production": "./dist/production/index.cjs",
-        "typescript": "./src/index.ts",
-        "default": "./dist/production/index.cjs"
-      }
-    }
   }
 }

--- a/packages/create/src/paths.ts
+++ b/packages/create/src/paths.ts
@@ -1,6 +1,7 @@
-import { join } from 'node:path'
-import { dirname } from 'node:path'
+import { findPackageRoot } from '@contember/cli-common'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export const packageRoot = process.env.CONTEMBER_CLI_PACKAGE_ROOT || join(dirname(fileURLToPath(import.meta.url)), '../../')
+const currentFilePath = dirname(fileURLToPath(import.meta.url))
+export const packageRoot = process.env.CONTEMBER_CLI_PACKAGE_ROOT || findPackageRoot(currentFilePath)
 export const resourcesDir = join(packageRoot, './resources')


### PR DESCRIPTION
This pull request introduces several changes aimed at improving the package root resolution and simplifying the project structure. The key updates include the addition of a new utility function to find the package root and its integration into various parts of the codebase.

### Utility Function Addition:
* [`packages/cli-common/src/utils/findPackageRoot.ts`](diffhunk://#diff-efc6e2e51abe9413fb3f66ef2888def16b9a2126b7a97e8ce7ed4c9d69548d8bR1-R20): Added a new utility function `findPackageRoot` to determine the root directory of a package by traversing up the directory tree until a `package.json` file is found.

### Codebase Integration:
* [`packages/cli/src/consts.ts`](diffhunk://#diff-73d0b43b3799173229739b56853b9a5db3d2fe2ee09c9127e8f20b45f929164cL1-R6): Replaced the existing logic for determining the package root with the new `findPackageRoot` function from `@contember/cli-common`.
* [`packages/create/src/paths.ts`](diffhunk://#diff-74ca1dd2182aaa9a586a05905a5562fd9ed9502e79452e217625b430d93362d5L1-R6): Updated to use the `findPackageRoot` function for determining the package root.

### Miscellaneous:
* [`packages/cli-common/src/index.ts`](diffhunk://#diff-7740476a8358451d1afaec8c7cc3bf0db58dd643c3bdd37103e1a39ddc72e2d0R4): Exported all utilities from the `utils` directory.
* [`packages/create/package.json`](diffhunk://#diff-84505d75821385613d447e5d9c00802c2b657d2fbed9b9ccc2303a1e751dcc3bL13-L34): Removed the `main`, `typings`, and `exports` fields, and cleaned up the `scripts` section.