### PR TITLE
style(react-ui-lib): align block buttons in editor block toolbar

### DIFF
--- a/packages/react-ui-lib/src/editor/common/editor-block-toolbar.tsx
+++ b/packages/react-ui-lib/src/editor/common/editor-block-toolbar.tsx
@@ -11,7 +11,7 @@ export const EditorBlockToolbar = memo(({ children }: EditorBlockToolbarProps) =
 
 	return (
 		<div className="sticky bottom-0" contentEditable={false}>
-			<div className={cn('-mx-3 -mb-2 p-2 rounded-b-md border-t bg-gray-50 space-x-2', !selection && 'pointer-events-none')}>{children}</div>
+			<div className={cn('-mx-3 -mb-2 p-2 rounded-b-md border-t bg-gray-50 flex flex-wrap gap-2', !selection && 'pointer-events-none')}>{children}</div>
 		</div>
 	)
 })


### PR DESCRIPTION
This pull request includes a small change to the `EditorBlockToolbar` component in the `packages/react-ui-lib` library. The change improves the layout of the toolbar by replacing the `space-x-2` class with `flex flex-wrap gap-2` for better spacing and wrapping of child elements.

* [`packages/react-ui-lib/src/editor/common/editor-block-toolbar.tsx`](diffhunk://#diff-f44b2c1fc8a39e8b197ef2f9613f5cee98232fed159c9b90755d7cfef9826e54L14-R14): Modified the `EditorBlockToolbar` component to use `flex flex-wrap gap-2` instead of `space-x-2` for improved layout and spacing.