### PR TITLE
improve assume membership

### DIFF
--- a/packages/engine-http/src/content/ProjectMembershipResolver.ts
+++ b/packages/engine-http/src/content/ProjectMembershipResolver.ts
@@ -53,7 +53,7 @@ export class ProjectMembershipResolver {
 				throwNotAllowed()
 			}
 
-			const parsedMemberships = membershipResolver.resolve(acl, assumedMemberships, identity)
+			const parsedMemberships = membershipResolver.resolve(acl, assumedMemberships, identity, true)
 			if (parsedMemberships.errors.length > 0) {
 				throw new HttpErrorResponse(
 					400,
@@ -73,7 +73,7 @@ export class ProjectMembershipResolver {
 		return {
 			effective: [
 				// intentionally ignoring validation errors of stored memberships
-				...membershipResolver.resolve(acl, explicitMemberships, identity).memberships,
+				...membershipResolver.resolve(acl, explicitMemberships, identity, false).memberships,
 				...implicitRolesToAssign.map(it => ({ role: it, variables: [] })),
 			],
 			fetched: explicitMemberships,

--- a/packages/engine-tenant-api/src/model/authorization/MembershipMatcher.ts
+++ b/packages/engine-tenant-api/src/model/authorization/MembershipMatcher.ts
@@ -12,6 +12,12 @@ export class MembershipMatcher {
 
 	matches(membership: Acl.Membership): boolean {
 		return this.memberships.some(invokerMembership => {
+			if (invokerMembership.matchRule === true) {
+				return true
+			}
+			if (!invokerMembership.matchRule) {
+				return false
+			}
 			const matchRule = invokerMembership.matchRule[membership.role]
 			if (!matchRule) {
 				return false

--- a/packages/engine-tenant-api/src/model/service/MembershipValidator.ts
+++ b/packages/engine-tenant-api/src/model/service/MembershipValidator.ts
@@ -13,7 +13,7 @@ export class MembershipValidator {
 		if (!schema) {
 			throw new Error()
 		}
-		return this.resolver.resolve(schema.acl, memberships, MembershipResolver.UnknownIdentity).errors
+		return this.resolver.resolve(schema.acl, memberships, MembershipResolver.UnknownIdentity, false).errors
 	}
 }
 

--- a/packages/schema-utils/src/type-schema/acl.ts
+++ b/packages/schema-utils/src/type-schema/acl.ts
@@ -2,7 +2,7 @@ import { Acl, Model } from '@contember/schema'
 import * as Typesafe from '@contember/typesafe'
 import { conditionSchema } from './condition'
 
-const membershipMatchRuleSchema = Typesafe.record(
+const membershipMatchRuleSchema = Typesafe.union(Typesafe.boolean, Typesafe.record(
 	Typesafe.string,
 	Typesafe.union(
 		Typesafe.literal(true),
@@ -16,7 +16,7 @@ const membershipMatchRuleSchema = Typesafe.record(
 			),
 		}),
 	),
-)
+))
 
 const tenantPermissionsSchema = Typesafe.partial({
 	invite: Typesafe.union(Typesafe.boolean, membershipMatchRuleSchema),

--- a/packages/schema/src/schema/acl.ts
+++ b/packages/schema/src/schema/acl.ts
@@ -99,13 +99,15 @@ export namespace Acl {
 			readonly variables?: MembershipVariablesMatchRule
 		}
 
-	export type MembershipMatchRule = {
-		readonly [role: string]: MembershipRoleMatchRule
-	}
+	export type MembershipMatchRule =
+		| boolean
+		| {
+			readonly [role: string]: MembershipRoleMatchRule
+		}
 
 	export type TenantPermissions = {
-		readonly invite?: boolean | MembershipMatchRule
-		readonly unmanagedInvite?: boolean | MembershipMatchRule
+		readonly invite?: MembershipMatchRule
+		readonly unmanagedInvite?:MembershipMatchRule
 		readonly view?: MembershipMatchRule
 		readonly manage?: MembershipMatchRule
 	}


### PR DESCRIPTION
- allow to override predefined variables in assume membership
- allow to simply set "true" instead of specifying per-level permissions for assume membership and some tenant-related operations