### PR TITLE
fix(engine-system-api): invalidate cached schema when version changes

### DIFF
--- a/packages/engine-system-api/src/model/migrations/SchemaProvider.ts
+++ b/packages/engine-system-api/src/model/migrations/SchemaProvider.ts
@@ -66,7 +66,7 @@ export class SchemaProvider {
 		db: DatabaseContext
 		currentSchema?: SchemaWithMeta | null
 	}): Promise<SchemaWithMeta> {
-		const newSchema = await db.queryHandler.fetch(new SchemaQuery(currentSchema?.meta.checksum))
+		const newSchema = await db.queryHandler.fetch(new SchemaQuery(currentSchema?.meta.checksum, currentSchema?.meta.version))
 		if (!newSchema) {
 			return currentSchema ?? emptyVersionedSchema
 		}

--- a/packages/engine-system-api/src/model/queries/schema/SchemaQuery.ts
+++ b/packages/engine-system-api/src/model/queries/schema/SchemaQuery.ts
@@ -5,6 +5,7 @@ import { SchemaWithMeta } from '../../migrations'
 export class SchemaQuery extends DatabaseQuery<SchemaWithMeta | null> {
 	constructor(
 		private readonly currentHash?: string,
+		private readonly currentVersion?: string,
 	) {
 		super()
 	}
@@ -25,6 +26,9 @@ export class SchemaQuery extends DatabaseQuery<SchemaWithMeta | null> {
 			.match(it => {
 				if (!this.currentHash) {
 					return it
+				}
+				if (this.currentVersion) {
+					return it.where(it => it.raw('(checksum != ? OR version != ?)', [this.currentHash, this.currentVersion]))
 				}
 				return it.where(it => it.raw('checksum != ?', this.currentHash))
 			})

--- a/packages/engine-system-api/src/model/queries/schema/SchemaQuery.ts
+++ b/packages/engine-system-api/src/model/queries/schema/SchemaQuery.ts
@@ -28,7 +28,7 @@ export class SchemaQuery extends DatabaseQuery<SchemaWithMeta | null> {
 					return it
 				}
 				if (this.currentVersion) {
-					return it.where(it => it.raw('(checksum != ? OR version != ?)', [this.currentHash, this.currentVersion]))
+					return it.where(it => it.raw('(checksum != ? OR version != ?)', this.currentHash, this.currentVersion))
 				}
 				return it.where(it => it.raw('checksum != ?', this.currentHash))
 			})


### PR DESCRIPTION
## Summary

Data transfer between environments fails with "Incompatible schema version" — and the reported server version flips between requests, e.g.:

```
request 1: "import version 2026-04-23-144600 does not match server version 2026-04-23-143841"
request 2: "import version 2026-04-23-143841 does not match server version 2026-04-23-144600"
```

No matter what version the export has, it's wrong — because different server workers report different versions.

### Root cause

`SchemaQuery` uses a checksum-based cache: it only returns fresh data from the `schema` table when `checksum != ?`. Content migrations update the `version` in the schema table but don't change the `checksum` (no structural schema change). After a content migration runs:

1. `ProjectMigrator` updates the schema table: version=`144600`, checksum=ABC (unchanged)
2. Workers that were alive during the migration still have cached version=`143841`, checksum=ABC
3. `SchemaQuery` sees matching checksum → returns `null` → stale version is served
4. Workers that started after the migration get a fresh cache with the correct version

Since requests are load-balanced across workers, the server version alternates depending on which worker handles the request — making import impossible.

### Fix

Pass the cached version alongside the checksum to `SchemaQuery`. The query now returns fresh data when either the checksum OR the version has changed: `(checksum != ? OR version != ?)`.

Backward compatible — when no version is passed (existing callers), behavior is unchanged.

## Test plan

- [ ] Run a content migration, then export without restarting — version should reflect the content migration
- [ ] Transfer data between environments after content migrations without restarting
- [ ] Verify no extra DB queries when neither checksum nor version has changed
- [ ] Consecutive import attempts against the same server report a consistent version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/846)
<!-- Reviewable:end -->
