### PR TITLE
fix(engine-http): handle PG text-format arrays in data transfer import

### DIFF
--- a/packages/engine-http/src/transfer/ImportExecutor.ts
+++ b/packages/engine-http/src/transfer/ImportExecutor.ts
@@ -25,6 +25,47 @@ type InsertContext = {
 export class ImportError extends Error {
 }
 
+const parsePgTextArray = (value: string): string[] => {
+	if (value === '{}') return []
+	if (!value.startsWith('{') || !value.endsWith('}')) {
+		throw new ParseError([], `invalid PostgreSQL array literal: ${value}`)
+	}
+	const inner = value.slice(1, -1)
+	const result: string[] = []
+	let current = ''
+	let inQuotes = false
+	let escaped = false
+	for (const ch of inner) {
+		if (escaped) {
+			current += ch
+			escaped = false
+		} else if (ch === '\\') {
+			escaped = true
+		} else if (ch === '"') {
+			inQuotes = !inQuotes
+		} else if (ch === ',' && !inQuotes) {
+			result.push(current)
+			current = ''
+		} else {
+			current += ch
+		}
+	}
+	result.push(current)
+	return result.map(it => it === 'NULL' ? it : it)
+}
+
+const listType = <T extends Typesafe.Json>(arrayType: Typesafe.Type<T>): Typesafe.Type<T> => {
+	return (input: unknown, path: PropertyKey[] = []) => {
+		if (Array.isArray(input)) {
+			return arrayType(input, path)
+		}
+		if (typeof input === 'string' && input.startsWith('{')) {
+			return arrayType(parsePgTextArray(input), path)
+		}
+		return arrayType(input, path)
+	}
+}
+
 type CommandProcessor<T extends CommandName> = (it: CommandIterator<T>) => Promise<CommandIterator | null>
 type CommandProcessorMap<T extends CommandName> = { [N in CommandName]?: N extends T ? CommandProcessor<N> : undefined }
 
@@ -391,12 +432,12 @@ export class ImportExecutor {
 			case Model.ColumnType.Time:
 			case Model.ColumnType.Date:
 			case Model.ColumnType.Json:
-				return column.list ? Typesafe.array(Typesafe.string) : Typesafe.string
+				return column.list ? listType(Typesafe.array(Typesafe.string)) : Typesafe.string
 			case Model.ColumnType.Int:
 			case Model.ColumnType.Double:
-				return column.list ? Typesafe.array(Typesafe.number) : Typesafe.number
+				return column.list ? listType(Typesafe.array(Typesafe.number)) : Typesafe.number
 			case Model.ColumnType.Bool:
-				return column.list ? Typesafe.array(Typesafe.boolean) : Typesafe.boolean
+				return column.list ? listType(Typesafe.array(Typesafe.boolean)) : Typesafe.boolean
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Parse PostgreSQL text-format array literals (e.g. `{foo,bar}`) during import, supporting exports from older engine versions
- JS arrays pass through unchanged
- Fixes import failures when importing data exported from pre-list-column engine versions

## Test plan

- [x] Existing transfer tests pass
- [x] Tested with crane-rental project import from older export format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/842)
<!-- Reviewable:end -->
