### PR TITLE
fix(react-devbar): move def error above all other elements

### DIFF
--- a/packages/react-devbar/src/index.css
+++ b/packages/react-devbar/src/index.css
@@ -204,7 +204,7 @@
 	inset: 0;
 	width: 100vw;
 	height: 100vh;
-	z-index: 50;
+	z-index: 16777271;
 	display: flex;
 	justify-content: center;
 	align-items: flex-start;


### PR DESCRIPTION
Changed the `z-index` value of `devError` from `50` to `16777271` to ensure the element is properly layered above other elements.