### PR TITLE
content client: add type to generated ContemberClientNames

### DIFF
--- a/packages/client-content-generator/src/ContemberClientGenerator.ts
+++ b/packages/client-content-generator/src/ContemberClientGenerator.ts
@@ -16,8 +16,17 @@ export class ContemberClientGenerator {
 		const enumTypeSchema = this.enumTypeSchemaGenerator.generate(model)
 		const entityTypeSchema = this.entityTypeSchemaGenerator.generate(model)
 
-		const namesCode = `import { SchemaNames } from '@contember/client-content'
-export const ContemberClientNames: SchemaNames = ` + JSON.stringify(nameSchema, null, 2)
+		const namesCode = `import type { SchemaNames, SchemaEntityNames } from '@contember/client-content'
+import type { ContemberClientEntities } from './entities'
+import type { ContemberClientEnums } from './enums'
+export const ContemberClientNames = {
+	entities: ${
+			JSON.stringify(nameSchema.entities, null, '\t').replaceAll('\n', '\n\t')
+		} satisfies {[K in keyof ContemberClientEntities]: SchemaEntityNames<K>},
+	enums: ${
+			JSON.stringify(nameSchema.enums, null, '\t').replaceAll('\n', '\n\t')
+		} satisfies {[K in keyof ContemberClientEnums]: readonly ContemberClientEnums[K][]},
+} satisfies SchemaNames`
 
 		const indexCode = `
 import { ContemberClientNames } from './names'

--- a/packages/client-content-generator/tests/__snapshots__/generateEnittyTypes.test.ts.snap
+++ b/packages/client-content-generator/tests/__snapshots__/generateEnittyTypes.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`generate entities generate for scalars 1`] = `
 "
@@ -8,34 +8,34 @@ export type JSONObject = { readonly [K in string]?: JSONValue }
 export type JSONArray = readonly JSONValue[]
 
 export type Foo <OverRelation extends string | never = never> = {
-\tname: 'Foo'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t\tstringCol: string | null
-\t\tintCol: number | null
-\t\tdoubleCol: number | null
-\t\tdateCol: string | null
-\t\tdatetimeCol: string | null
-\t\tbooleanCol: boolean | null
-\t\tjsonCol: JSONValue | null
-\t\tuuidCol: string | null
-\t}
-\thasOne: {
-\t}
-\thasMany: {
-\t}
-\thasManyBy: {
-\t}
+	name: 'Foo'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+	columns: {
+		id: string
+		stringCol: string | null
+		intCol: number | null
+		doubleCol: number | null
+		dateCol: string | null
+		datetimeCol: string | null
+		booleanCol: boolean | null
+		jsonCol: JSONValue | null
+		uuidCol: string | null
+	}
+	hasOne: {
+	}
+	hasMany: {
+	}
+	hasManyBy: {
+	}
 }
 
 export type ContemberClientEntities = {
-\tFoo: Foo
+	Foo: Foo
 }
 
 export type ContemberClientSchema = {
-\tentities: ContemberClientEntities
+	entities: ContemberClientEntities
 }
 "
 `;
@@ -49,27 +49,27 @@ export type JSONObject = { readonly [K in string]?: JSONValue }
 export type JSONArray = readonly JSONValue[]
 
 export type Foo <OverRelation extends string | never = never> = {
-\tname: 'Foo'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t\tenumCol: FooEnumCol | null
-\t}
-\thasOne: {
-\t}
-\thasMany: {
-\t}
-\thasManyBy: {
-\t}
+	name: 'Foo'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+	columns: {
+		id: string
+		enumCol: FooEnumCol | null
+	}
+	hasOne: {
+	}
+	hasMany: {
+	}
+	hasManyBy: {
+	}
 }
 
 export type ContemberClientEntities = {
-\tFoo: Foo
+	Foo: Foo
 }
 
 export type ContemberClientSchema = {
-\tentities: ContemberClientEntities
+	entities: ContemberClientEntities
 }
 "
 `;
@@ -82,45 +82,45 @@ export type JSONObject = { readonly [K in string]?: JSONValue }
 export type JSONArray = readonly JSONValue[]
 
 export type Foo <OverRelation extends string | never = never> = {
-\tname: 'Foo'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\t\t| Omit<{ oneHasOneInverseRel: Bar['unique']}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t\toneHasOneInverseRel: Bar
-\t}
-\thasMany: {
-\t}
-\thasManyBy: {
-\t}
+	name: 'Foo'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+		| Omit<{ oneHasOneInverseRel: Bar['unique']}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+		oneHasOneInverseRel: Bar
+	}
+	hasMany: {
+	}
+	hasManyBy: {
+	}
 }
 export type Bar <OverRelation extends string | never = never> = {
-\tname: 'Bar'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\t\t| Omit<{ oneHasOneOwningRel: Foo['unique']}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t\toneHasOneOwningRel: Foo
-\t}
-\thasMany: {
-\t}
-\thasManyBy: {
-\t}
+	name: 'Bar'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+		| Omit<{ oneHasOneOwningRel: Foo['unique']}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+		oneHasOneOwningRel: Foo
+	}
+	hasMany: {
+	}
+	hasManyBy: {
+	}
 }
 
 export type ContemberClientEntities = {
-\tFoo: Foo
-\tBar: Bar
+	Foo: Foo
+	Bar: Bar
 }
 
 export type ContemberClientSchema = {
-\tentities: ContemberClientEntities
+	entities: ContemberClientEntities
 }
 "
 `;
@@ -133,44 +133,44 @@ export type JSONObject = { readonly [K in string]?: JSONValue }
 export type JSONArray = readonly JSONValue[]
 
 export type Foo <OverRelation extends string | never = never> = {
-\tname: 'Foo'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\t\t| Omit<{ oneHasManyRel: Bar['unique']}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t}
-\thasMany: {
-\t\toneHasManyRel: Bar<'manyHasOneRel'>
-\t}
-\thasManyBy: {
-\t}
+	name: 'Foo'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+		| Omit<{ oneHasManyRel: Bar['unique']}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+	}
+	hasMany: {
+		oneHasManyRel: Bar<'manyHasOneRel'>
+	}
+	hasManyBy: {
+	}
 }
 export type Bar <OverRelation extends string | never = never> = {
-\tname: 'Bar'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t\tmanyHasOneRel: Foo
-\t}
-\thasMany: {
-\t}
-\thasManyBy: {
-\t}
+	name: 'Bar'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+		manyHasOneRel: Foo
+	}
+	hasMany: {
+	}
+	hasManyBy: {
+	}
 }
 
 export type ContemberClientEntities = {
-\tFoo: Foo
-\tBar: Bar
+	Foo: Foo
+	Bar: Bar
 }
 
 export type ContemberClientSchema = {
-\tentities: ContemberClientEntities
+	entities: ContemberClientEntities
 }
 "
 `;
