### PR TITLE
Correctly apply "read" predicates in nested mutations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,8 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
-
+        with:
+          bun-version: 1.1.45
       - name: Install deps
         run: |
           bun --version
@@ -79,6 +80,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+        with:
+            bun-version: 1.1.45
       - name: Install deps
         run: |
           bun --version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,8 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.45
       - name: Install deps
         run: |
           bun --version
@@ -47,6 +49,8 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.45
       - name: Install deps
         run: |
           bun --version

--- a/packages/engine-content-api/src/mapper/Mapper.ts
+++ b/packages/engine-content-api/src/mapper/Mapper.ts
@@ -60,7 +60,8 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 			.from(entity.tableName, 'root_')
 			.select(['root_', columnName])
 		const expandedWhere = this.uniqueWhereExpander.expand(entity, where)
-		const builtQb = this.whereBuilder.build(qb, entity, this.pathFactory.create([]), expandedWhere)
+		const withPredicates = this.predicatesInjector.inject(entity, expandedWhere)
+		const builtQb = this.whereBuilder.build(qb, entity, this.pathFactory.create([]), withPredicates)
 		const result = await builtQb.getResult(this.db)
 
 		return result[0] !== undefined ? result[0][columnName] : undefined


### PR DESCRIPTION
This pull request fixes an issue where read conditions in the ACL were not properly enforced during some nested mutations — primarily when using `connect`. Under certain circumstances, a user could reference an entity they were not allowed to read, simply by providing a valid unique identifier (e.g. slug or UUID).

### Example Scenario

Consider the following ACL and schema setup (simplified):

```ts
export const editor = c.createRole('editor')

@c.Allow(editor, {
  read: true,
  update: true,
})
export class Article {
  category = c.manyHasOne(Category)
}

@c.Allow(editor, {
  when: { isPublic: { eq: true } },
  read: true,
})
export class Category {
  isPublic = c.boolColumn().notNull()
  slug = c.stringColumn().notNull().unique()
}
```

- An `editor` is allowed to read `Category` **only if** `isPublic` is `true`.
- However, in a mutation like this:

  ```graphql
  mutation {
    updateArticle(
        by: {id: "uuid-of-article"},
        data: {category: {connect: {slug: "slug-of-private-category"}}}
    ) {
      ok
    }
  }
  ```

  the ACL condition was not being enforced when fetching the `Category` by `slug`. Thus, if the user knew (or guessed) a private category’s `slug`, they could connect it without actually having permission to read it.

### Changes in This Pull Request

The code now ensures that any read conditions (`when` clauses) are enforced when resolving the entity being connected or otherwise referenced.

### Impact

- **Security**: Closes a potential unauthorized data alteration, privilege escalation and data visibility gap where users could connect to entities they were not supposed to read.
- **Scope**: Mainly affects the `connect` operation. Other nested mutations could also be impacted.
- **Backward Compatibility**: Previously valid `connect` operations could now fail if they target entities that do not meet the ACL’s `when` condition.

### Next Steps

1. **Upgrade** to the patched version if you rely on strict ACL conditions.
2. **Review** your existing ACL rules to confirm that newly enforced conditions match intended permissions.
3. **Monitor** any unexpected failures in nested mutations (especially `connect`) after upgrading.

### Contember Cloud

This fix will be automatically applied to all Contember Cloud instances. No action is required from Cloud users.