### PR TITLE
fix(engine-http): only cast enum/json/date list columns to text[] on export

### DIFF
--- a/packages/engine-http/src/transfer/ExportExecutor.ts
+++ b/packages/engine-http/src/transfer/ExportExecutor.ts
@@ -116,8 +116,14 @@ export class ExportExecutor {
 		let builder = db.selectBuilder().from(table.name)
 
 		for (const column of Object.values(table.columns)) {
-			if (column.list) {
+			if (
+				column.list
+				&& (column.type === Model.ColumnType.Enum || column.type === Model.ColumnType.Json || column.type === Model.ColumnType.Date
+					|| column.type === Model.ColumnType.DateTime)
+			) {
 				builder = builder.select(expr => expr.raw(`${wrapIdentifier(column.name)}::text[]`))
+			} else if (column.list) {
+				builder = builder.select(column.name)
 			} else if (column.type === Model.ColumnType.Json || column.type === Model.ColumnType.Date || column.type === Model.ColumnType.DateTime) {
 				builder = builder.select(expr => expr.raw(`${wrapIdentifier(column.name)}::text`))
 			} else {


### PR DESCRIPTION
## Summary
- Fixes failing CI on main caused by `b11edccaa` — the `transfer-enum-list` e2e test returns 400 on import
- The export was casting **all** list columns to `::text[]`, turning int/bool arrays into string arrays (`[10, 20]` → `["10", "20"]`)
- Import validation then rejected these because it expects `number[]` / `boolean[]` for int/bool list columns
- Now only enum/json/date/datetime lists get the `::text[]` cast; native array types (int[], bool[], text[]) are exported as-is

## Test plan
- [ ] CI `transfer-enum-list` e2e test passes (was failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/841)
<!-- Reviewable:end -->
