### PR TITLE
feat(engine-actions): expose triggered action ids in graphql response

### DIFF
--- a/docs/docs/reference/engine/actions/definition.md
+++ b/docs/docs/reference/engine/actions/definition.md
@@ -263,3 +263,59 @@ export class Book {
 ```
 
 In this example, the `watch` action 'book_watch' is assigned a priority level of 2. Therefore, events triggered by changes in the 'title' or 'tags' fields of the 'Book' entity will have a processing priority level of 2 in the event queue.
+
+## Returning triggered actions in the GraphQL response
+
+By default, Contember persists triggered Action events to the queue silently — the GraphQL response contains only the mutation result and gives no indication that any Action was fired. If you need to correlate a mutation with the events it produced (for example, to wait for a specific webhook to be processed in tests, or to surface a deterministic event id to a client), you can opt in to returning the triggered events in the response `extensions`.
+
+Enable it via the `actions.returnTriggeredActions` schema setting:
+
+```typescript
+import { createSchema } from '@contember/schema-definition'
+import * as model from './model'
+
+export default {
+  ...createSchema(model),
+  settings: {
+    actions: {
+      returnTriggeredActions: true,
+    },
+  },
+}
+```
+
+When enabled, every Content API response whose execution fired at least one Action will include a `triggeredActions` entry under `extensions`. Responses that did not fire any Action (queries, or mutations that touched no watched fields) leave `extensions.triggeredActions` unset.
+
+#### Example: response with triggered actions
+
+```json
+{
+  "data": {
+    "createBook": {
+      "ok": true,
+      "node": { "id": "f4f0a97d-7850-4add-8946-a1ce016306ce" }
+    }
+  },
+  "extensions": {
+    "triggeredActions": {
+      "events": [
+        {
+          "id": "73bbf733-36a5-4e5c-8798-1ba1b7900b39",
+          "trigger": "book_watch",
+          "target": "book_watch_target",
+          "transactionId": "53e3790d-5485-490c-9420-a1e79b19b5d3"
+        }
+      ]
+    }
+  }
+}
+```
+
+Each entry in `events` corresponds to a row written to the Actions queue and contains:
+
+- `id` — the event id (matches `meta.eventId` in the [webhook payload](./invocation.md#event-metadata))
+- `trigger` — the name of the watch/trigger that produced the event
+- `target` — the name of the resolved target
+- `transactionId` — the id of the database transaction that fired the event; events fired by the same mutation share this value
+
+This setting is opt-in because it adds a small amount of bookkeeping per request and changes the response shape. Leave it disabled if you don't consume the data.

--- a/e2e/cases/actions/triggers.returnTriggeredActions.test.ts
+++ b/e2e/cases/actions/triggers.returnTriggeredActions.test.ts
@@ -1,0 +1,92 @@
+import { ActionsDefinition as actions, createSchema, SchemaDefinition as def } from '@contember/schema-definition'
+import { expect, test } from 'bun:test'
+import { createTester, gql } from '../../src/tester'
+
+namespace ActionsModel {
+	@actions.watch({
+		name: 'article_watch',
+		watch: `
+			title
+		`,
+		webhook: 'http://foobar',
+		selection: `
+			title
+		`,
+	})
+	export class Article {
+		title = def.stringColumn().unique()
+	}
+}
+
+test('triggers: return ids in response extensions when enabled', async () => {
+	const schema = createSchema(ActionsModel, schema => ({
+		...schema,
+		settings: {
+			...schema.settings,
+			actions: { returnTriggeredActions: true },
+		},
+	}))
+	const tester = await createTester(schema)
+
+	const res = await tester(
+		gql`
+			mutation {
+				createArticle(data: { title: "Hello world" }) {
+					ok
+					node { id }
+				}
+			}
+		`,
+		{ keepExtensions: true },
+	).expect(200)
+
+	const triggered = res.body.extensions?.triggeredActions
+	expect(triggered).toBeDefined()
+	expect(triggered.events).toBeArrayOfSize(1)
+	const event = triggered.events[0]
+	expect(event.id).toMatch(/^[0-9a-f-]{36}$/)
+	expect(event.transactionId).toMatch(/^[0-9a-f-]{36}$/)
+	expect(event.trigger).toBe('article_watch')
+	expect(event.target).toBe('article_watch_target')
+})
+
+test('triggers: return ids omits extension when no actions fire', async () => {
+	const schema = createSchema(ActionsModel, schema => ({
+		...schema,
+		settings: {
+			...schema.settings,
+			actions: { returnTriggeredActions: true },
+		},
+	}))
+	const tester = await createTester(schema)
+
+	const res = await tester(
+		gql`
+			query {
+				listArticle { id }
+			}
+		`,
+		{ keepExtensions: true },
+	).expect(200)
+
+	expect(res.body.extensions?.triggeredActions).toBeUndefined()
+})
+
+test('triggers: return ids disabled by default', async () => {
+	const schema = createSchema(ActionsModel)
+	const tester = await createTester(schema)
+
+	const res = await tester(
+		gql`
+			mutation {
+				createArticle(data: { title: "Hello world" }) {
+					ok
+					node { id }
+				}
+			}
+		`,
+		{ keepExtensions: true },
+	).expect(200)
+
+	expect(res.body.extensions?.triggeredActions).toBeUndefined()
+})

--- a/e2e/src/tester.ts
+++ b/e2e/src/tester.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 export const executeGraphql = (
 	path: string,
 	query: string,
-	options: { authorizationToken?: string; variables?: Record<string, any> },
+	options: { authorizationToken?: string; variables?: Record<string, any>; keepExtensions?: boolean },
 ) => {
 	const result = supertest(apiUrl)
 		.post(path)
@@ -50,7 +50,7 @@ export const executeGraphql = (
 		latestError = e
 	})
 	result.on('response', e => {
-		if ('extensions' in e.body) {
+		if (!options.keepExtensions && 'extensions' in e.body) {
 			const { extensions, ...rest } = e.body
 			e.body = rest
 		}
@@ -112,7 +112,7 @@ export const createTester = async (schema: Schema) => {
 
 	const queryCb = (
 		query: string,
-		options: { path?: string; authorizationToken?: string; variables?: Record<string, any> } = {},
+		options: { path?: string; authorizationToken?: string; variables?: Record<string, any>; keepExtensions?: boolean } = {},
 	) => {
 		return executeGraphql(options.path ?? '/content/' + projectSlug + '/live', query, options)
 	}

--- a/packages/engine-actions/src/ActionsExecutionContainerHookFactory.ts
+++ b/packages/engine-actions/src/ActionsExecutionContainerHookFactory.ts
@@ -14,7 +14,10 @@ export class ActionsExecutionContainerHookFactory {
 		return builder => {
 			return builder.setupService(
 				'mapperFactory',
-				(mapperFactory, { whereBuilder, schema, pathFactory, systemSchema, providers, stage, project, schemaMeta, joinBuilder, userInfo }) => {
+				(
+					mapperFactory,
+					{ whereBuilder, schema, pathFactory, systemSchema, providers, stage, project, schemaMeta, joinBuilder, userInfo, triggeredActionsCollector },
+				) => {
 					mapperFactory.hooks.push(mapper => {
 						const triggerPayloadPersister = new TriggerPayloadPersister(
 							mapper,
@@ -25,6 +28,7 @@ export class ActionsExecutionContainerHookFactory {
 							schemaMeta.id,
 							mapper.identityId,
 							userInfo,
+							triggeredActionsCollector,
 						)
 						const triggerPayloadBuilder = new TriggerPayloadBuilder(mapper)
 						const payloadManager = new TriggerPayloadManager(triggerPayloadBuilder, triggerPayloadPersister)

--- a/packages/engine-actions/src/triggers/TriggerPayloadPersister.ts
+++ b/packages/engine-actions/src/triggers/TriggerPayloadPersister.ts
@@ -1,5 +1,5 @@
 import { Client, InsertBuilder } from '@contember/database'
-import { Mapper } from '@contember/engine-content-api'
+import { Mapper, TriggeredActionEvent, TriggeredActionsCollector } from '@contember/engine-content-api'
 import { Actions, ActionsPayload } from '@contember/schema'
 import { EventRow } from '../model/types'
 import { notify } from '../utils/notifyChannel'
@@ -20,6 +20,7 @@ export class TriggerPayloadPersister {
 		private readonly schemaId: number | undefined,
 		private readonly identityId: string,
 		private readonly userInfo: { ipAddress: string | null; userAgent: string | null },
+		private readonly triggeredActionsCollector: TriggeredActionsCollector | undefined,
 	) {
 	}
 
@@ -28,13 +29,17 @@ export class TriggerPayloadPersister {
 		if (!this.schemaId) {
 			throw new Error('Schema id is not set')
 		}
+		const collector = this.triggeredActionsCollector
 		for (let i = 0; i < payloads.length; i += chunkSize) {
 			const chunk = payloads.slice(i, i + chunkSize)
-			await InsertBuilder.create()
-				.into('actions_event')
-				.values(chunk.map((it): EventRowToInsert => ({
-					id: this.providers.uuid(),
-					transaction_id: this.mapper.transactionId,
+			const collected: TriggeredActionEvent[] | undefined = collector ? [] : undefined
+			const rows = chunk.map((it): EventRowToInsert => {
+				const id = this.providers.uuid()
+				const transactionId = this.mapper.transactionId
+				collected?.push({ id, trigger: trigger.name, target: trigger.target, transactionId })
+				return {
+					id,
+					transaction_id: transactionId,
 					created_at: 'now',
 					visible_at: 'now',
 					num_retries: 0,
@@ -50,8 +55,16 @@ export class TriggerPayloadPersister {
 					identity_id: this.identityId,
 					ip_address: this.userInfo.ipAddress,
 					user_agent: this.userInfo.userAgent,
-				})))
+				}
+			})
+			await InsertBuilder.create()
+				.into('actions_event')
+				.values(rows)
 				.execute(this.client)
+
+			if (collected && collected.length > 0) {
+				collector!.add(collected)
+			}
 		}
 
 		await notify(this.client, this.projectSlug)

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -36,6 +36,32 @@ import {
 } from './input-validation'
 import { RefreshViewResolver } from './resolvers/RefreshViewResolver'
 
+export interface TriggeredActionEvent {
+	id: string
+	trigger: string
+	target: string
+	transactionId: string
+}
+
+export interface TriggeredActionsCollector {
+	add(events: readonly TriggeredActionEvent[]): void
+	getEvents(): readonly TriggeredActionEvent[]
+}
+
+export class InMemoryTriggeredActionsCollector implements TriggeredActionsCollector {
+	private events: TriggeredActionEvent[] = []
+
+	add(events: readonly TriggeredActionEvent[]): void {
+		for (const event of events) {
+			this.events.push(event)
+		}
+	}
+
+	getEvents(): readonly TriggeredActionEvent[] {
+		return this.events
+	}
+}
+
 export type ExecutionContainerArgs = {
 	schema: Schema
 	schemaMeta: { id?: number }
@@ -56,6 +82,7 @@ export interface ExecutionContainer {
 	mutationResolver: MutationResolver
 	validationResolver: ValidationResolver
 	refreshViewResolver: RefreshViewResolver
+	triggeredActionsCollector: TriggeredActionsCollector | undefined
 }
 
 export type ExecutionContainerBuilder = ReturnType<ExecutionContainerFactory['createBuilderInternal']>
@@ -96,6 +123,10 @@ export class ExecutionContainerFactory {
 			.addService('db', () => db)
 			.addService('project', () => project)
 			.addService('stage', () => stage)
+			.addService('triggeredActionsCollector', (): TriggeredActionsCollector | undefined =>
+				schema.settings.actions?.returnTriggeredActions === true
+					? new InMemoryTriggeredActionsCollector()
+					: undefined)
 			.addService('schema', () => schema)
 			.addService('schemaMeta', () => schemaMeta)
 			.addService('schemaDatabaseMetadata', () => schemaDatabaseMetadata)
@@ -248,6 +279,12 @@ export class ExecutionContainerFactory {
 	}
 
 	public create(args: ExecutionContainerArgs): ExecutionContainer {
-		return this.createBuilder(args).build().pick('validationResolver', 'readResolver', 'mutationResolver', 'refreshViewResolver')
+		return this.createBuilder(args).build().pick(
+			'validationResolver',
+			'readResolver',
+			'mutationResolver',
+			'refreshViewResolver',
+			'triggeredActionsCollector',
+		)
 	}
 }

--- a/packages/engine-http/src/content/ContentQueryHandlerFactory.ts
+++ b/packages/engine-http/src/content/ContentQueryHandlerFactory.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema } from 'graphql'
 import { createDbQueriesListener, createGraphQLQueryHandler, GraphQLListener, GraphQLQueryHandler } from '../graphql'
 import { ContentGraphqlContext } from './ContentGraphqlContext'
+import { createTriggeredActionsListener } from './triggeredActionsListener'
 
 export type ContentQueryHandler = GraphQLQueryHandler<ContentGraphqlContext>
 
@@ -10,6 +11,7 @@ export class ContentQueryHandlerFactory {
 	public create(graphQlSchema: GraphQLSchema): ContentQueryHandler {
 		const listeners: GraphQLListener<ContentGraphqlContext>[] = []
 		listeners.push(createDbQueriesListener(context => context.db, this.debug))
+		listeners.push(createTriggeredActionsListener())
 
 		return createGraphQLQueryHandler<ContentGraphqlContext>({
 			schema: graphQlSchema,

--- a/packages/engine-http/src/content/triggeredActionsListener.ts
+++ b/packages/engine-http/src/content/triggeredActionsListener.ts
@@ -1,0 +1,17 @@
+import { GraphQLListener } from '../graphql'
+import { ContentGraphqlContext } from './ContentGraphqlContext'
+
+export const createTriggeredActionsListener = (): GraphQLListener<ContentGraphqlContext> => ({
+	onResponse: ({ response, context }) => {
+		const collector = context.executionContainer.triggeredActionsCollector
+		if (!collector) {
+			return
+		}
+		const events = collector.getEvents()
+		if (events.length === 0) {
+			return
+		}
+		response.extensions ??= {}
+		response.extensions.triggeredActions = { events: [...events] }
+	},
+})

--- a/packages/schema-utils/src/type-schema/settings.ts
+++ b/packages/schema-utils/src/type-schema/settings.ts
@@ -13,6 +13,9 @@ export const settingsSchema = Typesafe.partial({
 		shortDateResponse: Typesafe.boolean,
 		uuidVersion: Typesafe.union(Typesafe.literal(4), Typesafe.literal(7)),
 	}),
+	actions: Typesafe.partial({
+		returnTriggeredActions: Typesafe.boolean,
+	}),
 })
 
 const settingSchemaCheck: Typesafe.Equals<Settings.Schema, ReturnType<typeof settingsSchema>> = true

--- a/packages/schema/src/schema/settings.ts
+++ b/packages/schema/src/schema/settings.ts
@@ -10,9 +10,14 @@ export namespace Settings {
 		readonly uuidVersion?: 4 | 7
 	}
 
+	export type ActionsSettings = {
+		readonly returnTriggeredActions?: boolean
+	}
+
 	export type Schema = {
 		readonly tenant?: TenantSettings
 		readonly content?: ContentSettings
+		readonly actions?: ActionsSettings
 
 		/**
 		 * @deprecated


### PR DESCRIPTION
## Summary

- Adds opt-in `schema.settings.actions.returnTriggeredActionIds` to expose triggered action event ids back in the GraphQL response under `extensions.triggeredActions`.
- Each entry contains `{ id, trigger, target, transactionId }` so clients can poll for event status or correlate downstream webhook deliveries.
- Collector lives in `ExecutionContainer`, populated by `TriggerPayloadPersister` after a successful insert; a new content-api graphql listener writes it to the response extensions.
- Default off — needs explicit opt-in per schema.

## Test plan

- [ ] e2e: triggered ids returned when setting is enabled
- [ ] e2e: extension omitted when no actions fire
- [ ] e2e: extension omitted when setting is off (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/843)
<!-- Reviewable:end -->
