### PR TITLE
feat(engine-actions): lazy dispatch worker for cloud mode

### DIFF
--- a/packages/engine-actions/src/dispatch/LazyDispatchWorker.ts
+++ b/packages/engine-actions/src/dispatch/LazyDispatchWorker.ts
@@ -1,0 +1,72 @@
+import { Runnable, RunnableArgs, Running, Supervisor, SupervisorOptions } from '@contember/engine-common'
+import { ProjectGroupContainerResolver } from '@contember/engine-http'
+import { DispatchWorkerSupervisorFactory } from './DispatchWorkerSupervisor'
+
+export class LazyDispatchWorker implements Runnable {
+	constructor(
+		private readonly projectGroupContainerResolver: ProjectGroupContainerResolver,
+		private readonly supervisorFactory: DispatchWorkerSupervisorFactory,
+		private readonly supervisorOptions: SupervisorOptions = { startupMax: 10 },
+	) {
+	}
+
+	public async run({ logger, onError }: RunnableArgs): Promise<Running> {
+		const running = new Map<string | undefined, Promise<Running | undefined>>()
+		let aborted = false
+
+		const unlisten = this.projectGroupContainerResolver.on('create', ({ container, slug }) => {
+			const groupLabel = slug ?? '<default>'
+			const childLogger = logger.child({ projectGroup: groupLabel })
+			childLogger.debug(`Starting dispatch worker for project group ${groupLabel}`)
+
+			const supervised = new Supervisor(
+				this.supervisorFactory.create(container),
+				this.supervisorOptions,
+			)
+			const runningPromise: Promise<Running | undefined> = supervised.run({
+				logger: childLogger,
+				onError: e => {
+					if (aborted) {
+						return
+					}
+					childLogger.error(e, { message: `Dispatch worker for project group ${groupLabel} crashed` })
+					onError(e)
+				},
+			}).catch(e => {
+				if (!aborted) {
+					childLogger.error(e, { message: `Failed to start dispatch worker for project group ${groupLabel}` })
+					onError(e)
+				}
+				return undefined
+			})
+			running.set(slug, runningPromise)
+
+			return () => {
+				running.delete(slug)
+				;(async () => {
+					try {
+						const r = await runningPromise
+						await r?.end()
+					} catch {
+					}
+				})()
+			}
+		})
+
+		return {
+			end: async () => {
+				aborted = true
+				unlisten()
+				const all = [...running.values()]
+				running.clear()
+				await Promise.allSettled(all.map(async p => {
+					try {
+						const r = await p
+						await r?.end()
+					} catch {
+					}
+				}))
+			},
+		}
+	}
+}

--- a/packages/engine-actions/src/index.ts
+++ b/packages/engine-actions/src/index.ts
@@ -21,6 +21,7 @@ import { WebhookTargetHandler } from './dispatch/WebhookTargetHandler'
 import { ActionsContextResolver } from './graphql/http/ActionsContextResolver'
 import { ActionsWebsocketControllerFactory } from './graphql/http/ActionsWebsocketControllerFactory'
 import { DispatchWorkerSupervisorFactory } from './dispatch/DispatchWorkerSupervisor'
+import { LazyDispatchWorker } from './dispatch/LazyDispatchWorker'
 import { ProjectDispatcherFactory } from './dispatch/ProjectDispatcher'
 import { VariablesQueryResolver } from './graphql/resolvers/query/VariablesQueryResolver'
 import { VariablesManager } from './model/VariablesManager'
@@ -108,11 +109,16 @@ export default class ActionsPlugin implements Plugin {
 						it.addWebsocketRoute('actions', '/actions/_worker', actionsWebsocketMiddlewareFactory.create())
 					},
 				)
