### PR TITLE
feat/optional deploy dsn

### DIFF
--- a/packages/cli/src/commands/deploy/DeployCommand.ts
+++ b/packages/cli/src/commands/deploy/DeployCommand.ts
@@ -10,7 +10,7 @@ import { RemoteProjectProvider } from '../../lib/project/RemoteProjectProvider'
 import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
 
 type Args = {
-	dsn: string
+	dsn?: string
 }
 
 type Options = {
@@ -35,7 +35,7 @@ export class DeployCommand extends Command<Args, Options> {
 
 	protected configure(configuration: CommandConfiguration<Args, Options>): void {
 		configuration.description('Deploy Contember project')
-		configuration.argument('dsn')
+		configuration.argument('dsn').optional()
 
 		configuration.option('admin').valueRequired()
 		configuration.option('root').valueNone()

--- a/packages/vite-plugin/tests/cases/unit/vite-plugin.test.ts
+++ b/packages/vite-plugin/tests/cases/unit/vite-plugin.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test'
+import contember from '../../../src'
+import { ConfigEnv, UserConfig, Plugin } from 'vite'
+
+const invokePluginHook = (plugin: Plugin, hookName: string, ...args: any[]) => {
+	const hook = plugin[hookName]
+	if (typeof hook === 'function') {
+		return hook(...args)
+	} else if (hook?.handler) {
+		return hook.handler(...args)
+	}
+	return undefined
+}
+
+const createMockServer = () => {
+	return {
+		middlewares: {
+			use: mock(() => { }),
+		},
+	}
+}
+
+const getPluginConfigResult = (plugin: Plugin) => {
+	const userConfig = {} as UserConfig
+	const configEnv = {} as ConfigEnv
+	const result = invokePluginHook(plugin, 'config', userConfig, configEnv) || {}
+
+	return result as UserConfig & {
+		define?: Record<string, string>
+		base?: string
+		build?: {
+			sourcemap?: boolean
+			rollupOptions?: {
+				input?: Record<string, string>
+				output?: Record<string, any>
+			}
+		}
+	}
+}
+
+describe('contember vite plugin', () => {
+	const originalEnv = process.env
+	const originalArgv = process.argv
+
+	beforeEach(() => {
+		process.env = { ...originalEnv }
+		process.argv = [...originalArgv]
+	})
+
+	afterEach(() => {
+		process.env = originalEnv
+		process.argv = originalArgv
+	})
+
+	it('should create a plugin with default options', () => {
+		const plugin = contember()
+		expect(plugin).toBeDefined()
+		expect(plugin.name).toBe('contember')
+	})
+
+	describe('server middleware', () => {
+		it('should normalize app path correctly', () => {
+			const plugin1 = contember({ appPath: 'test-app' })
+			const plugin2 = contember({ appPath: '/test-app' })
+
+			const mockServer1 = createMockServer()
+			const mockServer2 = createMockServer()
+
+			invokePluginHook(plugin1, 'configureServer', mockServer1)
+			invokePluginHook(plugin2, 'configureServer', mockServer2)
+
+			expect(mockServer1.middlewares.use).toHaveBeenCalled()
+			expect(mockServer2.middlewares.use).toHaveBeenCalled()
+		})
+
+		it('should skip middleware when disableMiddleware is true', () => {
+			const plugin = contember({ disableMiddleware: true })
+			const mockServer = createMockServer()
+
+			invokePluginHook(plugin, 'configureServer', mockServer)
+
+			expect(mockServer.middlewares.use).not.toHaveBeenCalled()
+		})
+
+		it('should handle SPA routing middleware correctly', () => {
+			const plugin = contember({ appPath: '/app' })
+			const mockServerMiddleware = mock(() => { })
+			const mockServer = { middlewares: { use: mockServerMiddleware } }
+
+			invokePluginHook(plugin, 'configureServer', mockServer)
+
+			const middleware = mockServerMiddleware.mock.calls[0][0]
+
+			const testCases = [
+				['/app', '/app/'],
+				['/app/dashboard', '/app/'],
+				['/app/settings/profile', '/app/'],
+				['/api/data', '/api/data'],
+				['/app/file.js', '/app/file.js'],
+				['/app/image.png', '/app/image.png'],
+				['/app?user=123', '/app/'],
+				['/app?user=123&sort=desc,user', '/app/'],
+				['/app?test.fakeExtension', '/app/'],
+			]
+
+			testCases.forEach(([url, expected]) => {
+				const req = { url }
+				const next = mock(() => { })
+
+				middleware(req, {}, next)
+
+				expect(req.url).toBe(expected)
+				expect(next).toHaveBeenCalled()
+			})
+		})
+	})
+
+	describe('DSN handling', () => {
+		it('should extract project name from CONTEMBER_DSN environment variable', () => {
+			process.env.CONTEMBER_DSN = 'contember://project-name:token@example.com'
+			const plugin = contember()
+			const configResult = getPluginConfigResult(plugin)
+
+			expect(configResult.define).toEqual({
+				'import.meta.env.VITE_CONTEMBER_ADMIN_PROJECT_NAME': '"project-name"',
+			})
+		})
+
+		it('should extract project name from command line arguments', () => {
+			delete process.env.CONTEMBER_DSN
+			process.argv.push('contember://arg-project:token@example.com')
+			const plugin = contember()
+			const configResult = getPluginConfigResult(plugin)
+
+			expect(configResult.define).toEqual({
+				'import.meta.env.VITE_CONTEMBER_ADMIN_PROJECT_NAME': '"arg-project"',
+			})
+		})
+
+		it('should handle invalid DSN format', () => {
+			process.env.CONTEMBER_DSN = 'invalid-dsn'
+			const consoleSpy = spyOn(console, 'warn').mockImplementation(() => { })
+			const plugin = contember()
+			const configResult = getPluginConfigResult(plugin)
+
+			expect(configResult.define).toEqual({})
+			expect(consoleSpy).toHaveBeenCalled()
+		})
+	})
+
+	describe('build version meta tag', () => {
+		it('should not include build version meta tag in development', () => {
+			process.env.NODE_ENV = 'development'
+			const plugin = contember()
+			expect(plugin.transformIndexHtml).toBeUndefined()
+		})
+
+		it('should add build version meta tag in production', () => {
+			process.env.NODE_ENV = 'production'
+			const plugin = contember()
+
+			const transform = plugin.transformIndexHtml
+			expect(transform).toBeDefined()
+
+			const result = invokePluginHook(plugin, 'transformIndexHtml', '<html></html>', { server: false })
+
+			expect(result.tags).toHaveLength(1)
+			expect(result.tags[0].tag).toBe('meta')
+			expect(result.tags[0].attrs.name).toBe('contember-build-version')
+		})
+
+		it('should respect buildVersion option (disabled)', () => {
+			const plugin = contember({ buildVersion: false })
+			expect(plugin.transformIndexHtml).toBeUndefined()
+		})
+
+		it('should respect buildVersion option (enabled)', () => {
+			process.env.NODE_ENV = 'development'
+			const plugin = contember({ buildVersion: true })
+
+			const result = invokePluginHook(plugin, 'transformIndexHtml', '<html></html>', { server: true })
+
+			expect(result.tags).toHaveLength(1)
+		})
+	})
+
+	describe('vite configuration', () => {
+		it('should configure vite with correct defaults', () => {
+			const plugin = contember({ appPath: '/custom-app' })
+
+			const userConfig = {
+				build: {
+					rollupOptions: {
+						output: {
+							format: 'esm',
+						},
+					},
+				},
+			} as UserConfig
+
+			const configResult = invokePluginHook(plugin, 'config', userConfig, {} as ConfigEnv)
+
+			expect(configResult.base).toBe('/')
+			expect(configResult.build?.sourcemap).toBe(true)
+			expect(configResult.build?.rollupOptions?.input).toEqual({
+				root: './index.html',
+				app: './custom-app/index.html',
+			})
+			// Should preserve existing options
+			expect(configResult.build?.rollupOptions?.output).toEqual({ format: 'esm' })
+		})
+	})
+})


### PR DESCRIPTION
This pull request includes several changes to the `DeployCommand` and `vite-plugin` packages to improve functionality and add new features. The most important changes include making the `dsn` argument optional, enhancing DSN handling, and adding comprehensive unit tests for the `vite-plugin`.

### Changes to `DeployCommand`:

* Made the `dsn` argument optional in the `DeployCommand` class to allow for more flexibility in deployment configurations. [[1]](diffhunk://#diff-802753d039465d6e0880ca4efeaec29338e136ff8788a2c16e2776f80dfc159aL13-R13) [[2]](diffhunk://#diff-802753d039465d6e0880ca4efeaec29338e136ff8788a2c16e2776f80dfc159aL38-R38)

### Changes to `vite-plugin`:

* Added a new helper function `extractProjectNameFromDsn` to handle DSN parsing and project name extraction.
* Refactored the `contember` function to use the new DSN helper and support environment variables for DSN configuration.
* Improved middleware configuration to handle SPA routing and added a new function to create build version meta tags. [[1]](diffhunk://#diff-610bb6af1585f8ecc202e248277bf1857d8a2eef08cdd1dc81cfd0428bec85c7L88-L99) [[2]](diffhunk://#diff-610bb6af1585f8ecc202e248277bf1857d8a2eef08cdd1dc81cfd0428bec85c7L111-R136)

### Unit Tests:

* Added comprehensive unit tests for the `vite-plugin` to ensure correct behavior of DSN handling, middleware configuration, and build version meta tag injection.