### PR TITLE
allow to set max patch size in migrations

### DIFF
--- a/packages/cli/src/dic.ts
+++ b/packages/cli/src/dic.ts
@@ -150,7 +150,9 @@ export const createContainer = ({ env, version, runtime, workspace }: {
 		.addService('schemaVersionBuilder', ({ migrationsResolver, schemaMigrator }) =>
 			new SchemaVersionBuilder(migrationsResolver, schemaMigrator))
 		.addService('schemaDiffer', ({ schemaMigrator }) =>
-			new SchemaDiffer(schemaMigrator))
+			new SchemaDiffer(schemaMigrator, {
+				maxPatchSize: env.migrationsOptions?.maxPatchSize,
+			}))
 		.addService('migrationCreator', ({ migrationFilesManager, schemaDiffer }) =>
 			new MigrationCreator(migrationFilesManager, schemaDiffer, {
 				json: JSON.stringify({ formatVersion: VERSION_LATEST, modifications: [] }, undefined, '\t') + '\n',

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -6,6 +6,9 @@ export interface CliEnv {
 	dockerComposeFile?: string
 	dsn?: string
 	dir?: string
+	migrationsOptions?: {
+		maxPatchSize?: number
+	}
 }
 
 export const readCliEnv = (): CliEnv => {
@@ -17,5 +20,8 @@ export const readCliEnv = (): CliEnv => {
 		projectName: process.env.CONTEMBER_PROJECT_NAME,
 		dockerComposeFile: process.env.COMPOSE_FILE,
 		dsn: process.env.CONTEMBER_DSN,
+		migrationsOptions: {
+			maxPatchSize: process.env.CONTEMBER_MIGRATIONS_MAX_PATCH_SIZE ? parseInt(process.env.CONTEMBER_MIGRATIONS_MAX_PATCH_SIZE) : undefined,
+		},
 	}
 }

--- a/packages/engine-system-api/src/SystemContainer.ts
+++ b/packages/engine-system-api/src/SystemContainer.ts
@@ -80,8 +80,6 @@ export class SystemContainerFactory {
 				new AccessEvaluator.PermissionEvaluator(new PermissionsFactory().create()))
 			.addService('authorizator', ({ accessEvaluator }): Authorizator =>
 				new Authorizator.Default(accessEvaluator))
-			.addService('schemaDiffer', ({ schemaMigrator }) =>
-				new SchemaDiffer(schemaMigrator))
 			.addService('migrationDescriber', ({ modificationHandlerFactory }) =>
 				new MigrationDescriber(modificationHandlerFactory))
 			.addService('databaseMetadataResolver', () =>

--- a/packages/schema-migrations/src/SchemaDiffer.ts
+++ b/packages/schema-migrations/src/SchemaDiffer.ts
@@ -48,7 +48,12 @@ import { ConvertOneHasManyToOneHasOneRelationDiffer } from './modifications/rela
 type DiffOptions = { skipRecreateValidation?: boolean; skipInitialSchemaValidation?: boolean }
 
 export class SchemaDiffer {
-	constructor(private readonly schemaMigrator: SchemaMigrator) {}
+	constructor(
+		private readonly schemaMigrator: SchemaMigrator,
+		private readonly options?: {
+			maxPatchSize?: number
+		},
+	) {}
 
 	diffSchemas(originalSchema: Schema, updatedSchema: Schema, {
 		skipInitialSchemaValidation = false,
@@ -99,8 +104,8 @@ export class SchemaDiffer {
 			new CreateUniqueConstraintDiffer(),
 			new CreateIndexDiffer(),
 			new RemoveEnumDiffer(),
-			new UpdateAclSchemaDiffer(),
-			new UpdateValidationSchemaDiffer(),
+			new UpdateAclSchemaDiffer(this.options),
+			new UpdateValidationSchemaDiffer(this.options),
 			new UpdateEntityOrderByDiffer(),
 			new UpdateTargetDiffer(),
 			new CreateTargetDiffer(),

--- a/packages/schema-migrations/src/modifications/acl/UpdateAclSchemaModification.ts
+++ b/packages/schema-migrations/src/modifications/acl/UpdateAclSchemaModification.ts
@@ -32,12 +32,19 @@ export const updateAclSchemaModification = createModificationType({
 })
 
 export class UpdateAclSchemaDiffer implements Differ {
+	constructor(
+		private readonly options?: {
+			maxPatchSize?: number
+		},
+	) {
+	}
+
 	createDiff(originalSchema: Schema, updatedSchema: Schema) {
 		if (deepEqual(originalSchema.acl, updatedSchema.acl)) {
 			return []
 		}
 		const patch = createPatch(originalSchema.acl, updatedSchema.acl)
-		if (patch.length <= 100) {
+		if (patch.length <= (this.options?.maxPatchSize ?? 100)) {
 			return [patchAclSchemaModification.createModification({ patch })]
 		}
 		return [updateAclSchemaModification.createModification({ schema: updatedSchema.acl })]

--- a/packages/schema-migrations/src/modifications/validation/UpdateValidationSchemaModification.ts
+++ b/packages/schema-migrations/src/modifications/validation/UpdateValidationSchemaModification.ts
@@ -33,12 +33,19 @@ export const updateValidationSchemaModification = createModificationType({
 })
 
 export class UpdateValidationSchemaDiffer implements Differ {
+	constructor(
+		private readonly options?: {
+			maxPatchSize?: number
+		},
+	) {
+	}
+
 	createDiff(originalSchema: Schema, updatedSchema: Schema) {
 		if (deepEqual(originalSchema.validation, updatedSchema.validation)) {
 			return []
 		}
 		const patch = createPatch(originalSchema.validation, updatedSchema.validation)
-		if (patch.length <= 20) {
+		if (patch.length <= (this.options?.maxPatchSize ?? 100)) {
 			return [patchValidationSchemaModification.createModification({ patch })]
 		}
 		return [updateValidationSchemaModification.createModification({ schema: updatedSchema.validation })]


### PR DESCRIPTION
This pull request introduces enhancements to the schema migration process by allowing the configuration of a maximum patch size for ACL and validation schema differences using CONTEMBER_MIGRATIONS_MAX_PATCH_SIZE  env for CLI.