-				.setupService('applicationWorkers', (it, { actions_dispatchWorkerSupervisorFactory, projectGroupContainer, serverConfig }) => {
-					if (!(serverConfig as any).projectGroup) {
-						it.registerWorker(this.name, actions_dispatchWorkerSupervisorFactory.create(projectGroupContainer))
-					}
-				}) as unknown as MasterContainerBuilder
+				.setupService(
+					'applicationWorkers',
+					(it, { actions_dispatchWorkerSupervisorFactory, projectGroupContainer, projectGroupContainerResolver, serverConfig }) => {
+						if (!(serverConfig as any).projectGroup) {
+							it.registerWorker(this.name, actions_dispatchWorkerSupervisorFactory.create(projectGroupContainer))
+						} else {
+							it.registerWorker(this.name, new LazyDispatchWorker(projectGroupContainerResolver, actions_dispatchWorkerSupervisorFactory))
+						}
+					},
+				) as unknown as MasterContainerBuilder
 		}
 		return hook
 	}

--- a/packages/engine-actions/tests/cases/unit/lazyDispatchWorker.test.ts
+++ b/packages/engine-actions/tests/cases/unit/lazyDispatchWorker.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, test } from 'bun:test'
+import { Runnable, RunnableArgs, Running } from '@contember/engine-common'
+import { createLogger, TestLoggerHandler } from '@contember/logger'
+import { LazyDispatchWorker } from '../../../src/dispatch/LazyDispatchWorker'
+import { DispatchWorkerSupervisorFactory } from '../../../src/dispatch/DispatchWorkerSupervisor'
+import { ProjectGroupContainerResolver } from '@contember/engine-http'
+import { ProjectGroupContainer } from '@contember/engine-http'
+
+const silentLogger = createLogger(new TestLoggerHandler())
+
+const tick = () => new Promise<void>(r => setImmediate(r))
+
+const waitFor = async (cond: () => boolean, attempts = 50) => {
+	for (let i = 0; i < attempts; i++) {
+		if (cond()) return
+		await tick()
+	}
+	throw new Error('waitFor: condition not met')
+}
+
+type FakeRunnable = Runnable & {
+	id: string
+	startCount: number
+	endCount: number
+	failOnRun?: () => Error | undefined
+	emitError?: (e: any) => void
+}
+
+const createFakeSupervisor = (id: string, opts: { failOnRun?: () => Error | undefined } = {}): FakeRunnable => {
+	const fake: FakeRunnable = {
+		id,
+		startCount: 0,
+		endCount: 0,
+		failOnRun: opts.failOnRun,
+		async run(args: RunnableArgs): Promise<Running> {
+			fake.startCount++
+			const failure = fake.failOnRun?.()
+			if (failure) {
+				throw failure
+			}
+			fake.emitError = args.onError
+			return {
+				end: async () => {
+					fake.endCount++
+				},
+			}
+		},
+	}
+	return fake
+}
+
+type FakeResolver = Pick<ProjectGroupContainerResolver, 'on'> & {
+	fire: (slug: string | undefined) => (() => void) | undefined
+	listenerCount: () => number
+}
+
+const createFakeResolver = (): FakeResolver => {
+	const listeners: Array<(args: { container: ProjectGroupContainer; slug: string | undefined }) => void | (() => void)> = []
+	return {
+		on(_event, cb) {
+			listeners.push(cb as any)
+			return () => {
+				const idx = listeners.indexOf(cb as any)
+				if (idx >= 0) listeners.splice(idx, 1)
+			}
+		},
+		fire(slug) {
+			const fakeContainer = { slug } as unknown as ProjectGroupContainer
+			const cleanups = listeners.map(it => it({ container: fakeContainer, slug }))
+			return () => cleanups.forEach(it => it?.())
+		},
+		listenerCount: () => listeners.length,
+	}
+}
+
+const createFakeFactory = (registry: FakeRunnable[]): DispatchWorkerSupervisorFactory => {
+	let counter = 0
+	return {
+		create(_container: ProjectGroupContainer): any {
+			const fake = createFakeSupervisor(`fake-${counter++}`)
+			registry.push(fake)
+			return fake
+		},
+	} as any
+}
+
+const recordOnError = () => {
+	const errors: any[] = []
+	return { errors, onError: (e: any) => errors.push(e) }
+}
+
+describe('LazyDispatchWorker', () => {
+	test('does not spawn supervisor before any project group is created', async () => {
+		const resolver = createFakeResolver()
+		const supervisors: FakeRunnable[] = []
+		const worker = new LazyDispatchWorker(resolver as any, createFakeFactory(supervisors))
+		const { onError } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+
+		expect(supervisors).toHaveLength(0)
+		expect(resolver.listenerCount()).toBe(1)
+
+		await running.end()
+		expect(resolver.listenerCount()).toBe(0)
+	})
+
+	test('spawns supervisor when project group is created', async () => {
+		const resolver = createFakeResolver()
+		const supervisors: FakeRunnable[] = []
+		const worker = new LazyDispatchWorker(resolver as any, createFakeFactory(supervisors))
+		const { onError, errors } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+
+		resolver.fire('tenantA')
+		await waitFor(() => supervisors.length === 1 && supervisors[0].startCount === 1)
+
+		expect(supervisors[0].startCount).toBe(1)
+		expect(supervisors[0].endCount).toBe(0)
+		expect(errors).toHaveLength(0)
+
+		await running.end()
+		expect(supervisors[0].endCount).toBe(1)
+	})
+
+	test('spawns one supervisor per project group, isolated', async () => {
+		const resolver = createFakeResolver()
+		const supervisors: FakeRunnable[] = []
+		const worker = new LazyDispatchWorker(resolver as any, createFakeFactory(supervisors))
+		const { onError } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+
+		resolver.fire('tenantA')
+		resolver.fire('tenantB')
+		await waitFor(() => supervisors.length === 2 && supervisors.every(it => it.startCount === 1))
+
+		await running.end()
+		expect(supervisors.map(it => it.endCount)).toEqual([1, 1])
+	})
+
+	test('container invalidation ends only that supervisor', async () => {
+		const resolver = createFakeResolver()
+		const supervisors: FakeRunnable[] = []
+		const worker = new LazyDispatchWorker(resolver as any, createFakeFactory(supervisors))
+		const { onError } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+
+		const cleanupA = resolver.fire('tenantA')!
+		resolver.fire('tenantB')
+		await waitFor(() => supervisors.length === 2 && supervisors.every(it => it.startCount === 1))
+
+		cleanupA()
+		await waitFor(() => supervisors[0].endCount === 1)
+
+		expect(supervisors[0].endCount).toBe(1)
+		expect(supervisors[1].endCount).toBe(0)
+
+		await running.end()
+		expect(supervisors[1].endCount).toBe(1)
+	})
+
+	test('end() unsubscribes listener, no further supervisors are spawned', async () => {
+		const resolver = createFakeResolver()
+		const supervisors: FakeRunnable[] = []
+		const worker = new LazyDispatchWorker(resolver as any, createFakeFactory(supervisors))
+		const { onError } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+		expect(resolver.listenerCount()).toBe(1)
+
+		await running.end()
+		expect(resolver.listenerCount()).toBe(0)
+
+		resolver.fire('tenantLate')
+		await tick()
+		expect(supervisors).toHaveLength(0)
+	})
+
+	test('startup failure of a tenant supervisor propagates to onError once retries are exhausted', async () => {
+		const resolver = createFakeResolver()
+		const registry: FakeRunnable[] = []
+		const factory: DispatchWorkerSupervisorFactory = {
+			create(_container: ProjectGroupContainer): any {
+				const fake = createFakeSupervisor(`fake-${registry.length}`, {
+					failOnRun: () => new Error('boom'),
+				})
+				registry.push(fake)
+				return fake
+			},
+		} as any
+		const worker = new LazyDispatchWorker(resolver as any, factory, { startupMax: 0, minBackoff: 1 })
+		const { onError, errors } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+
+		resolver.fire('tenantBroken')
+		await waitFor(() => errors.length > 0, 200)
+
+		expect(errors[0]).toBeInstanceOf(Error)
+		expect((errors[0] as Error).message).toContain('boom')
+
+		await running.end()
+	})
+
+	test('errors after end() are swallowed', async () => {
+		const resolver = createFakeResolver()
+		const supervisors: FakeRunnable[] = []
+		const worker = new LazyDispatchWorker(resolver as any, createFakeFactory(supervisors))
+		const { onError, errors } = recordOnError()
+
+		const running = await worker.run({ logger: silentLogger, onError })
+
+		resolver.fire('tenantA')
+		await waitFor(() => supervisors.length === 1 && supervisors[0].emitError !== undefined)
+
+		await running.end()
+		expect(supervisors[0].endCount).toBe(1)
+
+		supervisors[0].emitError!(new Error('after end'))
+		await tick()
+		expect(errors).toHaveLength(0)
+	})
+})


