### PR TITLE
fix(engine): handle empty x-contember-ref

### DIFF
--- a/e2e/cases/content/x-contember-ref.test.ts
+++ b/e2e/cases/content/x-contember-ref.test.ts
@@ -13,6 +13,24 @@ test('Content API: X-Contember-Ref header', async () => {
 
 	const tester = await createTester(createSchema(TagModel))
 
+	// Check that X-Contember-Ref work for empty schema
+	await tester(
+		gql`
+			query {
+				listTag(filter: { label: { eq: "typescript" } }) {
+					label
+				}
+			}
+		`,
+	)
+		.set('X-Contember-Ref', 'None')
+		.expect(response => {
+			expect(response.body.data).toStrictEqual({
+				listTag: [],
+			})
+		})
+		.expect(200)
+
 	await tester(
 		gql`
 			mutation {

--- a/packages/engine-http/src/content/NotModifiedChecker.ts
+++ b/packages/engine-http/src/content/NotModifiedChecker.ts
@@ -31,6 +31,11 @@ export class NotModifiedChecker {
 			return queryHandler.fetch(new LatestTransactionIdByStageQuery(stageId))
 		})
 
+		// No content transaction found
+		if (latestRef === null) {
+			return null
+		}
+
 		return {
 			isModified: latestRef !== requestRef,
 			setResponseHeader: res => {

--- a/packages/engine-system-api/src/model/queries/events/LatestTransactionIdByStageQuery.ts
+++ b/packages/engine-system-api/src/model/queries/events/LatestTransactionIdByStageQuery.ts
@@ -1,12 +1,11 @@
 import { DatabaseQuery, DatabaseQueryable, SelectBuilder } from '@contember/database'
-import { ImplementationException } from '../../../utils'
 
-export class LatestTransactionIdByStageQuery extends DatabaseQuery<string> {
+export class LatestTransactionIdByStageQuery extends DatabaseQuery<string | null> {
 	constructor(private readonly stageId: string) {
 		super()
 	}
 
-	async fetch(queryable: DatabaseQueryable): Promise<string> {
+	async fetch(queryable: DatabaseQueryable): Promise<string | null> {
 		const rows = await SelectBuilder.create<{ transaction_id: string }>()
 			.from('stage_transaction')
 			.select('transaction_id')
@@ -15,9 +14,6 @@ export class LatestTransactionIdByStageQuery extends DatabaseQuery<string> {
 			.limit(1)
 			.getResult(queryable.db)
 
-		if (rows.length !== 1) {
-			throw new ImplementationException()
-		}
-		return rows[0].transaction_id
+		return rows.length === 0 ? null : rows[0].transaction_id
 	}
 }


### PR DESCRIPTION
Currently Contember fails with internal server error if it recieves a request with `x-contember-ref`, but there is nothing in the `stage_transaction` table. 

The problem is there at least since v1.1. 

(I have not tested the fix.)