### PR TITLE
Actions improvements

### DIFF
--- a/docker-compose.override.dist.yaml
+++ b/docker-compose.override.dist.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   playground:
     user: '1000:1000'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
 
   playground:
@@ -105,9 +104,9 @@ services:
       - bun
       - "--conditions=typescript"
       - /src/packages/cli/src/run.ts
-    depends_on:
-      engine:
-        condition: service_healthy
+#    depends_on:
+#      engine:
+#        condition: service_healthy
 
 
   minio:

--- a/packages/cli/src/commands/actions/ActionsGetEventCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsGetEventCommand.ts
@@ -1,0 +1,42 @@
+import { Command, CommandConfiguration, Input } from '@contember/cli-common'
+import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
+import { ActionsClient } from '../../lib/actions/ActionsClient'
+
+type Args = {
+	eventId: string
+}
+
+type Options = {
+	project?: string
+}
+
+export class ActionsGetEventCommand extends Command<Args, Options> {
+	constructor(
+		private readonly remoteProjectResolver: RemoteProjectResolver,
+	) {
+		super()
+	}
+
+	protected configure(configuration: CommandConfiguration<Args, Options>): void {
+		configuration.description('Get single event')
+		configuration.argument('eventId')
+		configuration.option('project').valueRequired()
+	}
+
+	protected async execute(input: Input<Args, Options>): Promise<void | number> {
+		const dsn = input.getOption('project')
+		const project = await this.remoteProjectResolver.resolve(dsn)
+		if (!project) {
+			throw `Project not defined`
+		}
+		const api = ActionsClient.create(project.endpoint, project.name, project.token)
+
+		const result = await api.getEvent(input.getArgument('eventId'))
+		if (!result) {
+			console.log('Event not found')
+			return 1
+		}
+		console.log(JSON.stringify(result, null, 2))
+
+	}
+}

--- a/packages/cli/src/commands/actions/ActionsListFailedEventsCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsListFailedEventsCommand.ts
@@ -1,0 +1,70 @@
+import { Command, CommandConfiguration, Input } from '@contember/cli-common'
+import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
+import { ActionsClient } from '../../lib/actions/ActionsClient'
+import chalkTable from 'chalk-table'
+type Args = {
+}
+
+type Options = {
+	project?: string
+	json?: boolean
+}
+
+export class ActionsListFailedEventsCommand extends Command<Args, Options> {
+	constructor(
+		private readonly remoteProjectResolver: RemoteProjectResolver,
+	) {
+		super()
+	}
+
+	protected configure(configuration: CommandConfiguration<Args, Options>): void {
+		configuration.description('Show failed events')
+		configuration.option('project').valueRequired()
+		configuration.option('json').valueNone()
+	}
+
+	protected async execute(input: Input<Args, Options>): Promise<void | number> {
+		const dsn = input.getOption('project')
+		const project = await this.remoteProjectResolver.resolve(dsn)
+		if (!project) {
+			throw `Project not defined`
+		}
+		const api = ActionsClient.create(project.endpoint, project.name, project.token)
+
+		const result = await api.listFailedEvents()
+		if (input.getOption('json')) {
+			console.log(JSON.stringify(result, null, 2))
+			return
+		}
+		if (result.length === 0) {
+			console.log('No failed events')
+			return
+		}
+		const table = chalkTable(
+			{
+				columns: [
+					{ field: 'id', name: 'ID' },
+					{ field: 'createdAt', name: 'Created at' },
+					{ field: 'lastStateChange', name: 'Last state change' },
+					{ field: 'visibleAt', name: 'Visible at' },
+					{ field: 'numRetries', name: 'Retries' },
+					{ field: 'state', name: 'State' },
+					{ field: 'target', name: 'Target' },
+					{ field: 'log', name: 'Log' },
+				],
+			},
+			result.map(it => ({
+				id: it.id,
+				createdAt: it.createdAt,
+				lastStateChange: it.lastStateChange,
+				visibleAt: it.visibleAt || '',
+				numRetries: it.numRetries.toString(),
+				state: it.state,
+				target: it.target,
+				log: JSON.stringify(it.log.length > 0 ? it.log[it.log.length - 1] : {}),
+			})),
+		)
+		console.log(table)
+
+	}
+}

--- a/packages/cli/src/commands/actions/ActionsListVariablesCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsListVariablesCommand.ts
@@ -1,0 +1,37 @@
+import { Command, CommandConfiguration, Input } from '@contember/cli-common'
+import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
+import { ActionsClient } from '../../lib/actions/ActionsClient'
+import chalkTable from 'chalk-table'
+
+type Args = {
+}
+
+type Options = {
+	project?: string
+}
+
+export class ActionsListVariablesCommand extends Command<Args, Options> {
+	constructor(
+		private readonly remoteProjectResolver: RemoteProjectResolver,
+	) {
+		super()
+	}
+
+	protected configure(configuration: CommandConfiguration<Args, Options>): void {
+		configuration.description('Show action variables')
+		configuration.option('project').valueRequired()
+	}
+
+	protected async execute(input: Input<Args, Options>): Promise<void | number> {
+		const dsn = input.getOption('project')
+		const project = await this.remoteProjectResolver.resolve(dsn)
+		if (!project) {
+			throw `Project not defined`
+		}
+		const api = ActionsClient.create(project.endpoint, project.name, project.token)
+		const result = await api.listVariables()
+		console.log(chalkTable({
+			columns: ['name', 'value'],
+		}, result))
+	}
+}

