### PR TITLE
uuid v7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,11 +49,10 @@
         "chevrotain": "6.5.0",
         "fast-deep-equal": "^3.1.3",
         "js-levenshtein": "1.1.6",
-        "uuid": "10.0.0",
+        "uuid": "^11.0.5",
       },
       "devDependencies": {
         "@types/js-levenshtein": "1.1.3",
-        "@types/uuid": "10.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
       },
@@ -69,10 +68,7 @@
         "@contember/binding-common": "workspace:*",
         "@contember/client": "workspace:*",
         "@contember/utilities": "workspace:*",
-        "uuid": "9.0.1",
-      },
-      "devDependencies": {
-        "@types/uuid": "9.0.8",
+        "uuid": "^11.0.5",
       },
     },
     "packages/binding-ng": {
@@ -337,7 +333,7 @@
         "lru-cache": "^11.0.1",
         "path-to-regexp": "^6.2.2",
         "prom-client": "^12.0.0",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.5",
         "ws": "^8.18.0",
       },
       "devDependencies": {
@@ -347,7 +343,6 @@
         "@types/koa__cors": "^5.0.0",
         "@types/lru-cache": "^7.10.10",
         "@types/node": "^20.16.11",
-        "@types/uuid": "^10.0.0",
         "@types/ws": "^8.5.12",
         "graphql": "^16.9.0",
       },
@@ -381,12 +376,11 @@
         "mime-types": "^2.1.35",
         "picomatch": "^4.0.2",
         "qs": "^6.13.0",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.5",
       },
       "devDependencies": {
         "@types/mime-types": "^2.1.4",
         "@types/qs": "^6.9.16",
-        "@types/uuid": "^10.0.0",
         "graphql": "^16.9.0",
       },
       "peerDependencies": {
@@ -405,7 +399,7 @@
         "@contember/engine-vimeo-plugin": "workspace:*",
         "graphql": "^16.9.0",
         "pg": "^8.12.0",
-        "uuid": "^10.0.0",
+        "uuid": "^11.0.5",
       },
       "devDependencies": {
         "@types/koa-compress": "^4.0.6",
@@ -644,7 +638,6 @@
       },
       "devDependencies": {
         "@types/js-levenshtein": "1.1.3",
-        "@types/uuid": "10.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
       },