### PR DESCRIPTION
## Summary

Enables `CONTEMBER_APPLICATION_WORKER` together with cloud mode (`CONTEMBER_PROJECT_GROUP_DOMAIN_MAPPING`).

Previously, the actions plugin only registered its dispatch worker when `serverConfig.projectGroup` was unset — running the worker with `CONTEMBER_APPLICATION_WORKER=actions` alongside `CONTEMBER_PROJECT_GROUP_DOMAIN_MAPPING` either threw `Worker actions does not exist` or silently no-op'd with `=all`.

## Approach

Add a `LazyDispatchWorker` (`Runnable`) that:

- subscribes to `projectGroupContainerResolver.on('create')` — same hook the Prometheus metrics already use
- per resolved project group container, spawns a `DispatchWorkerSupervisor` wrapped in `Supervisor` for startup retry resilience (handles fresh-tenant migrations race)
- uses the listener cleanup callback to end a supervisor when its container is invalidated (config header changes)
- on `end()`, unsubscribes and drains all running supervisors

The single-tenant code path is unchanged.

## Limitation

Lazy hook fires when something in the **same process** calls `projectGroupContainerResolver.getProjectGroupContainer()` — i.e. when an HTTP request resolves a tenant. Dedicated worker processes (`CONTEMBER_APPLICATION_WORKER=actions` with no HTTP listener) will not spawn supervisors until something pings them on a tenant domain. For typical deployments use `CONTEMBER_APPLICATION_WORKER=all` in a single process.