@@ -183,43 +183,43 @@ export type JSONObject = { readonly [K in string]?: JSONValue }
 export type JSONArray = readonly JSONValue[]
 
 export type Foo <OverRelation extends string | never = never> = {
-\tname: 'Foo'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t}
-\thasMany: {
-\t\tmanyHasManyRel: Bar
-\t}
-\thasManyBy: {
-\t}
+	name: 'Foo'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+	}
+	hasMany: {
+		manyHasManyRel: Bar
+	}
+	hasManyBy: {
+	}
 }
 export type Bar <OverRelation extends string | never = never> = {
-\tname: 'Bar'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t}
-\thasMany: {
-\t\tmanyHasManyInverseRel: Foo
-\t}
-\thasManyBy: {
-\t}
+	name: 'Bar'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+	}
+	hasMany: {
+		manyHasManyInverseRel: Foo
+	}
+	hasManyBy: {
+	}
 }
 
 export type ContemberClientEntities = {
-\tFoo: Foo
-\tBar: Bar
+	Foo: Foo
+	Bar: Bar
 }
 
 export type ContemberClientSchema = {
-\tentities: ContemberClientEntities
+	entities: ContemberClientEntities
 }
 "
 `;
@@ -232,47 +232,47 @@ export type JSONObject = { readonly [K in string]?: JSONValue }
 export type JSONArray = readonly JSONValue[]
 
 export type Foo <OverRelation extends string | never = never> = {
-\tname: 'Foo'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\t\t| Omit<{ locales: FooLocale['unique']}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t}
-\thasOne: {
-\t}
-\thasMany: {
-\t\tlocales: FooLocale<'foo'>
-\t}
-\thasManyBy: {
-\t\tlocalesByLocale: { entity: FooLocale; by: {locale: string}  }
-\t}
+	name: 'Foo'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+		| Omit<{ locales: FooLocale['unique']}, OverRelation>
+	columns: {
+		id: string
+	}
+	hasOne: {
+	}
+	hasMany: {
+		locales: FooLocale<'foo'>
+	}
+	hasManyBy: {
+		localesByLocale: { entity: FooLocale; by: {locale: string}  }
+	}
 }
 export type FooLocale <OverRelation extends string | never = never> = {
-\tname: 'FooLocale'
-\tunique:
-\t\t| Omit<{ id: string}, OverRelation>
-\t\t| Omit<{ locale: string, foo: Foo['unique']}, OverRelation>
-\tcolumns: {
-\t\tid: string
-\t\tlocale: string
-\t}
-\thasOne: {
-\t\tfoo: Foo
-\t}
-\thasMany: {
-\t}
-\thasManyBy: {
-\t}
+	name: 'FooLocale'
+	unique:
+		| Omit<{ id: string}, OverRelation>
+		| Omit<{ locale: string, foo: Foo['unique']}, OverRelation>
+	columns: {
+		id: string
+		locale: string
+	}
+	hasOne: {
+		foo: Foo
+	}
+	hasMany: {
+	}
+	hasManyBy: {
+	}
 }
 
 export type ContemberClientEntities = {
-\tFoo: Foo
-\tFooLocale: FooLocale
+	Foo: Foo
+	FooLocale: FooLocale
 }
 
 export type ContemberClientSchema = {
-\tentities: ContemberClientEntities
+	entities: ContemberClientEntities
 }
 "
 `;