--- a/packages/cli/src/commands/actions/ActionsRetryEventCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsRetryEventCommand.ts
@@ -1,0 +1,42 @@
+import { Command, CommandConfiguration, Input } from '@contember/cli-common'
+import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
+import { ActionsClient } from '../../lib/actions/ActionsClient'
+import chalkTable from 'chalk-table'
+type Args = {
+	eventId: string
+}
+
+type Options = {
+	project?: string
+}
+
+export class ActionsRetryEventCommand extends Command<Args, Options> {
+	constructor(
+		private readonly remoteProjectResolver: RemoteProjectResolver,
+	) {
+		super()
+	}
+
+	protected configure(configuration: CommandConfiguration<Args, Options>): void {
+		configuration.description('Retry given event')
+		configuration.argument('eventId')
+		configuration.option('project').valueRequired()
+	}
+
+	protected async execute(input: Input<Args, Options>): Promise<void | number> {
+		const dsn = input.getOption('project')
+		const project = await this.remoteProjectResolver.resolve(dsn)
+		if (!project) {
+			throw `Project not defined`
+		}
+		const api = ActionsClient.create(project.endpoint, project.name, project.token)
+
+		const result = await api.retryEvent(input.getArgument('eventId'))
+		if (result) {
+			console.log('Event requeued for processing')
+		} else {
+			console.log('Failed to requeue event. Check the event status')
+			return 1
+		}
+	}
+}

