### PR TITLE
fix(react-routing): prevent rewrite of useDimensionState hook default…

### DIFF
--- a/packages/react-routing/src/hooks/useDimensionState.tsx
+++ b/packages/react-routing/src/hooks/useDimensionState.tsx
@@ -21,11 +21,15 @@ export const useDimensionState = ({ dimension, defaultValue, storage = 'null' }:
 	const redirect = useRedirect()
 
 	useEffect(() => {
-		setStoredState(currentDimensionValue)
+		if (currentDimensionValue.length > 0 && !(currentDimensionValue.length === 1 && currentDimensionValue[0] === '')) {
+			setStoredState(currentDimensionValue)
+		}
 	}, [currentDimensionValue, setStoredState])
 
 	useEffect(() => {
-		if (currentDimensionValue.length === 0 && initialStoredState.length > 0) {
+		const isDimensionEmpty = currentDimensionValue.length === 0 || (currentDimensionValue.length === 1 && currentDimensionValue[0] === '')
+
+		if (isDimensionEmpty && initialStoredState.length > 0 && initialStoredState[0] !== '') {
 			redirect(it => it ? {
 				...it,
 				dimensions: {
@@ -34,7 +38,7 @@ export const useDimensionState = ({ dimension, defaultValue, storage = 'null' }:
 				},
 			} : null)
 		}
-	}, [currentDimensionValue.length, dimension, initialStoredState, redirect])
+	}, [currentDimensionValue, dimension, initialStoredState, redirect])
 
 	return currentDimensionValue
 }


### PR DESCRIPTION
### Summary
useDimensionState now ignores placeholder [''] values. This stops the default value from being unintentionally replaced.

### Key changes
•	Skip setStoredState when currentDimensionValue is empty or just [''].
•	Treat both [] and [''] as “empty” for redirect logic.
•	Redirect only if a non-empty initialStoredState exists.