### PR TITLE
views: generated primary key

### DIFF
--- a/e2e/cases/content/view-id.test.ts
+++ b/e2e/cases/content/view-id.test.ts
@@ -33,3 +33,38 @@ test('read view with generated id', async () => {
 		.expect(200)
 
 })
+
+namespace ViewIdComputedTest {
+	@c.View(`
+SELECT 
+	null as id, 
+	1 as value,
+	'bar' as value2
+`, {
+		idSource: ['value', 'value2'],
+	})
+	export class Foo {
+		value = def.intColumn()
+		value2 = def.stringColumn()
+	}
+}
+
+test('read view with computed id', async () => {
+	const tester = await createTester(createSchema(ViewIdComputedTest))
+
+	await tester(
+		gql`
+            query {
+                listFoo {
+                    id
+                }
+            }
+		`,
+	)
+		.expect(response => {
+			expect(response.body.data.listFoo).toHaveLength(1)
+			expect(response.body.data.listFoo[0].id).toBe('15f0dc32-0141-8ac0-9b97-42e33730fb35')
+		})
+		.expect(200)
+
+})

--- a/e2e/cases/content/view-id.test.ts
+++ b/e2e/cases/content/view-id.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'bun:test'
+import { createTester, gql } from '../../src/tester'
+import { c, createSchema, SchemaDefinition as def } from '@contember/schema-definition'
+
+namespace ViewIdTest {
+	@c.View(`
+SELECT 
+	null as id, 
+	1 as value
+`)
+	export class Foo {
+		value = def.intColumn()
+	}
+}
+
+test('read view with generated id', async () => {
+	const tester = await createTester(createSchema(ViewIdTest))
+
+	await tester(
+		gql`
+			query {
+				listFoo {
+					id
+					value
+				}
+			}
+		`,
+	)
+		.expect(response => {
+			expect(response.body.data.listFoo).toHaveLength(1)
+			expect(response.body.data.listFoo[0].id).toMatch(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/)
+		})
+		.expect(200)
+
+})

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -122,8 +122,8 @@ export class ExecutionContainerFactory {
 				new OrderByBuilder(schema.model, joinBuilder))
 			.addService('relationFetcher', ({ whereBuilder, orderByBuilder, predicatesInjector, pathFactory }) =>
 				new RelationFetcher(whereBuilder, orderByBuilder, predicatesInjector, pathFactory))
