### PR TITLE
feat(create): add remote template source support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -191,8 +191,12 @@
       "dependencies": {
         "@contember/cli-common": "workspace:*",
         "chalk": "^5.3.0",
+        "degit": "^2.8.4",
         "fs-extra": "^11.2.0",
         "js-yaml": "^4.1.0",
+      },
+      "devDependencies": {
+        "@types/degit": "^2.8.6",
       },
     },
     "packages/database": {
@@ -1678,6 +1682,8 @@
 
     "@types/cookies": ["@types/cookies@0.9.0", "", { "dependencies": { "@types/connect": "*", "@types/express": "*", "@types/keygrip": "*", "@types/node": "*" } }, "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q=="],
 
+    "@types/degit": ["@types/degit@2.8.6", "", {}, "sha512-y0M7sqzsnHB6cvAeTCBPrCQNQiZe8U4qdzf8uBVmOWYap5MMTN/gB2iEqrIqFiYcsyvP74GnGD5tgsHttielFw=="],
+
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "@types/express": ["@types/express@5.0.0", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/qs": "*", "@types/serve-static": "*" } }, "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ=="],
@@ -1931,6 +1937,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "degit": ["degit@2.8.4", "", { "bin": { "degit": "degit" } }, "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -6,11 +6,15 @@
   "dependencies": {
     "@contember/cli-common": "workspace:*",
     "chalk": "^5.3.0",
+    "degit": "^2.8.4",
     "fs-extra": "^11.2.0",
     "js-yaml": "^4.1.0"
   },
   "type": "module",
   "scripts": {
     "pre-build": "rm -rf rm ./resources/templates/default/admin/lib && cp -r ../react-ui-lib/src ./resources/templates/default/admin/lib && rm ./resources/templates/default/admin/lib/index.ts ./resources/templates/default/admin/lib/tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/degit": "^2.8.6"
   }
 }

--- a/packages/create/src/commands/WorkspaceCreateCommand.ts
+++ b/packages/create/src/commands/WorkspaceCreateCommand.ts
@@ -23,15 +23,16 @@ export class WorkspaceCreateCommand extends Command<Args, Options> {
 	protected configure(configuration: CommandConfiguration<Args, Options>): void {
 		configuration.description('Creates a new Contember project')
 		configuration.argument('projectName')
-		configuration.option('template').shortcut('t')
+		configuration.option('template').shortcut('t').valueRequired().description('Template name or remote source')
 	}
 
 	protected async execute(input: Input<Args, Options>): Promise<void> {
 		const projectName = input.getArgument('projectName')
 		const projectDirectory = join(process.cwd(), projectName)
 		const packageManager = detectPackageManager()
+		const template = input.getOption('template') ?? 'default'
 
-		await this.templateInstaller.installTemplate(input.getOption('template') ?? 'default', projectDirectory, {
+		await this.templateInstaller.installTemplate(template, projectDirectory, {
 			version: await getPackageVersion(),
 			projectName: projectName,
 			packageManager: packageManager,

--- a/packages/create/src/lib/FileSystem.ts
+++ b/packages/create/src/lib/FileSystem.ts
@@ -10,6 +10,7 @@ export class FileSystem {
 	readDir = fs.readdir
 	copy = copy
 	unlink = fs.unlink
+	remove = fs.rm
 	pathExists = async (path: string) => {
 		try {
 			await access(path)


### PR DESCRIPTION
This PR adds support for remote template sources in the create command by cloning templates from remote repositories. Key changes include:

- Integration of degit for cloning remote templates and managing temporary directories.
- Addition of a new "remove" method in the FileSystem abstraction.
- Enhancement of the CLI option for templates to accept remote sources.