A future warmup mechanism (env list of slugs eagerly resolved at startup) would lift this limitation but is out of scope here.

## Multi-replica safety

Already covered by the existing dispatch SQL: `FOR NO KEY UPDATE SKIP LOCKED` on the fetch query plus the 10-minute ACK timeout via `visible_at`. Multiple replicas can poll concurrently without duplicates; webhook delivery remains at-least-once (idempotent receivers required, as before).

## Tests

7 new unit tests in `packages/engine-actions/tests/cases/unit/lazyDispatchWorker.test.ts`:

- listener registration / no premature spawn
- spawn on `create`, end on worker `end()`
- per-tenant isolation
- cleanup callback ends only the affected supervisor
- post-`end()` `create` events are ignored
- startup failure propagates to `onError` after retry exhaustion (uses `startupMax: 0` for fast test)
- `onError` calls after `end()` are swallowed via `aborted` flag

A small testability tweak was needed: `LazyDispatchWorker` now accepts an optional `SupervisorOptions` constructor parameter (defaulting to `{ startupMax: 10 }`), so tests can configure fast retries.

## Test plan

- [x] `bun test packages/engine-actions` — all 29 tests pass
- [x] `bun run ts:build` — clean (pre-existing `graphql-client-tenant`/`graphql-client-system` codegen errors unrelated)
- [ ] Manual smoke test in cloud-mode deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/847)
<!-- Reviewable:end -->