--- a/packages/cli/src/commands/actions/ActionsSetVariablesCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsSetVariablesCommand.ts
@@ -21,7 +21,7 @@ export class ActionsSetVariablesCommand extends Command<Args, Options> {
 	}
 
 	protected configure(configuration: CommandConfiguration<Args, Options>): void {
-		configuration.description('Show action variables')
+		configuration.description('Set action variables')
 		configuration.option('project').valueRequired()
 		configuration.option('merge').valueNone().description('merges with new values (default behaviour)')
 		configuration.option('set').valueNone().description('replaces all variables')

--- a/packages/cli/src/commands/actions/ActionsSetVariablesCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsSetVariablesCommand.ts
@@ -1,0 +1,56 @@
+import { Command, CommandConfiguration, Input } from '@contember/cli-common'
+import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
+import { ActionsClient } from '../../lib/actions/ActionsClient'
+
+type Args = {
+	variables: string[]
+}
+
+type Options = {
+	project?: string
+	merge?: boolean
+	set?: boolean
+	['append-only-missing']?: boolean
+}
+
+export class ActionsSetVariablesCommand extends Command<Args, Options> {
+	constructor(
+		private readonly remoteProjectResolver: RemoteProjectResolver,
+	) {
+		super()
+	}
+
+	protected configure(configuration: CommandConfiguration<Args, Options>): void {
+		configuration.description('Show action variables')
+		configuration.option('project').valueRequired()
+		configuration.option('merge').valueNone().description('merges with new values (default behaviour)')
+		configuration.option('set').valueNone().description('replaces all variables')
+		configuration.option('append-only-missing').valueNone().description('appends values if not already exist')
+		configuration.argument('variables').variadic().description('variables to set, in the form of name=value')
+	}
+
+	protected async execute(input: Input<Args, Options>): Promise<void | number> {
+		const dsn = input.getOption('project')
+		const project = await this.remoteProjectResolver.resolve(dsn)
+		if (!project) {
+			throw `Project not defined`
+		}
+		const api = ActionsClient.create(project.endpoint, project.name, project.token)
+		const mode = input.getOption('merge')
+			? 'MERGE' as const : input.getOption('set')
+				? 'SET' as const : input.getOption('append-only-missing')
+					? 'APPEND_ONLY_MISSING' as const : 'MERGE' as const
+
+		const variables = input.getArgument('variables').flatMap(it => it.split('\n')).filter(it => it.trim().length > 0)
+		const result = await api.setVariables(variables.map(it => {
+			const [name, value] = it.split('=')
+			return { name, value }
+		}), mode)
+		if (result) {
+			console.log('Success')
+		} else {
+			console.error('Failed')
+			return 1
+		}
+	}
+}

--- a/packages/cli/src/commands/actions/ActionsStopEventCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsStopEventCommand.ts
@@ -1,0 +1,42 @@
+import { Command, CommandConfiguration, Input } from '@contember/cli-common'
+import { RemoteProjectResolver } from '../../lib/project/RemoteProjectResolver'
+import { ActionsClient } from '../../lib/actions/ActionsClient'
+import chalkTable from 'chalk-table'
+type Args = {
+	eventId: string
+}
+
+type Options = {
+	project?: string
+}
+
+export class ActionsStopEventCommand extends Command<Args, Options> {
+	constructor(
+		private readonly remoteProjectResolver: RemoteProjectResolver,
+	) {
+		super()
+	}
+
+	protected configure(configuration: CommandConfiguration<Args, Options>): void {
+		configuration.description('Stop given event')
+		configuration.argument('eventId')
+		configuration.option('project').valueRequired()
+	}
+
+	protected async execute(input: Input<Args, Options>): Promise<void | number> {
+		const dsn = input.getOption('project')
+		const project = await this.remoteProjectResolver.resolve(dsn)
+		if (!project) {
+			throw `Project not defined`
+		}
+		const api = ActionsClient.create(project.endpoint, project.name, project.token)
+
+		const result = await api.stopEvent(input.getArgument('eventId'))
+		if (result) {
+			console.log('Event stopped')
+		} else {
+			console.log('Failed to stop event. Check the event id.')
+			return 1
+		}
+	}
+}

--- a/packages/cli/src/dic.ts
+++ b/packages/cli/src/dic.ts
@@ -68,6 +68,10 @@ import { TenantClientProvider } from './lib/TenantClientProvider'
 import { Workspace } from './lib/workspace/Workspace'
 import { ActionsListVariablesCommand } from './commands/actions/ActionsListVariablesCommand'
 import { ActionsSetVariablesCommand } from './commands/actions/ActionsSetVariablesCommand'
+import { ActionsListFailedEventsCommand } from './commands/actions/ActionsListFailedEventsCommand'
+import { ActionsRetryEventCommand } from './commands/actions/ActionsRetryEventCommand'
+import { ActionsGetEventCommand } from './commands/actions/ActionsGetEventCommand'
+import { ActionsStopEventCommand } from './commands/actions/ActionsStopEventCommand'
 
 const jsSample = `
 export const query = \`\`
@@ -224,6 +228,15 @@ export const createContainer = ({ env, version, runtime, workspace }: {
 			new ActionsListVariablesCommand(remoteProjectResolver))
 		.addService('actionsSetVariables', ({ remoteProjectResolver }) =>
 			new ActionsSetVariablesCommand(remoteProjectResolver))
+		.addService('actionsListFailedEvents', ({ remoteProjectResolver }) =>
+			new ActionsListFailedEventsCommand(remoteProjectResolver))
+		.addService('actionsRetryEvent', ({ remoteProjectResolver }) =>
+			new ActionsRetryEventCommand(remoteProjectResolver))
+		.addService('actionsGetEvent', ({ remoteProjectResolver }) =>
+			new ActionsGetEventCommand(remoteProjectResolver))
+		.addService('actionsStopEvent', ({ remoteProjectResolver }) =>
+			new ActionsStopEventCommand(remoteProjectResolver))
+
 		.addService('commandList', dic => {
 			const commands: CommandFactoryList = {
 				['deploy']: () => dic.deployCommand,
@@ -244,6 +257,10 @@ export const createContainer = ({ env, version, runtime, workspace }: {
 				['project:generate-doc']: () => dic.projectGenerateDocumentationCommand,
 				['actions:list-variables']: () => dic.actionsListVariables,
 				['actions:set-variables']: () => dic.actionsSetVariables,
+				['actions:failed-events']: () => dic.actionsListFailedEvents,
+				['actions:retry-event']: () => dic.actionsRetryEvent,
+				['actions:get-event']: () => dic.actionsGetEvent,
+				['actions:stop-event']: () => dic.actionsStopEvent,
 			}
 			return commands
 		})

--- a/packages/cli/src/dic.ts
+++ b/packages/cli/src/dic.ts
@@ -66,6 +66,8 @@ import { RemoteProjectProvider } from './lib/project/RemoteProjectProvider'
 import { SystemClientProvider } from './lib/SystemClientProvider'
 import { TenantClientProvider } from './lib/TenantClientProvider'
 import { Workspace } from './lib/workspace/Workspace'
+import { ActionsListVariablesCommand } from './commands/actions/ActionsListVariablesCommand'
+import { ActionsSetVariablesCommand } from './commands/actions/ActionsSetVariablesCommand'
 
 const jsSample = `
 export const query = \`\`
@@ -218,6 +220,10 @@ export const createContainer = ({ env, version, runtime, workspace }: {
 			new TransferCommand(remoteProjectResolver, dataTransferClient))
 		.addService('workspaceUpdateCommand', ({ packageWorkspaceResolver, dockerComposeManager }) =>
 			new WorkspaceUpdateApiCommand(packageWorkspaceResolver, dockerComposeManager))
+		.addService('actionsListVariables', ({ remoteProjectResolver }) =>
+			new ActionsListVariablesCommand(remoteProjectResolver))
+		.addService('actionsSetVariables', ({ remoteProjectResolver }) =>
+			new ActionsSetVariablesCommand(remoteProjectResolver))
 		.addService('commandList', dic => {
 			const commands: CommandFactoryList = {
 				['deploy']: () => dic.deployCommand,
@@ -236,6 +242,8 @@ export const createContainer = ({ env, version, runtime, workspace }: {
 				['project:validate']: () => dic.projectValidateCommand,
 				['project:print-schema']: () => dic.projectPrintSchemaCommand,
 				['project:generate-doc']: () => dic.projectGenerateDocumentationCommand,
+				['actions:list-variables']: () => dic.actionsListVariables,
+				['actions:set-variables']: () => dic.actionsSetVariables,
 			}
 			return commands
 		})

--- a/packages/cli/src/lib/actions/ActionsClient.ts
+++ b/packages/cli/src/lib/actions/ActionsClient.ts
@@ -1,0 +1,40 @@
+import { GraphQlClient } from '@contember/graphql-client'
+
+const createActionsApiUrl = (url: string, project: string) => {
+	if (url.endsWith('/')) {
+		url = url.substring(0, url.length - 1)
+	}
+
+	return url + '/actions/' + project
+}
+export class ActionsClient {
+	constructor(private readonly apiClient: GraphQlClient) {}
+
+	public static create(url: string, project: string, apiToken: string): ActionsClient {
+		const graphqlClient = new GraphQlClient({ url: createActionsApiUrl(url, project), apiToken })
+		return new ActionsClient(graphqlClient)
+	}
+
+	public async listVariables(): Promise<{ name: string; value: string }[]> {
+		const query = `query {
+  variables {
+  	name
+  	value
+  }
+}`
+		const result = await this.apiClient.execute<{
+			variables: Array<{ name: string; value: string }>
+		}>(query)
+		return result.variables
+	}
+
+	public async setVariables(variables: { name: string; value: string }[], mode: 'MERGE' | 'SET' | 'APPEND_ONLY_MISSING'): Promise<boolean> {
+		const query = `mutation($variables: [VariableInput!]!, $mode: SetVariablesMode) {
+  setVariables(args: { variables: $variables, mode: $mode }) {
+	ok
+  }
+  }`
+		const result = await this.apiClient.execute<{ setVariables: { ok: boolean } }>(query, { variables: { mode, variables } })
+		return result.setVariables.ok
+	}
+}

--- a/packages/engine-actions/graphql.codegen.yml
+++ b/packages/engine-actions/graphql.codegen.yml
@@ -10,7 +10,7 @@ generates:
       enumsAsTypes: "1"
       scalars:
         DateTime: Date
-        Uuid: String
+        Uuid: string
         Json: any
     plugins:
       - "typescript"
@@ -18,4 +18,4 @@ generates:
       - "typescript-resolvers"
 hooks:
   afterAllFileWrite:
-    - yarn run -T eslint --fix
+    - bun run eslint --fix

--- a/packages/engine-actions/src/authorization/ActionsAuthorizationActions.ts
+++ b/packages/engine-actions/src/authorization/ActionsAuthorizationActions.ts
@@ -11,4 +11,6 @@ export namespace ActionsAuthorizationActions {
 
 	export const EVENTS_VIEW = Authorizator.createAction(Resources.events, 'view')
 	export const EVENTS_PROCESS = Authorizator.createAction(Resources.events, 'process')
+	export const EVENTS_RETRY = Authorizator.createAction(Resources.events, 'retry')
+	export const EVENTS_STOP = Authorizator.createAction(Resources.events, 'stop')
 }

--- a/packages/engine-actions/src/dispatch/EventsRepository.ts
+++ b/packages/engine-actions/src/dispatch/EventsRepository.ts
@@ -114,7 +114,7 @@ export class EventsRepository {
 	}
 
 	private async markFailed(db: Client, event: HandledEvent): Promise<void> {
-		const numRetries = event.row.num_retries
+		const numRetries = event.row.num_retries + 1
 		const now = new Date()
 		const nextAttempt = new Date()
 		nextAttempt.setTime(nextAttempt.getTime() + (event.target?.initialRepeatIntervalMs ?? DEFAULT_REPEAT_INTERVAL_MS) * Math.pow(2, event.row.num_retries))
@@ -122,7 +122,7 @@ export class EventsRepository {
 			.table('actions_event')
 			.values<EventRow>({
 				last_state_change: now,
-				num_retries: event.row.num_retries + 1,
+				num_retries: numRetries,
 				log: JSON.stringify([...event.row.log, event.result]) as any,
 				...(numRetries < (event.target?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS) ? {
 					state: 'retrying',

--- a/packages/engine-actions/src/dispatch/ProjectDispatcher.ts
+++ b/packages/engine-actions/src/dispatch/ProjectDispatcher.ts
@@ -3,7 +3,7 @@ import { EventDispatcher } from './EventDispatcher'
 import { ContentSchemaResolver } from '@contember/engine-http'
 import { Runnable, RunnableArgs, Running } from '@contember/engine-common'
 import { Listener } from '@contember/database'
-import { NOTIFY_CHANNEL_NAME } from '../triggers/TriggerPayloadPersister'
+import { NOTIFY_CHANNEL_NAME } from '../utils/notifyChannel'
 
 
 export class ProjectDispatcherFactory {

--- a/packages/engine-actions/src/graphql/http/ActionsApiMiddlewareFactory.ts
+++ b/packages/engine-actions/src/graphql/http/ActionsApiMiddlewareFactory.ts
@@ -25,6 +25,7 @@ export class ActionsApiMiddlewareFactory {
 			const graphqlContext: ActionsContext = {
 				db: systemDatabase,
 				logger,
+				project: projectContainer.project,
 				contentSchemaResolver: projectContainer.contentSchemaResolver,
 				requireAccess: async (action, message) => {
 					if (!(await this.authorizator.isAllowed(identity, new AuthorizationScope.Global(), action))) {

--- a/packages/engine-actions/src/graphql/resolvers/ActionsContext.ts
+++ b/packages/engine-actions/src/graphql/resolvers/ActionsContext.ts
@@ -7,5 +7,6 @@ export interface ActionsContext {
 	logger: Logger
 	db: DatabaseContext
 	contentSchemaResolver: ContentSchemaResolver
+	project: { slug: string }
 	requireAccess: (action: Authorizator.Action, message?: string) => Promise<void>
 }

--- a/packages/engine-actions/src/graphql/resolvers/ResolversFactory.ts
+++ b/packages/engine-actions/src/graphql/resolvers/ResolversFactory.ts
@@ -1,7 +1,7 @@
 import { DateTimeType, JSONType, UuidType } from '@contember/graphql-utils'
 import { Resolvers } from '../schema'
 import { EventsQueryResolver } from './query'
-import { ProcessBatchMutationResolver, SetVariablesMutationResolver } from './mutation'
+import { ProcessBatchMutationResolver, RetryEventMutationResolver, SetVariablesMutationResolver, StopEventMutationResolver } from './mutation'
 import { ActionsContext } from './ActionsContext'
 import { VariablesQueryResolver } from './query/VariablesQueryResolver'
 
@@ -11,6 +11,8 @@ export class ResolversFactory {
 		private readonly processBatchMutationResolver: ProcessBatchMutationResolver,
 		private readonly variablesQueryResolver: VariablesQueryResolver,
 		private readonly setVariablesMutationResolver: SetVariablesMutationResolver,
+		private readonly retryEventMutationResolver: RetryEventMutationResolver,
+		private readonly stopEventMutationResolver: StopEventMutationResolver,
 	) {
 	}
 
@@ -22,11 +24,14 @@ export class ResolversFactory {
 			Mutation: {
 				processBatch: this.processBatchMutationResolver.processBatch.bind(this.processBatchMutationResolver),
 				setVariables: this.setVariablesMutationResolver.setVariables.bind(this.setVariablesMutationResolver),
+				retryEvent: this.retryEventMutationResolver.retryEvent.bind(this.retryEventMutationResolver),
+				stopEvent: this.stopEventMutationResolver.stopEvent.bind(this.stopEventMutationResolver),
 			},
 			Query: {
 				eventsInProcessing: this.eventsQueryResolver.eventsInProcessing.bind(this.eventsQueryResolver),
 				eventsToProcess: this.eventsQueryResolver.eventsToProcess.bind(this.eventsQueryResolver),
 				failedEvents: this.eventsQueryResolver.failedEvents.bind(this.eventsQueryResolver),
+				event: this.eventsQueryResolver.event.bind(this.eventsQueryResolver),
 				variables: this.variablesQueryResolver.variables.bind(this.variablesQueryResolver),
 			},
 		}

--- a/packages/engine-actions/src/graphql/resolvers/mutation/RetryEventMutationResolver.ts
+++ b/packages/engine-actions/src/graphql/resolvers/mutation/RetryEventMutationResolver.ts
@@ -1,0 +1,22 @@
+import { MutationResolvers, MutationRetryEventArgs } from '../../schema'
+import { ActionsContext } from '../ActionsContext'
+import { ActionsAuthorizationActions } from '../../../authorization'
+import { EventsRepository } from '../../../dispatch/EventsRepository'
+import { notify } from '../../../utils/notifyChannel'
+
+export class RetryEventMutationResolver implements MutationResolvers<ActionsContext> {
+	constructor(
+		private readonly eventsRepository: EventsRepository,
+	) {
+	}
+	async retryEvent(parent: unknown, args: MutationRetryEventArgs, ctx: ActionsContext) {
+		await ctx.requireAccess(ActionsAuthorizationActions.EVENTS_RETRY)
+
+		await this.eventsRepository.requeue(ctx.db.client, [args.id])
+		await notify(ctx.db.client, ctx.project.slug)
+
+		return {
+			ok: true,
+		}
+	}
+}

--- a/packages/engine-actions/src/graphql/resolvers/mutation/StopEventMutationResolver.ts
+++ b/packages/engine-actions/src/graphql/resolvers/mutation/StopEventMutationResolver.ts
@@ -1,0 +1,19 @@
+import { MutationResolvers, MutationRetryEventArgs } from '../../schema'
+import { ActionsContext } from '../ActionsContext'
+import { ActionsAuthorizationActions } from '../../../authorization'
+import { EventsRepository } from '../../../dispatch/EventsRepository'
+
+export class StopEventMutationResolver implements MutationResolvers<ActionsContext> {
+	constructor(
+		private readonly eventsRepository: EventsRepository,
+	) {
+	}
+	async stopEvent(parent: unknown, args: MutationRetryEventArgs, ctx: ActionsContext) {
+		await ctx.requireAccess(ActionsAuthorizationActions.EVENTS_STOP)
+
+		await this.eventsRepository.markStopped(ctx.db.client, [args.id])
+		return {
+			ok: true,
+		}
+	}
+}

--- a/packages/engine-actions/src/graphql/resolvers/mutation/index.ts
+++ b/packages/engine-actions/src/graphql/resolvers/mutation/index.ts
@@ -1,2 +1,4 @@
 export * from './ProcessBatchMutationResolver'
 export * from './SetVariablesMutationResolver'
+export * from './RetryEventMutationResolver'
+export * from './StopEventMutationResolver'

--- a/packages/engine-actions/src/graphql/schema/actions.graphql.ts
+++ b/packages/engine-actions/src/graphql/schema/actions.graphql.ts
@@ -15,11 +15,14 @@ export const schema: DocumentNode = gql`
         failedEvents(args: EventArgs): [Event!]!
         eventsToProcess(args: EventArgs): [Event!]!
         eventsInProcessing(args: EventArgs): [Event!]!
+        event(id: Uuid!): Event
         variables: [Variable!]!
     }
 
     type Mutation {
         processBatch: ProcessBatchResponse!
+        retryEvent(id: Uuid!): RetryEventResponse!
+        stopEvent(id: Uuid!): StopEventResponse!
         setVariables(args: SetVariablesArgs!): SetVariablesResponse!
     }
 