@@ -1726,8 +1719,6 @@
 
     "@types/serve-static": ["@types/serve-static@1.15.7", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw=="],
 
-    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
-
     "@types/ws": ["@types/ws@8.5.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@6.21.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.5.1", "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/type-utils": "6.21.0", "@typescript-eslint/utils": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4", "graphemer": "^1.4.0", "ignore": "^5.2.4", "natural-compare": "^1.4.0", "semver": "^7.5.4", "ts-api-utils": "^1.0.1" }, "peerDependencies": { "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha", "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA=="],
@@ -2666,7 +2657,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@11.0.5", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="],
 
     "value-or-promise": ["value-or-promise@1.0.12", "", {}, "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q=="],
 
@@ -2729,10 +2720,6 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
-
-    "@contember/binding-legacy/@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
-
-    "@contember/binding-legacy/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@contember/react-block-repeater/@radix-ui/primitive": ["@radix-ui/primitive@1.1.1", "", {}, "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="],
 

--- a/packages/binding-common/package.json
+++ b/packages/binding-common/package.json
@@ -35,7 +35,7 @@
     "chevrotain": "6.5.0",
     "fast-deep-equal": "^3.1.3",
     "js-levenshtein": "1.1.6",
-    "uuid": "10.0.0"
+    "uuid": "^11.0.5"
   },
   "peerDependencies": {
     "react": "^18 || ^19",
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@types/js-levenshtein": "1.1.3",
-    "@types/uuid": "10.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/binding-legacy/package.json
+++ b/packages/binding-legacy/package.json
@@ -32,9 +32,6 @@
     "@contember/binding-common": "workspace:*",
     "@contember/client": "workspace:*",
     "@contember/utilities": "workspace:*",
-    "uuid": "9.0.1"
-  },
-  "devDependencies": {
-    "@types/uuid": "9.0.8"
+    "uuid": "^11.0.5"
   }
 }

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -169,7 +169,7 @@ export class ExecutionContainerFactory {
 			.addService('updater', ({ predicateFactory, updateBuilderFactory, schema, schemaDatabaseMetadata }) =>
 				new Updater(schema.model, schemaDatabaseMetadata, predicateFactory, updateBuilderFactory))
 			.addService('inserter', ({  insertBuilderFactory, providers, schema, schemaDatabaseMetadata }) =>
-				new Inserter(schema.model, schemaDatabaseMetadata, insertBuilderFactory, providers))
+				new Inserter(schema.model, schemaDatabaseMetadata, insertBuilderFactory, providers, { uuidVersion: schema.settings.content?.uuidVersion }))
 			.addService('mapperFactory', ({ predicatesInjector, selectBuilderFactory, uniqueWhereExpander, whereBuilder, junctionTableManager, deleteExecutor, updater, inserter, pathFactory, providers, schema, schemaDatabaseMetadata }) => {
 				return new MapperFactory(
 					db,

--- a/packages/engine-content-api/src/input-validation/ColumnValueResolver.ts
+++ b/packages/engine-content-api/src/input-validation/ColumnValueResolver.ts
@@ -9,7 +9,7 @@ export class ColumnValueResolver {
 			return '00000000-0000-0000-0000-000000000000'
 		}
 		try {
-			return resolveColumnValue(context, this.providers)
+			return resolveColumnValue(context, this.providers, {})
 		} catch (e) {
 			if (e instanceof NoDataError) {
 				return undefined

--- a/packages/engine-content-api/src/mapper/insert/Inserter.ts
+++ b/packages/engine-content-api/src/mapper/insert/Inserter.ts
@@ -16,6 +16,7 @@ export class Inserter {
 		private readonly schemaDatabaseMetadata: DatabaseMetadata,
 		private readonly insertBuilderFactory: InsertBuilderFactory,
 		private readonly providers: Providers,
+		private readonly options: { uuidVersion?: 4 | 7 },
 	) {}
 
 	public async insert(
@@ -30,7 +31,7 @@ export class Inserter {
 		insertBuilder.addPredicates(Object.keys(data))
 
 		const visitor = new CreateInputVisitor<SqlCreateInputProcessorResult>(
-			new SqlCreateInputProcessor(insertBuilder, mapper, this.providers),
+			new SqlCreateInputProcessor(insertBuilder, mapper, this.providers, this.options),
 			this.schema,
 			data,
 		)

--- a/packages/engine-content-api/src/mapper/insert/SqlCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/SqlCreateInputProcessor.ts
@@ -25,6 +25,7 @@ export class SqlCreateInputProcessor implements CreateInputProcessor<SqlCreateIn
 		private readonly insertBuilder: InsertBuilder,
 		private readonly mapper: Mapper,
 		private readonly providers: Providers,
+		private readonly options: { uuidVersion?: 4 | 7 } = {},
 	) {
 		this.oneHasOneInverseCreateInputProcessor = new OneHasOneInverseCreateInputProcessor(this.mapper)
 		this.oneHasOneOwningCreateInputProcessor = new OneHasOneOwningCreateInputProcessor(this.mapper, this.insertBuilder)
@@ -36,7 +37,7 @@ export class SqlCreateInputProcessor implements CreateInputProcessor<SqlCreateIn
 	public async column(context: Model.ColumnContext & { input: Input.ColumnValue | undefined }): Promise<SqlCreateInputProcessorResult> {
 		this.insertBuilder.addFieldValue(
 			context.column.name,
-			resolveColumnValue(context, this.providers),
+			resolveColumnValue(context, this.providers, this.options),
 		)
 		return []
 	}

--- a/packages/engine-http/package.json
+++ b/packages/engine-http/package.json
@@ -51,7 +51,7 @@
     "lru-cache": "^11.0.1",
     "path-to-regexp": "^6.2.2",
     "prom-client": "^12.0.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.0.5",
     "ws": "^8.18.0"
   },
   "devDependencies": {
@@ -61,7 +61,6 @@
     "@types/koa__cors": "^5.0.0",
     "@types/lru-cache": "^7.10.10",
     "@types/node": "^20.16.11",
-    "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.12",
     "graphql": "^16.9.0"
   },

--- a/packages/engine-http/src/providers.ts
+++ b/packages/engine-http/src/providers.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidv4 } from 'uuid'
+import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
 import bcrypt from 'bcryptjs'
 import crypto, { BinaryLike } from 'node:crypto'
 
 
 export const createProviders = () => ({
-	uuid: () => uuidv4(),
+	uuid: ({ version = 4 }: { version?: 4 | 7 } = {}) => version === 4 ? uuidv4() : uuidv7(),
 	now: () => new Date(),
 	bcrypt: async (value: string) => await bcrypt.hash(value, 10),
 	bcryptCompare: (data: any, hash: string) => bcrypt.compare(data, hash),

--- a/packages/engine-s3-plugin/package.json
+++ b/packages/engine-s3-plugin/package.json
@@ -29,12 +29,11 @@
     "mime-types": "^2.1.35",
     "picomatch": "^4.0.2",
     "qs": "^6.13.0",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@types/mime-types": "^2.1.4",
     "@types/qs": "^6.9.16",
-    "@types/uuid": "^10.0.0",
     "graphql": "^16.9.0"
   },
   "peerDependencies": {

--- a/packages/engine-server/package.json
+++ b/packages/engine-server/package.json
@@ -30,7 +30,7 @@
     "@contember/engine-vimeo-plugin": "workspace:*",
     "graphql": "^16.9.0",
     "pg": "^8.12.0",
-    "uuid": "^10.0.0"
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@types/koa-compress": "^4.0.6",

--- a/packages/playground/api/index.ts
+++ b/packages/playground/api/index.ts
@@ -17,5 +17,5 @@ export default createSchema(model, schema => ({
 			},
 		},
 	},
-	settings: settingsPresets['v2.0'],
+	settings: settingsPresets.latest,
 }))

--- a/packages/playground/api/migrations/2025-02-18-151927-uuid-v7.json
+++ b/packages/playground/api/migrations/2025-02-18-151927-uuid-v7.json
@@ -1,0 +1,16 @@
+{
+	"formatVersion": 6,
+	"modifications": [
+		{
+			"modification": "updateSettings",
+			"op": "set",
+			"key": "content",
+			"value": {
+				"useExistsInHasManyFilter": true,
+				"fullDateTimeResponse": true,
+				"shortDateResponse": true,
+				"uuidVersion": 7
+			}
+		}
+	]
+}

--- a/packages/react-binding/package.json
+++ b/packages/react-binding/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@types/js-levenshtein": "1.1.3",
-    "@types/uuid": "10.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   }

--- a/packages/schema-definition/src/presets.ts
+++ b/packages/schema-definition/src/presets.ts
@@ -29,8 +29,20 @@ const v2_0preset: Settings.Schema = {
 	},
 }
 
+
+const v2_1preset: Settings.Schema = {
+	...v2_0preset,
+	content: {
+		...v2_0preset.content,
+		uuidVersion: 7,
+	},
+}
+
 export const settingsPresets = {
 	'v1.3': v1_3preset,
 	'v1.4': v1_4preset,
 	'v2.0': v2_0preset,
+	'v2.1': v2_1preset,
+
+	'latest': v2_1preset,
 }

--- a/packages/schema-utils/src/dataUtils.ts
+++ b/packages/schema-utils/src/dataUtils.ts
@@ -1,7 +1,7 @@
 import { Input, Model, Value } from '@contember/schema'
 
 export interface Providers {
-	uuid: () => string
+	uuid: (args?: { version?: 4 | 7 }) => string
 	now: () => Date
 }
 
@@ -42,13 +42,6 @@ export const resolveDefaultValue = (column: Model.AnyColumn, providers: Pick<Pro
 	throw new NoDataError(`No data for column ${column.name}`)
 }
 
-export const resolvePrimaryGenerator = (column: Model.AnyColumn, providers: Providers): (() => Input.PrimaryValue | undefined) => {
-	if (column.type === Model.ColumnType.Uuid) {
-		return providers.uuid
-	}
-	return () => undefined
-}
-
 export const resolveColumnValue = (
 	{
 		entity,
@@ -60,12 +53,18 @@ export const resolveColumnValue = (
 		input: Input.ColumnValue | undefined
 	},
 	providers: Providers,
+	options: {
+		uuidVersion?: 4 | 7
+	},
 ): Value.FieldValue | undefined => {
 	if (input !== undefined) {
 		return input
 	}
 	if (entity.primary === column.name) {
-		return resolvePrimaryGenerator(column, providers)()
+		if (column.type === Model.ColumnType.Uuid) {
+			return providers.uuid({ version: options.uuidVersion })
+		}
+		return undefined
 	}
 
 	return resolveDefaultValue(column, providers)

--- a/packages/schema-utils/src/type-schema/settings.ts
+++ b/packages/schema-utils/src/type-schema/settings.ts
@@ -11,6 +11,7 @@ export const settingsSchema = Typesafe.partial({
 		useExistsInHasManyFilter: Typesafe.boolean,
 		fullDateTimeResponse: Typesafe.boolean,
 		shortDateResponse: Typesafe.boolean,
+		uuidVersion: Typesafe.union(Typesafe.literal(4), Typesafe.literal(7)),
 	}),
 })
 

--- a/packages/schema/src/schema/settings.ts
+++ b/packages/schema/src/schema/settings.ts
@@ -7,6 +7,7 @@ export namespace Settings {
 		readonly shortDateResponse?: boolean
 		readonly fullDateTimeResponse?: boolean
 		readonly useExistsInHasManyFilter?: boolean
+		readonly uuidVersion?: 4 | 7
 	}
 
 	export type Schema = {


### PR DESCRIPTION
This PR introduces support for UUID v7 as generator for primary columns. This feature is opt-in and can be enabled via the `content.uuidVersion `setting or by using the 2.1 settings preset.