--- a/packages/client-content-generator/tests/__snapshots__/generateEnumTypes.test.ts.snap
+++ b/packages/client-content-generator/tests/__snapshots__/generateEnumTypes.test.ts.snap
@@ -1,16 +1,16 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`generate enums 1`] = `
 "export type OrderStatus = 
-\t | "new"
-\t | "paid"
-\t | "cancelled"
+	 | "new"
+	 | "paid"
+	 | "cancelled"
 export type OrderType = 
-\t | "normal"
-\t | "express"
+	 | "normal"
+	 | "express"
 export type ContemberClientEnums = {
-\tOrderStatus: OrderStatus
-\torderType: OrderType
+	OrderStatus: OrderStatus
+	orderType: OrderType
 }
 
 "

--- a/packages/client-content/package.json
+++ b/packages/client-content/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@contember/client-content-generator": "workspace:*",
-    "expect-type": "catalog:"
+    "expect-type": "^1.1.0"
   },
   "repository": {
     "type": "git",

--- a/packages/client-content/tests/cases/unit/__snapshots__/mutation.test.ts.snap
+++ b/packages/client-content/tests/cases/unit/__snapshots__/mutation.test.ts.snap
@@ -1,1203 +1,6 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`mutations in trx create trx 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tmut: createAuthor(data: $AuthorCreateInput_1) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx mutation with a node 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tmut: createAuthor(data: $AuthorCreateInput_1) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t\tnode {
-\t\t\t\tid
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx mutation with a node 2`] = `
-{
-  "AuthorCreateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "MutationTransactionOptions_0": {},
-}
-`;
-
-exports[`mutations in trx update 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorUniqueWhere_1: AuthorUniqueWhere!, $AuthorUpdateInput_2: AuthorUpdateInput!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tmut: updateAuthor(by: $AuthorUniqueWhere_1, data: $AuthorUpdateInput_2) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx update 2`] = `
-{
-  "AuthorUniqueWhere_1": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-  "AuthorUpdateInput_2": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "MutationTransactionOptions_0": {},
-}
-`;
-
-exports[`mutations in trx delete 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorUniqueWhere_1: AuthorUniqueWhere!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tmut: deleteAuthor(by: $AuthorUniqueWhere_1) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx delete 2`] = `
-{
-  "AuthorUniqueWhere_1": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-  "MutationTransactionOptions_0": {},
-}
-`;
-
-exports[`mutations in trx upsert 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorUniqueWhere_1: AuthorUniqueWhere!, $AuthorCreateInput_2: AuthorCreateInput!, $AuthorUpdateInput_3: AuthorUpdateInput!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tmut: upsertAuthor(by: $AuthorUniqueWhere_1, create: $AuthorCreateInput_2, update: $AuthorUpdateInput_3) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx upsert 2`] = `
-{
-  "AuthorCreateInput_2": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "AuthorUniqueWhere_1": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-  "AuthorUpdateInput_3": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "MutationTransactionOptions_0": {},
-}
-`;
-
-exports[`mutations in trx multiple mutations as array 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!, $AuthorCreateInput_2: AuthorCreateInput!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tmut_0: createAuthor(data: $AuthorCreateInput_1) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t\tmut_1: createAuthor(data: $AuthorCreateInput_2) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx multiple mutations as array: 
-\t\t\t{
-\t\t\t  "AuthorCreateInput_1": {
-\t\t\t    "email": "xx@localhost",
-\t\t\t    "name": "John",
-\t\t\t  },
-\t\t\t  "AuthorCreateInput_2": {
-\t\t\t    "email": "xx@localhost",
-\t\t\t    "name": "John",
-\t\t\t  },
-\t\t\t  "MutationTransactionOptions_0": {},
-\t\t\t}
-\t\t 1`] = `
-{
-  "AuthorCreateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "AuthorCreateInput_2": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "MutationTransactionOptions_0": {},
-}
-`;
-
-exports[`mutations in trx multiple named mutations trx: 
-\t\t\t"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!, $PostCreateInput_2: PostCreateInput!) {
-\t\t\t\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\t\t\t\tok
-\t\t\t\t\terrorMessage
-\t\t\t\t\terrors {
-\t\t\t\t\t\t... MutationError
-\t\t\t\t\t}
-\t\t\t\t\tvalidation {
-\t\t\t\t\t\t... ValidationResult
-\t\t\t\t\t}
-\t\t\t\t\tcreateAuthor(data: $AuthorCreateInput_1) {
-\t\t\t\t\t\tok
-\t\t\t\t\t\terrorMessage
-\t\t\t\t\t\terrors {
-\t\t\t\t\t\t\t... MutationError
-\t\t\t\t\t\t}
-\t\t\t\t\t\tvalidation {
-\t\t\t\t\t\t\t... ValidationResult
-\t\t\t\t\t\t}
-\t\t\t\t\t}
-\t\t\t\t\tcreatePost(data: $PostCreateInput_2) {
-\t\t\t\t\t\tok
-\t\t\t\t\t\terrorMessage
-\t\t\t\t\t\terrors {
-\t\t\t\t\t\t\t... MutationError
-\t\t\t\t\t\t}
-\t\t\t\t\t\tvalidation {
-\t\t\t\t\t\t\t... ValidationResult
-\t\t\t\t\t\t}
-\t\t\t\t\t}
-\t\t\t\t}
-\t\t\t}
-\t\t\tfragment MutationError on _MutationError {
-\t\t\t\tpaths {
-\t\t\t\t\t... on _FieldPathFragment {
-\t\t\t\t\t\tfield
-\t\t\t\t\t}
-\t\t\t\t\t... on _IndexPathFragment {
-\t\t\t\t\t\tindex
-\t\t\t\t\t\talias
-\t\t\t\t\t}
-\t\t\t\t}
-\t\t\t\tmessage
-\t\t\t\ttype
-\t\t\t}
-\t\t\tfragment ValidationResult on _ValidationResult {
-\t\t\t\tvalid
-\t\t\t\terrors {
-\t\t\t\t\tpath {
-\t\t\t\t\t\t... on _FieldPathFragment {
-\t\t\t\t\t\t\tfield
-\t\t\t\t\t\t}
-\t\t\t\t\t\t... on _IndexPathFragment {
-\t\t\t\t\t\t\tindex
-\t\t\t\t\t\t\talias
-\t\t\t\t\t\t}
-\t\t\t\t\t}
-\t\t\t\t\tmessage {
-\t\t\t\t\t\ttext
-\t\t\t\t\t}
-\t\t\t\t}
-\t\t\t}
-\t\t\t"
-\t\t 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!, $PostCreateInput_2: PostCreateInput!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tcreateAuthor(data: $AuthorCreateInput_1) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t\tcreatePost(data: $PostCreateInput_2) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx multiple named mutations trx: 
-\t\t\t{
-\t\t\t  "AuthorCreateInput_1": {
-\t\t\t    "email": "xx@localhost",
-\t\t\t    "name": "John",
-\t\t\t  },
-\t\t\t  "MutationTransactionOptions_0": {},
-\t\t\t  "PostCreateInput_2": {
-\t\t\t    "publishedAt": "now",
-\t\t\t  },
-\t\t\t}
-\t\t 1`] = `
-{
-  "AuthorCreateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "MutationTransactionOptions_0": {},
-  "PostCreateInput_2": {
-    "publishedAt": "now",
-  },
-}
-`;
-
-exports[`mutations in trx mutation and query combo trx 1`] = `
-"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $PostCreateInput_1: PostCreateInput!, $PostUniqueWhere_2: PostUniqueWhere!) {
-\tmut: transaction(options: $MutationTransactionOptions_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tcreatePost(data: $PostCreateInput_1) {
-\t\t\tok
-\t\t\terrorMessage
-\t\t\terrors {
-\t\t\t\t... MutationError
-\t\t\t}
-\t\t\tvalidation {
-\t\t\t\t... ValidationResult
-\t\t\t}
-\t\t}
-\t\tpost: query {
-\t\t\tvalue: getPost(by: $PostUniqueWhere_2) {
-\t\t\t\tid
-\t\t\t\tpublishedAt
-\t\t\t}
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations in trx mutation and query combo trx 2`] = `
-{
-  "MutationTransactionOptions_0": {},
-  "PostCreateInput_1": {
-    "publishedAt": "now",
-  },
-  "PostUniqueWhere_2": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-}
-`;
-
-exports[`mutations without trx create 1`] = `
-"mutation($AuthorCreateInput_0: AuthorCreateInput!) {
-\tmut: createAuthor(data: $AuthorCreateInput_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx create 2`] = `
-{
-  "AuthorCreateInput_0": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-}
-`;
-
-exports[`mutations without trx mutation with a node 1`] = `
-"mutation($AuthorCreateInput_0: AuthorCreateInput!) {
-\tmut: createAuthor(data: $AuthorCreateInput_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t\tnode {
-\t\t\tid
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx mutation with a node 2`] = `
-{
-  "AuthorCreateInput_0": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-}
-`;
-
-exports[`mutations without trx update 1`] = `
-"mutation($AuthorUniqueWhere_0: AuthorUniqueWhere!, $AuthorUpdateInput_1: AuthorUpdateInput!) {
-\tmut: updateAuthor(by: $AuthorUniqueWhere_0, data: $AuthorUpdateInput_1) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx update 2`] = `
-{
-  "AuthorUniqueWhere_0": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-  "AuthorUpdateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-}
-`;
-
-exports[`mutations without trx delete 1`] = `
-"mutation($AuthorUniqueWhere_0: AuthorUniqueWhere!) {
-\tmut: deleteAuthor(by: $AuthorUniqueWhere_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-"
-`;
-
-exports[`mutations without trx delete 2`] = `
-{
-  "AuthorUniqueWhere_0": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-}
-`;
-
-exports[`mutations without trx upsert 1`] = `
-"mutation($AuthorUniqueWhere_0: AuthorUniqueWhere!, $AuthorCreateInput_1: AuthorCreateInput!, $AuthorUpdateInput_2: AuthorUpdateInput!) {
-\tmut: upsertAuthor(by: $AuthorUniqueWhere_0, create: $AuthorCreateInput_1, update: $AuthorUpdateInput_2) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx upsert 2`] = `
-{
-  "AuthorCreateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "AuthorUniqueWhere_0": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-  "AuthorUpdateInput_2": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-}
-`;
-
-exports[`mutations without trx multiple mutations as array 1`] = `
-"mutation($AuthorCreateInput_0: AuthorCreateInput!, $AuthorCreateInput_1: AuthorCreateInput!) {
-\tmut_0: createAuthor(data: $AuthorCreateInput_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-\tmut_1: createAuthor(data: $AuthorCreateInput_1) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx multiple mutations as array 2`] = `
-{
-  "AuthorCreateInput_0": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "AuthorCreateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-}
-`;
-
-exports[`mutations without trx multiple named mutations 1`] = `
-"mutation($AuthorCreateInput_0: AuthorCreateInput!, $PostCreateInput_1: PostCreateInput!) {
-\tcreateAuthor(data: $AuthorCreateInput_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-\tcreatePost(data: $PostCreateInput_1) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx multiple named mutations 2`] = `
-{
-  "AuthorCreateInput_0": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "PostCreateInput_1": {
-    "publishedAt": "now",
-  },
-}
-`;
-
-exports[`mutations without trx mutation and query combo 1`] = `
-"mutation($PostCreateInput_0: PostCreateInput!, $PostUniqueWhere_1: PostUniqueWhere!) {
-\tcreatePost(data: $PostCreateInput_0) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-\tpost: query {
-\t\tvalue: getPost(by: $PostUniqueWhere_1) {
-\t\t\tid
-\t\t\tpublishedAt
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx mutation and query combo 2`] = `
-{
-  "PostCreateInput_0": {
-    "publishedAt": "now",
-  },
-  "PostUniqueWhere_1": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-}
-`;
-
-exports[`mutations without trx update locale relation 1`] = `
-"mutation($PostUniqueWhere_0: PostUniqueWhere!, $PostUpdateInput_1: PostUpdateInput!) {
-\tmut: updatePost(by: $PostUniqueWhere_0, data: $PostUpdateInput_1) {
-\t\tok
-\t\terrorMessage
-\t\terrors {
-\t\t\t... MutationError
-\t\t}
-\t\tvalidation {
-\t\t\t... ValidationResult
-\t\t}
-\t}
-}
-fragment MutationError on _MutationError {
-\tpaths {
-\t\t... on _FieldPathFragment {
-\t\t\tfield
-\t\t}
-\t\t... on _IndexPathFragment {
-\t\t\tindex
-\t\t\talias
-\t\t}
-\t}
-\tmessage
-\ttype
-}
-fragment ValidationResult on _ValidationResult {
-\tvalid
-\terrors {
-\t\tpath {
-\t\t\t... on _FieldPathFragment {
-\t\t\t\tfield
-\t\t\t}
-\t\t\t... on _IndexPathFragment {
-\t\t\t\tindex
-\t\t\t\talias
-\t\t\t}
-\t\t}
-\t\tmessage {
-\t\t\ttext
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`mutations without trx update locale relation 2`] = `
-{
-  "PostUniqueWhere_0": {
-    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
-  },
-  "PostUpdateInput_1": {
-    "locales": [
-      {
-        "update": {
-          "by": {
-            "locale": {
-              "code": "cs",
-            },
-          },
-          "data": {
-            "title": "cs title",
-          },
-        },
-      },
-    ],
-    "publishedAt": "now",
-  },
-}
-`;
-
-exports[`mutations in trx create trx 2`] = `
-{
-  "AuthorCreateInput_1": {
-    "email": "xx@localhost",
-    "name": "John",
-  },
-  "MutationTransactionOptions_0": {},
-}
-`;
-
-exports[`mutations without trx mutate or fail 1`] = `
 "mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!) {
 	mut: transaction(options: $MutationTransactionOptions_0) {
 		ok
@@ -1253,13 +56,1146 @@ fragment ValidationResult on _ValidationResult {
 "
 `;
 
-exports[`mutations without trx mutate or fail 2`] = `
+exports[`mutations in trx create trx 2`] = `
 {
   "AuthorCreateInput_1": {
     "email": "xx@localhost",
     "name": "John",
   },
   "MutationTransactionOptions_0": {},
+}
+`;
+
+exports[`mutations in trx mutation with a node 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		mut: createAuthor(data: $AuthorCreateInput_1) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+			node {
+				id
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx mutation with a node 2`] = `
+{
+  "AuthorCreateInput_1": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "MutationTransactionOptions_0": {},
+}
+`;
+
+exports[`mutations in trx update 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorUniqueWhere_1: AuthorUniqueWhere!, $AuthorUpdateInput_2: AuthorUpdateInput!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		mut: updateAuthor(by: $AuthorUniqueWhere_1, data: $AuthorUpdateInput_2) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx update 2`] = `
+{
+  "AuthorUniqueWhere_1": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+  "AuthorUpdateInput_2": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "MutationTransactionOptions_0": {},
+}
+`;
+
+exports[`mutations in trx delete 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorUniqueWhere_1: AuthorUniqueWhere!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		mut: deleteAuthor(by: $AuthorUniqueWhere_1) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx delete 2`] = `
+{
+  "AuthorUniqueWhere_1": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+  "MutationTransactionOptions_0": {},
+}
+`;
+
+exports[`mutations in trx upsert 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorUniqueWhere_1: AuthorUniqueWhere!, $AuthorCreateInput_2: AuthorCreateInput!, $AuthorUpdateInput_3: AuthorUpdateInput!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		mut: upsertAuthor(by: $AuthorUniqueWhere_1, create: $AuthorCreateInput_2, update: $AuthorUpdateInput_3) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx upsert 2`] = `
+{
+  "AuthorCreateInput_2": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "AuthorUniqueWhere_1": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+  "AuthorUpdateInput_3": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "MutationTransactionOptions_0": {},
+}
+`;
+
+exports[`mutations in trx multiple mutations as array 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!, $AuthorCreateInput_2: AuthorCreateInput!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		mut_0: createAuthor(data: $AuthorCreateInput_1) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+		mut_1: createAuthor(data: $AuthorCreateInput_2) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx multiple mutations as array: 
+			{
+			  "AuthorCreateInput_1": {
+			    "email": "xx@localhost",
+			    "name": "John",
+			  },
+			  "AuthorCreateInput_2": {
+			    "email": "xx@localhost",
+			    "name": "John",
+			  },
+			  "MutationTransactionOptions_0": {},
+			}
+		 1`] = `
+{
+  "AuthorCreateInput_1": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "AuthorCreateInput_2": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "MutationTransactionOptions_0": {},
+}
+`;
+
+exports[`mutations in trx multiple named mutations trx: 
+			"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!, $PostCreateInput_2: PostCreateInput!) {
+				mut: transaction(options: $MutationTransactionOptions_0) {
+					ok
+					errorMessage
+					errors {
+						... MutationError
+					}
+					validation {
+						... ValidationResult
+					}
+					createAuthor(data: $AuthorCreateInput_1) {
+						ok
+						errorMessage
+						errors {
+							... MutationError
+						}
+						validation {
+							... ValidationResult
+						}
+					}
+					createPost(data: $PostCreateInput_2) {
+						ok
+						errorMessage
+						errors {
+							... MutationError
+						}
+						validation {
+							... ValidationResult
+						}
+					}
+				}
+			}
+			fragment MutationError on _MutationError {
+				paths {
+					... on _FieldPathFragment {
+						field
+					}
+					... on _IndexPathFragment {
+						index
+						alias
+					}
+				}
+				message
+				type
+			}
+			fragment ValidationResult on _ValidationResult {
+				valid
+				errors {
+					path {
+						... on _FieldPathFragment {
+							field
+						}
+						... on _IndexPathFragment {
+							index
+							alias
+						}
+					}
+					message {
+						text
+					}
+				}
+			}
+			"
+		 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $AuthorCreateInput_1: AuthorCreateInput!, $PostCreateInput_2: PostCreateInput!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		createAuthor(data: $AuthorCreateInput_1) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+		createPost(data: $PostCreateInput_2) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx multiple named mutations trx: 
+			{
+			  "AuthorCreateInput_1": {
+			    "email": "xx@localhost",
+			    "name": "John",
+			  },
+			  "MutationTransactionOptions_0": {},
+			  "PostCreateInput_2": {
+			    "publishedAt": "now",
+			  },
+			}
+		 1`] = `
+{
+  "AuthorCreateInput_1": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "MutationTransactionOptions_0": {},
+  "PostCreateInput_2": {
+    "publishedAt": "now",
+  },
+}
+`;
+
+exports[`mutations in trx mutation and query combo trx 1`] = `
+"mutation($MutationTransactionOptions_0: MutationTransactionOptions, $PostCreateInput_1: PostCreateInput!, $PostUniqueWhere_2: PostUniqueWhere!) {
+	mut: transaction(options: $MutationTransactionOptions_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		createPost(data: $PostCreateInput_1) {
+			ok
+			errorMessage
+			errors {
+				... MutationError
+			}
+			validation {
+				... ValidationResult
+			}
+		}
+		post: query {
+			value: getPost(by: $PostUniqueWhere_2) {
+				id
+				publishedAt
+				status
+			}
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations in trx mutation and query combo trx 2`] = `
+{
+  "MutationTransactionOptions_0": {},
+  "PostCreateInput_1": {
+    "publishedAt": "now",
+  },
+  "PostUniqueWhere_2": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+}
+`;
+
+exports[`mutations without trx create 1`] = `
+"mutation($AuthorCreateInput_0: AuthorCreateInput!) {
+	mut: createAuthor(data: $AuthorCreateInput_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx create 2`] = `
+{
+  "AuthorCreateInput_0": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+}
+`;
+
+exports[`mutations without trx mutation with a node 1`] = `
+"mutation($AuthorCreateInput_0: AuthorCreateInput!) {
+	mut: createAuthor(data: $AuthorCreateInput_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+		node {
+			id
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx mutation with a node 2`] = `
+{
+  "AuthorCreateInput_0": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+}
+`;
+
+exports[`mutations without trx update 1`] = `
+"mutation($AuthorUniqueWhere_0: AuthorUniqueWhere!, $AuthorUpdateInput_1: AuthorUpdateInput!) {
+	mut: updateAuthor(by: $AuthorUniqueWhere_0, data: $AuthorUpdateInput_1) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx update 2`] = `
+{
+  "AuthorUniqueWhere_0": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+  "AuthorUpdateInput_1": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+}
+`;
+
+exports[`mutations without trx delete 1`] = `
+"mutation($AuthorUniqueWhere_0: AuthorUniqueWhere!) {
+	mut: deleteAuthor(by: $AuthorUniqueWhere_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+"
+`;
+
+exports[`mutations without trx delete 2`] = `
+{
+  "AuthorUniqueWhere_0": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+}
+`;
+
+exports[`mutations without trx upsert 1`] = `
+"mutation($AuthorUniqueWhere_0: AuthorUniqueWhere!, $AuthorCreateInput_1: AuthorCreateInput!, $AuthorUpdateInput_2: AuthorUpdateInput!) {
+	mut: upsertAuthor(by: $AuthorUniqueWhere_0, create: $AuthorCreateInput_1, update: $AuthorUpdateInput_2) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx upsert 2`] = `
+{
+  "AuthorCreateInput_1": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "AuthorUniqueWhere_0": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+  "AuthorUpdateInput_2": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+}
+`;
+
+exports[`mutations without trx multiple mutations as array 1`] = `
+"mutation($AuthorCreateInput_0: AuthorCreateInput!, $AuthorCreateInput_1: AuthorCreateInput!) {
+	mut_0: createAuthor(data: $AuthorCreateInput_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+	mut_1: createAuthor(data: $AuthorCreateInput_1) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx multiple mutations as array 2`] = `
+{
+  "AuthorCreateInput_0": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "AuthorCreateInput_1": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+}
+`;
+
+exports[`mutations without trx multiple named mutations 1`] = `
+"mutation($AuthorCreateInput_0: AuthorCreateInput!, $PostCreateInput_1: PostCreateInput!) {
+	createAuthor(data: $AuthorCreateInput_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+	createPost(data: $PostCreateInput_1) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx multiple named mutations 2`] = `
+{
+  "AuthorCreateInput_0": {
+    "email": "xx@localhost",
+    "name": "John",
+  },
+  "PostCreateInput_1": {
+    "publishedAt": "now",
+  },
+}
+`;
+
+exports[`mutations without trx mutation and query combo 1`] = `
+"mutation($PostCreateInput_0: PostCreateInput!, $PostUniqueWhere_1: PostUniqueWhere!) {
+	createPost(data: $PostCreateInput_0) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+	post: query {
+		value: getPost(by: $PostUniqueWhere_1) {
+			id
+			publishedAt
+			status
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx mutation and query combo 2`] = `
+{
+  "PostCreateInput_0": {
+    "publishedAt": "now",
+  },
+  "PostUniqueWhere_1": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+}
+`;
+
+exports[`mutations without trx update locale relation 1`] = `
+"mutation($PostUniqueWhere_0: PostUniqueWhere!, $PostUpdateInput_1: PostUpdateInput!) {
+	mut: updatePost(by: $PostUniqueWhere_0, data: $PostUpdateInput_1) {
+		ok
+		errorMessage
+		errors {
+			... MutationError
+		}
+		validation {
+			... ValidationResult
+		}
+	}
+}
+fragment MutationError on _MutationError {
+	paths {
+		... on _FieldPathFragment {
+			field
+		}
+		... on _IndexPathFragment {
+			index
+			alias
+		}
+	}
+	message
+	type
+}
+fragment ValidationResult on _ValidationResult {
+	valid
+	errors {
+		path {
+			... on _FieldPathFragment {
+				field
+			}
+			... on _IndexPathFragment {
+				index
+				alias
+			}
+		}
+		message {
+			text
+		}
+	}
+}
+"
+`;
+
+exports[`mutations without trx update locale relation 2`] = `
+{
+  "PostUniqueWhere_0": {
+    "id": "ca7a9b84-efbb-435d-a063-da11f205335a",
+  },
+  "PostUpdateInput_1": {
+    "locales": [
+      {
+        "update": {
+          "by": {
+            "locale": {
+              "code": "cs",
+            },
+          },
+          "data": {
+            "title": "cs title",
+          },
+        },
+      },
+    ],
+    "publishedAt": "now",
+  },
 }
 `;
 

--- a/packages/client-content/tests/cases/unit/__snapshots__/query.test.ts.snap
+++ b/packages/client-content/tests/cases/unit/__snapshots__/query.test.ts.snap
@@ -1,130 +1,108 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`queries list 1`] = `
 "query {
-\tauthors: listAuthor {
-\t\tid
-\t\tname
-\t\temail
-\t}
+	authors: listAuthor {
+		id
+		name
+		email
+	}
 }
 "
 `;
 
 exports[`queries multiple queries 1`] = `
 "query {
-\tauthors: listAuthor {
-\t\tid
-\t\tname
-\t\temail
-\t}
-\tposts: listPost {
-\t\tid
-\t\tpublishedAt
-\t}
+	authors: listAuthor {
+		id
+		name
+		email
+	}
+	posts: listPost {
+		id
+		publishedAt
+		status
+	}
 }
 "
 `;
 
 exports[`queries single query 1`] = `
 "query {
-\tvalue: listPost {
-\t\tid
-\t\tpublishedAt
-\t}
+	value: listPost {
+		id
+		publishedAt
+		status
+	}
 }
 "
 `;
 
 exports[`queries nested object 1`] = `
 "query {
-\tauthors: listAuthor {
-\t\tid
-\t\tname
-\t\temail
-\t\tposts {
-\t\t\tid
-\t\t\tpublishedAt
-\t\t\ttags {
-\t\t\t\tid
-\t\t\t\tname
-\t\t\t}
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`queries nested object args 1`] = `
-"query($PostWhere_0: PostWhere, $Int_1: Int) {
-\tauthors: listAuthor {
-\t\tid
-\t\tname
-\t\temail
-\t\tposts(filter: $PostWhere_0, limit: $Int_1) {
-\t\t\tid
-\t\t\tpublishedAt
-\t\t}
-\t}
-}
-"
-`;
-
-exports[`queries list with args: 
-\t\t\t"query($AuthorWhere_0: AuthorWhere, $AuthorOrderBy_1: [AuthorOrderBy!], $Int_2: Int, $Int_3: Int) {
-\t\t\t\tauthors: listAuthor(filter: $AuthorWhere_0, orderBy: $AuthorOrderBy_1, limit: $Int_2, offset: $Int_3) {
-\t\t\t\t\tid
-\t\t\t\t\tname
-\t\t\t\t\temail
-\t\t\t\t}
-\t\t\t}
-\t\t\t"
-\t\t 1`] = `
-"query($AuthorWhere_0: AuthorWhere, $AuthorOrderBy_1: [AuthorOrderBy!], $Int_2: Int, $Int_3: Int) {
-\tauthors: listAuthor(filter: $AuthorWhere_0, orderBy: $AuthorOrderBy_1, limit: $Int_2, offset: $Int_3) {
-\t\tid
-\t\tname
-\t\temail
-\t}
-}
-"
-`;
-
-exports[`queries get by id 1`] = `
-"query($AuthorUniqueWhere_0: AuthorUniqueWhere!) {
-\tauthors: getAuthor(by: $AuthorUniqueWhere_0) {
-\t\tid
-\t\tname
-\t\temail
-\t}
-}
-"
-`;
-
-exports[`queries nested has-many transform 1`] = `
-[
-  {
-    "query": 
-"query($AuthorUniqueWhere_0: AuthorUniqueWhere!) {
-	author: getAuthor(by: $AuthorUniqueWhere_0) {
+	authors: listAuthor {
 		id
 		name
 		email
 		posts {
 			id
 			publishedAt
+			status
+			tags {
+				id
+				name
+			}
 		}
 	}
 }
 "
-,
-    "variables": {
-      "AuthorUniqueWhere_0": {
-        "id": "123",
-      },
-    },
-  },
-]
+`;
+
+exports[`queries nested object args 1`] = `
+"query($PostWhere_0: PostWhere, $Int_1: Int) {
+	authors: listAuthor {
+		id
+		name
+		email
+		posts(filter: $PostWhere_0, limit: $Int_1) {
+			id
+			publishedAt
+			status
+		}
+	}
+}
+"
+`;
+
+exports[`queries list with args: 
+			"query($AuthorWhere_0: AuthorWhere, $AuthorOrderBy_1: [AuthorOrderBy!], $Int_2: Int, $Int_3: Int) {
+				authors: listAuthor(filter: $AuthorWhere_0, orderBy: $AuthorOrderBy_1, limit: $Int_2, offset: $Int_3) {
+					id
+					name
+					email
+				}
+			}
+			"
+		 1`] = `
+"query($AuthorWhere_0: AuthorWhere, $AuthorOrderBy_1: [AuthorOrderBy!], $Int_2: Int, $Int_3: Int) {
+	authors: listAuthor(filter: $AuthorWhere_0, orderBy: $AuthorOrderBy_1, limit: $Int_2, offset: $Int_3) {
+		id
+		name
+		email
+	}
+}
+"
+`;
+
+exports[`queries get by id 1`] = `
+"query($AuthorUniqueWhere_0: AuthorUniqueWhere!) {
+	authors: getAuthor(by: $AuthorUniqueWhere_0) {
+		id
+		name
+		email
+	}
+}
+"
 `;
 
 exports[`queries top level list transform 1`] = `
@@ -167,6 +145,33 @@ exports[`queries top level get transform 1`] = `
 ]
 `;
 
+exports[`queries nested has-many transform 1`] = `
+[
+  {
+    "query": 
+"query($AuthorUniqueWhere_0: AuthorUniqueWhere!) {
+	author: getAuthor(by: $AuthorUniqueWhere_0) {
+		id
+		name
+		email
+		posts {
+			id
+			publishedAt
+			status
+		}
+	}
+}
+"
+,
+    "variables": {
+      "AuthorUniqueWhere_0": {
+        "id": "123",
+      },
+    },
+  },
+]
+`;
+
 exports[`queries nested has-one transform 1`] = `
 [
   {
@@ -175,6 +180,7 @@ exports[`queries nested has-one transform 1`] = `
 	post: getPost(by: $PostUniqueWhere_0) {
 		id
 		publishedAt
+		status
 		author {
 			id
 			name
@@ -201,6 +207,7 @@ exports[`queries nested has-many-by transform 1`] = `
 	post: getPost(by: $PostUniqueWhere_0) {
 		id
 		publishedAt
+		status
 		localesByLocale(by: $PostLocalesByLocaleUniqueWhere_1) {
 			id
 			title

--- a/packages/client-content/tests/cases/unit/types.test.ts
+++ b/packages/client-content/tests/cases/unit/types.test.ts
@@ -1,6 +1,7 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { describe, expect, test } from 'bun:test'
 import { ContentClientInput } from '../../../src'
-import { ContemberClientEntities, FragmentOf, FragmentType, queryBuilder } from '../../client'
+import { ContemberClientEntities, FragmentOf, FragmentType, PostStatus, queryBuilder } from '../../client'
 import { expectTypeOf } from 'expect-type'
 
 const qb = queryBuilder
@@ -143,6 +144,6 @@ describe('ts types', () => {
 	test('omit', async () => {
 		const fragment = qb.fragment('Post', it => it.$$().omit('publishedAt'))
 		type fragmentType = FragmentType<typeof fragment>
-		expectTypeOf<fragmentType>().toEqualTypeOf<{ id: string }>()
+		expectTypeOf<fragmentType>().toEqualTypeOf<{ id: string; status: PostStatus | null }>()
 	})
 })

--- a/packages/client-content/tests/client/entities.ts
+++ b/packages/client-content/tests/client/entities.ts
@@ -1,3 +1,4 @@
+import type { PostStatus } from './enums'
 
 export type JSONPrimitive = string | number | boolean | null
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray
@@ -47,6 +48,7 @@ export type Post <OverRelation extends string | never = never> = {
 	columns: {
 		id: string
 		publishedAt: string | null
+		status: PostStatus | null
 	}
 	hasOne: {
 		author: Author

--- a/packages/client-content/tests/client/enums.ts
+++ b/packages/client-content/tests/client/enums.ts
@@ -1,3 +1,8 @@
+export type PostStatus = 
+	 | "draft"
+	 | "published"
+	 | "archived"
 export type ContemberClientEnums = {
+	PostStatus: PostStatus
 }
 

--- a/packages/client-content/tests/client/names.ts
+++ b/packages/client-content/tests/client/names.ts
@@ -1,117 +1,129 @@
-import { SchemaNames } from '@contember/client-content'
-export const ContemberClientNames: SchemaNames = {
-  "entities": {
-    "Locale": {
-      "name": "Locale",
-      "fields": {
-        "id": {
-          "type": "column"
-        },
-        "code": {
-          "type": "column"
-        }
-      },
-      "scalars": [
-        "id",
-        "code"
-      ]
-    },
-    "Author": {
-      "name": "Author",
-      "fields": {
-        "id": {
-          "type": "column"
-        },
-        "name": {
-          "type": "column"
-        },
-        "email": {
-          "type": "column"
-        },
-        "posts": {
-          "type": "many",
-          "entity": "Post"
-        }
-      },
-      "scalars": [
-        "id",
-        "name",
-        "email"
-      ]
-    },
-    "Post": {
-      "name": "Post",
-      "fields": {
-        "id": {
-          "type": "column"
-        },
-        "publishedAt": {
-          "type": "column"
-        },
-        "tags": {
-          "type": "many",
-          "entity": "Tag"
-        },
-        "author": {
-          "type": "one",
-          "entity": "Author"
-        },
-        "locales": {
-          "type": "many",
-          "entity": "PostLocale"
-        }
-      },
-      "scalars": [
-        "id",
-        "publishedAt"
-      ]
-    },
-    "PostLocale": {
-      "name": "PostLocale",
-      "fields": {
-        "id": {
-          "type": "column"
-        },
-        "locale": {
-          "type": "one",
-          "entity": "Locale"
-        },
-        "title": {
-          "type": "column"
-        },
-        "content": {
-          "type": "column"
-        },
-        "post": {
-          "type": "one",
-          "entity": "Post"
-        }
-      },
-      "scalars": [
-        "id",
-        "title",
-        "content"
-      ]
-    },
-    "Tag": {
-      "name": "Tag",
-      "fields": {
-        "id": {
-          "type": "column"
-        },
-        "name": {
-          "type": "column"
-        },
-        "posts": {
-          "type": "many",
-          "entity": "Post"
-        }
-      },
-      "scalars": [
-        "id",
-        "name"
-      ]
-    }
-  },
-  "enums": {}
-}
+import type { SchemaNames, SchemaEntityNames } from '@contember/client-content'
+import type { ContemberClientEntities } from './entities'
+import type { ContemberClientEnums } from './enums'
+export const ContemberClientNames = {
+	entities: {
+		"Locale": {
+			"name": "Locale",
+			"fields": {
+				"id": {
+					"type": "column"
+				},
+				"code": {
+					"type": "column"
+				}
+			},
+			"scalars": [
+				"id",
+				"code"
+			]
+		},
+		"Author": {
+			"name": "Author",
+			"fields": {
+				"id": {
+					"type": "column"
+				},
+				"name": {
+					"type": "column"
+				},
+				"email": {
+					"type": "column"
+				},
+				"posts": {
+					"type": "many",
+					"entity": "Post"
+				}
+			},
+			"scalars": [
+				"id",
+				"name",
+				"email"
+			]
+		},
+		"Post": {
+			"name": "Post",
+			"fields": {
+				"id": {
+					"type": "column"
+				},
+				"publishedAt": {
+					"type": "column"
+				},
+				"tags": {
+					"type": "many",
+					"entity": "Tag"
+				},
+				"author": {
+					"type": "one",
+					"entity": "Author"
+				},
+				"locales": {
+					"type": "many",
+					"entity": "PostLocale"
+				},
+				"status": {
+					"type": "column"
+				}
+			},
+			"scalars": [
+				"id",
+				"publishedAt",
+				"status"
+			]
+		},
+		"PostLocale": {
+			"name": "PostLocale",
+			"fields": {
+				"id": {
+					"type": "column"
+				},
+				"locale": {
+					"type": "one",
+					"entity": "Locale"
+				},
+				"title": {
+					"type": "column"
+				},
+				"content": {
+					"type": "column"
+				},
+				"post": {
+					"type": "one",
+					"entity": "Post"
+				}
+			},
+			"scalars": [
+				"id",
+				"title",
+				"content"
+			]
+		},
+		"Tag": {
+			"name": "Tag",
+			"fields": {
+				"id": {
+					"type": "column"
+				},
+				"name": {
+					"type": "column"
+				},
+				"posts": {
+					"type": "many",
+					"entity": "Post"
+				}
+			},
+			"scalars": [
+				"id",
+				"name"
+			]
+		}
+	} satisfies {[K in keyof ContemberClientEntities]: SchemaEntityNames<K>},
+	enums: {
+		"PostStatus": [
+			"draft",
+			"published",
+			"archived"
+		]
+	} satisfies {[K in keyof ContemberClientEnums]: readonly ContemberClientEnums[K][]},
+} satisfies SchemaNames

--- a/packages/client-content/tests/schema.ts
+++ b/packages/client-content/tests/schema.ts
@@ -16,6 +16,7 @@ namespace Schema {
 		tags = c.manyHasMany(Tag, 'posts')
 		author = c.manyHasOne(Author, 'posts')
 		locales = c.oneHasMany(PostLocale, 'post')
+		status = c.enumColumn(c.createEnum('draft', 'published', 'archived'))
 	}
 
 	@c.Unique('locale', 'post')


### PR DESCRIPTION
so enums can be easily used in zod enums like this
```ts
import {ContemberClientNames} from '@app/client'

const postStatus = z.enum(ContemberClientNames.enums.PostStatus)
```