@@ -54,6 +57,14 @@ export const schema: DocumentNode = gql`
     }
 
     type ProcessBatchResponse {
+        ok: Boolean!
+    }
+    
+    type RetryEventResponse {
+        ok: Boolean!
+    }
+    
+    type StopEventResponse {
         ok: Boolean!
     }
 

--- a/packages/engine-actions/src/graphql/schema/index.ts
+++ b/packages/engine-actions/src/graphql/schema/index.ts
@@ -16,7 +16,7 @@ export type Scalars = {
 	Float: { input: number; output: number }
 	DateTime: { input: Date; output: Date }
 	Json: { input: any; output: any }
-	Uuid: { input: String; output: String }
+	Uuid: { input: string; output: string }
 }
 
 export type Event = {
@@ -52,12 +52,24 @@ export type EventState =
 export type Mutation = {
 	readonly __typename?: 'Mutation'
 	readonly processBatch: ProcessBatchResponse
+	readonly retryEvent: RetryEventResponse
 	readonly setVariables: SetVariablesResponse
+	readonly stopEvent: StopEventResponse
+}
+
+
+export type MutationRetryEventArgs = {
+	id: Scalars['Uuid']['input']
 }
 
 
 export type MutationSetVariablesArgs = {
 	args: SetVariablesArgs
+}
+
+
+export type MutationStopEventArgs = {
+	id: Scalars['Uuid']['input']
 }
 
 export type ProcessBatchResponse = {
@@ -67,10 +79,16 @@ export type ProcessBatchResponse = {
 
 export type Query = {
 	readonly __typename?: 'Query'
+	readonly event?: Maybe<Event>
 	readonly eventsInProcessing: ReadonlyArray<Event>
 	readonly eventsToProcess: ReadonlyArray<Event>
 	readonly failedEvents: ReadonlyArray<Event>
 	readonly variables: ReadonlyArray<Variable>
+}
+
+
+export type QueryEventArgs = {
+	id: Scalars['Uuid']['input']
 }
 
 
@@ -86,6 +104,11 @@ export type QueryEventsToProcessArgs = {
 
 export type QueryFailedEventsArgs = {
 	args?: InputMaybe<EventArgs>
+}
+
+export type RetryEventResponse = {
+	readonly __typename?: 'RetryEventResponse'
+	readonly ok: Scalars['Boolean']['output']
 }
 
 export type SetVariablesArgs = {
@@ -106,6 +129,11 @@ export type SetVariablesMode =
 
 export type SetVariablesResponse = {
 	readonly __typename?: 'SetVariablesResponse'
+	readonly ok: Scalars['Boolean']['output']
+}
+
+export type StopEventResponse = {
+	readonly __typename?: 'StopEventResponse'
 	readonly ok: Scalars['Boolean']['output']
 }
 
@@ -201,9 +229,11 @@ export type ResolversTypes = {
 	Mutation: ResolverTypeWrapper<{}>
 	ProcessBatchResponse: ResolverTypeWrapper<ProcessBatchResponse>
 	Query: ResolverTypeWrapper<{}>
+	RetryEventResponse: ResolverTypeWrapper<RetryEventResponse>
 	SetVariablesArgs: SetVariablesArgs
 	SetVariablesMode: SetVariablesMode
 	SetVariablesResponse: ResolverTypeWrapper<SetVariablesResponse>
+	StopEventResponse: ResolverTypeWrapper<StopEventResponse>
 	String: ResolverTypeWrapper<Scalars['String']['output']>
 	Uuid: ResolverTypeWrapper<Scalars['Uuid']['output']>
 	Variable: ResolverTypeWrapper<Variable>
@@ -221,8 +251,10 @@ export type ResolversParentTypes = {
 	Mutation: {}
 	ProcessBatchResponse: ProcessBatchResponse
 	Query: {}
+	RetryEventResponse: RetryEventResponse
 	SetVariablesArgs: SetVariablesArgs
 	SetVariablesResponse: SetVariablesResponse
+	StopEventResponse: StopEventResponse
 	String: Scalars['String']['output']
 	Uuid: Scalars['Uuid']['output']
 	Variable: Variable
@@ -255,7 +287,9 @@ export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
 	processBatch?: Resolver<ResolversTypes['ProcessBatchResponse'], ParentType, ContextType>
+	retryEvent?: Resolver<ResolversTypes['RetryEventResponse'], ParentType, ContextType, RequireFields<MutationRetryEventArgs, 'id'>>
 	setVariables?: Resolver<ResolversTypes['SetVariablesResponse'], ParentType, ContextType, RequireFields<MutationSetVariablesArgs, 'args'>>
+	stopEvent?: Resolver<ResolversTypes['StopEventResponse'], ParentType, ContextType, RequireFields<MutationStopEventArgs, 'id'>>
 }
 
 export type ProcessBatchResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['ProcessBatchResponse'] = ResolversParentTypes['ProcessBatchResponse']> = {
@@ -264,13 +298,24 @@ export type ProcessBatchResponseResolvers<ContextType = any, ParentType extends 
 }
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+	event?: Resolver<Maybe<ResolversTypes['Event']>, ParentType, ContextType, RequireFields<QueryEventArgs, 'id'>>
 	eventsInProcessing?: Resolver<ReadonlyArray<ResolversTypes['Event']>, ParentType, ContextType, Partial<QueryEventsInProcessingArgs>>
 	eventsToProcess?: Resolver<ReadonlyArray<ResolversTypes['Event']>, ParentType, ContextType, Partial<QueryEventsToProcessArgs>>
 	failedEvents?: Resolver<ReadonlyArray<ResolversTypes['Event']>, ParentType, ContextType, Partial<QueryFailedEventsArgs>>
 	variables?: Resolver<ReadonlyArray<ResolversTypes['Variable']>, ParentType, ContextType>
 }
 
+export type RetryEventResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['RetryEventResponse'] = ResolversParentTypes['RetryEventResponse']> = {
+	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
+	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}
+
 export type SetVariablesResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['SetVariablesResponse'] = ResolversParentTypes['SetVariablesResponse']> = {
+	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
+	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}
+
+export type StopEventResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['StopEventResponse'] = ResolversParentTypes['StopEventResponse']> = {
 	ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
@@ -292,7 +337,9 @@ export type Resolvers<ContextType = any> = {
 	Mutation?: MutationResolvers<ContextType>
 	ProcessBatchResponse?: ProcessBatchResponseResolvers<ContextType>
 	Query?: QueryResolvers<ContextType>
+	RetryEventResponse?: RetryEventResponseResolvers<ContextType>
 	SetVariablesResponse?: SetVariablesResponseResolvers<ContextType>
+	StopEventResponse?: StopEventResponseResolvers<ContextType>
 	Uuid?: GraphQLScalarType
 	Variable?: VariableResolvers<ContextType>
 }

--- a/packages/engine-actions/src/model/EventByIdQuery.ts
+++ b/packages/engine-actions/src/model/EventByIdQuery.ts
@@ -1,0 +1,21 @@
+import { DatabaseQuery, DatabaseQueryable, SelectBuilder } from '@contember/database'
+import { EventRow } from './types'
+
+export class EventByIdQuery extends DatabaseQuery<EventRow | null> {
+	constructor(
+		private readonly id: string,
+	) {
+		super()
+	}
+
+	async fetch(queryable: DatabaseQueryable): Promise<EventRow | null> {
+		const result = await SelectBuilder.create<EventRow>()
+			.from('actions_event')
+			.select('*')
+			.where({
+				id: this.id,
+			})
+			.getResult(queryable.db)
+		return this.fetchOneOrNull(result)
+	}
+}

--- a/packages/engine-actions/src/triggers/TriggerPayloadPersister.ts
+++ b/packages/engine-actions/src/triggers/TriggerPayloadPersister.ts
@@ -2,8 +2,9 @@ import { Client, InsertBuilder } from '@contember/database'
 import { Mapper } from '@contember/engine-content-api'
 import { Actions, ActionsPayload } from '@contember/schema'
 import { EventRow } from '../model/types'
+import { notify } from '../utils/notifyChannel'
 
-export const NOTIFY_CHANNEL_NAME = 'actions_event'
+
 type EventRowToInsert = Omit<EventRow, 'created_at' | 'visible_at' | 'last_state_change' | 'log'> & {
 	created_at: string | Date
 	visible_at: string | Date
@@ -49,6 +50,6 @@ export class TriggerPayloadPersister {
 				.execute(this.client)
 		}
 
-		await this.client.query('SELECT pg_notify(?, ?)', [NOTIFY_CHANNEL_NAME, this.projectSlug])
+		await notify(this.client, this.projectSlug)
 	}
 }

--- a/packages/engine-actions/src/utils/notifyChannel.ts
+++ b/packages/engine-actions/src/utils/notifyChannel.ts
@@ -1,0 +1,6 @@
+import { Client } from '@contember/database'
+
+export const NOTIFY_CHANNEL_NAME = 'actions_event'
+export const notify = async (db: Client, projectSlug: string) => {
+	await db.query('SELECT pg_notify(?, ?)', [NOTIFY_CHANNEL_NAME, projectSlug])
+}

--- a/packages/playground/api/migrations/2025-03-31-145304-actions.json
+++ b/packages/playground/api/migrations/2025-03-31-145304-actions.json
@@ -1,0 +1,87 @@
+{
+	"formatVersion": 6,
+	"modifications": [
+		{
+			"modification": "createEntity",
+			"entity": {
+				"eventLog": {
+					"enabled": true
+				},
+				"name": "ActionsEntry",
+				"primary": "id",
+				"primaryColumn": "id",
+				"tableName": "actions_entry",
+				"fields": {
+					"id": {
+						"name": "id",
+						"columnName": "id",
+						"columnType": "uuid",
+						"nullable": false,
+						"type": "Uuid"
+					}
+				},
+				"unique": [],
+				"indexes": []
+			}
+		},
+		{
+			"modification": "createColumn",
+			"entityName": "ActionsEntry",
+			"field": {
+				"name": "value",
+				"columnName": "value",
+				"columnType": "text",
+				"nullable": true,
+				"type": "String"
+			}
+		},
+		{
+			"modification": "patchAclSchema",
+			"patch": [
+				{
+					"op": "add",
+					"path": "/roles/admin/entities/ActionsEntry",
+					"value": {
+						"predicates": {},
+						"operations": {
+							"read": {
+								"id": true,
+								"value": true
+							},
+							"create": {
+								"id": true,
+								"value": true
+							},
+							"update": {
+								"id": true,
+								"value": true
+							},
+							"delete": true,
+							"customPrimary": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"modification": "createTarget",
+			"target": {
+				"type": "webhook",
+				"name": "ActionsEntry_target",
+				"url": "{{url}}/webhook"
+			}
+		},
+		{
+			"modification": "createTrigger",
+			"trigger": {
+				"type": "watch",
+				"name": "ActionsEntry",
+				"entity": "ActionsEntry",
+				"watch": [
+					"value"
+				],
+				"target": "ActionsEntry_target"
+			}
+		}
+	]
+}

--- a/packages/playground/api/model/Actions.ts
+++ b/packages/playground/api/model/Actions.ts
@@ -1,0 +1,12 @@
+import { c } from '@contember/schema-definition'
+
+@c.Watch({
+	name: 'ActionsEntry',
+	watch: 'value',
+	webhook: {
+		url: '{{url}}/webhook',
+	},
+})
+export class ActionsEntry {
+	value = c.stringColumn()
+}

--- a/packages/playground/api/model/index.ts
+++ b/packages/playground/api/model/index.ts
@@ -1,4 +1,5 @@
 export * from './Acl'
+export * from './Actions'
 export * from './Blocks'
 export * from './Board'
 export * from './Dimensions'


### PR DESCRIPTION
### Add CLI Support for Managing Action Events and Variables

This PR introduces several new CLI commands and backend GraphQL mutations to enhance observability and control over action events in Contember:

#### 🔧 CLI Enhancements
- `actions:list-variables` – List currently defined action variables.
- `actions:set-variables` – Set or update action variables with support for merge, set, or append-only modes.
- `actions:failed-events` – List failed action events, with optional JSON output.
- `actions:get-event` – Show details of a specific event.
- `actions:retry-event` – Manually requeue a failed event for processing.
- `actions:stop-event` – Mark an event as stopped to prevent further retries.

#### 🧠 Engine Improvements
- Added `retryEvent` and `stopEvent` mutations to control event lifecycle via GraphQL.
- Fixed off-by-one error in retry attempt count.
- Introduced new event state: `stopped`.
- Added single-event querying support (`event(id: UUID!)`).
