### PR TITLE
fix(vite-plugin): disable appending build version to html during development to disable outdated dialog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
       "name": "@contember/cli",
       "version": "2.1.0-alpha.1",
       "bin": {
-        "contember": "./dist/production/run.js"
+        "contember": "./dist/production/run.js",
       },
       "dependencies": {
         "@contember/cli-common": "workspace:*",
@@ -161,7 +161,7 @@
       "name": "@contember/client-content-generator",
       "version": "2.1.0-alpha.1",
       "bin": {
-        "contember-client-generator": "./dist/production/generate.cjs"
+        "contember-client-generator": "./dist/production/generate.cjs",
       },
       "dependencies": {
         "@contember/client-content": "workspace:*",


### PR DESCRIPTION
This pull request includes significant enhancements and refactoring to the `packages/vite-plugin/src/index.ts` file. The changes primarily focus on improving the configuration options for the Contember Vite plugin, adding detailed documentation, and enhancing the robustness of the plugin's functionalities.

### Enhancements to Configuration Options:
* Added detailed JSDoc comments to the `ContemberOptions` type, providing clear descriptions for each option and their default values.
* Enhanced the destructuring of `options` in the `contember` function to include default values for `appPath`, `buildVersion`, and `disableMiddleware`.
* Introduced comprehensive documentation for the Contember Vite plugin, including a description of its features and an example usage.

### Code Robustness:
* Improved the handling of the Contember DSN to include error handling and logging for invalid DSN formats.
* Normalized the `appPath` to ensure it always starts with a `/`, improving consistency in path handling.

### Middleware and Build Version Handling:
* Updated middleware and build version handling to use the normalized `appPath` and default values, ensuring correct behavior based on the provided options.