-			.addService('fieldsVisitorFactory', ({ relationFetcher, predicateFactory, schema }) =>
-				new FieldsVisitorFactory(relationFetcher, predicateFactory, schema.settings.content ?? {}))
+			.addService('fieldsVisitorFactory', ({ relationFetcher, predicateFactory, schema, providers }) =>
+				new FieldsVisitorFactory(relationFetcher, predicateFactory, schema.settings.content ?? {}, providers))
 			.addService('metaHandler', ({ whereBuilder, predicateFactory }) =>
 				new MetaHandler(whereBuilder, predicateFactory))
 			.addService('uniqueWhereExpander', ({ schema }) =>

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -123,7 +123,7 @@ export class ExecutionContainerFactory {
 			.addService('relationFetcher', ({ whereBuilder, orderByBuilder, predicatesInjector, pathFactory }) =>
 				new RelationFetcher(whereBuilder, orderByBuilder, predicatesInjector, pathFactory))
 			.addService('fieldsVisitorFactory', ({ relationFetcher, predicateFactory, schema, providers }) =>
-				new FieldsVisitorFactory(relationFetcher, predicateFactory, schema.settings.content ?? {}, providers))
+				new FieldsVisitorFactory(schema.model, relationFetcher, predicateFactory, schema.settings.content ?? {}, providers))
 			.addService('metaHandler', ({ whereBuilder, predicateFactory }) =>
 				new MetaHandler(whereBuilder, predicateFactory))
 			.addService('uniqueWhereExpander', ({ schema }) =>

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
@@ -3,11 +3,12 @@ import { RelationFetcher } from '../RelationFetcher'
 import { Mapper } from '../../Mapper'
 import { SelectExecutionHandlerContext } from '../SelectExecutionHandler'
 import { PredicateFactory } from '../../../acl'
-import { Settings } from '@contember/schema'
+import { Model, Settings } from '@contember/schema'
 import { Providers } from '@contember/schema-utils'
 
 export class FieldsVisitorFactory {
 	constructor(
+		private readonly schema: Model.Schema,
 		private readonly relationFetcher: RelationFetcher,
 		private readonly predicateFactory: PredicateFactory,
 		private readonly settings: Settings.ContentSettings,
@@ -16,6 +17,7 @@ export class FieldsVisitorFactory {
 
 	create(mapper: Mapper, context: SelectExecutionHandlerContext): FieldsVisitor {
 		return new FieldsVisitor(
+			this.schema,
 			this.relationFetcher,
 			this.predicateFactory,
 			mapper,

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitorFactory.ts
@@ -4,12 +4,14 @@ import { Mapper } from '../../Mapper'
 import { SelectExecutionHandlerContext } from '../SelectExecutionHandler'
 import { PredicateFactory } from '../../../acl'
 import { Settings } from '@contember/schema'
+import { Providers } from '@contember/schema-utils'
 
 export class FieldsVisitorFactory {
 	constructor(
 		private readonly relationFetcher: RelationFetcher,
 		private readonly predicateFactory: PredicateFactory,
 		private readonly settings: Settings.ContentSettings,
+		private readonly providers: Providers,
 	) {}
 
 	create(mapper: Mapper, context: SelectExecutionHandlerContext): FieldsVisitor {
@@ -20,6 +22,7 @@ export class FieldsVisitorFactory {
 			context,
 			context.relationPath,
 			this.settings,
+			this.providers,
 		)
 	}
 }

--- a/packages/engine-content-api/src/utils/viewComputedId.ts
+++ b/packages/engine-content-api/src/utils/viewComputedId.ts
@@ -1,0 +1,23 @@
+import crypto from 'node:crypto'
+
+export const viewComputedId = (inputs: (string)[]): string => {
+	let uuidBytes: Buffer
+	uuidBytes = crypto.createHash('md5').update(inputs.join('\x00')).digest()
+
+	// Set the version (v8) in the high nibble of byte 6.
+	uuidBytes[6] = (uuidBytes[6] & 0x0f) | 0x80 // 0x80 = 1000 0000 (version 8)
+
+	// Set the variant (RFC 4122) in byte 8.
+	uuidBytes[8] = (uuidBytes[8] & 0x3f) | 0x80
+
+	return formatUUID(uuidBytes)
+}
+
+const formatUUID = (buf: Buffer): string => {
+	const hex = buf.toString('hex')
+	return hex.substring(0, 8)
+		+ '-' + hex.substring(8, 12)
+		+ '-' + hex.substring(12, 16)
+		+ '-' + hex.substring(16, 20)
+		+ '-' + hex.substring(20)
+}

--- a/packages/schema-definition/src/model/definition/ViewDefinition.ts
+++ b/packages/schema-definition/src/model/definition/ViewDefinition.ts
@@ -1,7 +1,11 @@
 import { extendEntity } from './extensions'
 import { EntityConstructor } from './types'
+import { DecoratorFunction } from '../../utils'
 
-export const View = (sql: string, { dependencies }: { dependencies?: (() => EntityConstructor[]) | EntityConstructor[] } = {}) =>
+export const View = <T>(sql: string, { dependencies, idSource }: {
+	dependencies?: (() => EntityConstructor[]) | EntityConstructor[]
+	idSource?: readonly ((keyof T) & string)[]
+} = {}): DecoratorFunction<T> =>
 	extendEntity(({ entity, entityRegistry }) => {
 		const dependenciesResolved = typeof dependencies === 'function' ? dependencies() : dependencies
 		if (dependenciesResolved?.some(it => it === undefined)) {
@@ -19,6 +23,7 @@ dependencies: () => [MyEntity]
 			view: {
 				sql,
 				...(dependenciesResolved ? { dependencies: dependenciesResolved.map(it => entityRegistry.getName(it)) } : {}),
+				...(idSource ? { idSource } : {}),
 			},
 		})
 	})

--- a/packages/schema-utils/src/type-schema/model.ts
+++ b/packages/schema-utils/src/type-schema/model.ts
@@ -155,6 +155,7 @@ const viewSchemaInner = Typesafe.intersection(
 	}),
 	Typesafe.partial({
 		dependencies: Typesafe.array(Typesafe.string),
+		idSource: Typesafe.array(Typesafe.string),
 	}),
 )
 const viewSchemaCheck: Typesafe.Equals<Model.View, ReturnType<typeof viewSchemaInner>> = true

--- a/packages/schema/src/schema/model.ts
+++ b/packages/schema/src/schema/model.ts
@@ -19,6 +19,7 @@ export namespace Model {
 	export type View = {
 		readonly sql: string
 		readonly dependencies?: readonly string[]
+		readonly idSource?: readonly string[]
 	}
 
 	export type EventLogConfig = {


### PR DESCRIPTION
- **UUID Generation in Engine:** 
  - Instead of generating UUIDs in the database, they can now be computed in the engine, reducing potential database performance overhead.
  - When an entity’s primary key is `NULL`, a UUID is generated on the fly.

- **Computed ID Support:**
  - Adds support for hash-based computed IDs by specifying `idSource` attributes in views.
  - Uses a deterministic hash-based UUID approach to ensure stable IDs.
