### PR TITLE
chore(playground): switch playground project name to playground instead of playground2

### DIFF
--- a/.github/workflows/deploy-playground.yaml
+++ b/.github/workflows/deploy-playground.yaml
@@ -23,7 +23,7 @@ jobs:
           bun run pre-build
           bun run --filter=@contember/playground build
         env:
-          VITE_CONTEMBER_ADMIN_PROJECT_NAME: playground2
+          VITE_CONTEMBER_ADMIN_PROJECT_NAME: playground
           VITE_CONTEMBER_ADMIN_SESSION_TOKEN: ${{ secrets.PLAYGROUND_SESSION_TOKEN }}
 
       - name: Deploy


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy-playground.yaml` file. The change updates the project name environment variable for the Contember admin from "playground2" to "playground".

* [`.github/workflows/deploy-playground.yaml`](diffhunk://#diff-9ada9d906b8fb7d822a6daa9dfea26ab32d9bf98efe5a90ab0b5740139a5f633L26-R26): Changed `VITE_CONTEMBER_ADMIN_PROJECT_NAME` from "playground2" to "playground".