### PR TITLE
fix(engine-http): aggregate CustomMetric values by labels

### DIFF
--- a/packages/engine-http/src/prometheus/CustomMetric.ts
+++ b/packages/engine-http/src/prometheus/CustomMetric.ts
@@ -1,7 +1,7 @@
 type LabelValues<T extends string> = Partial<Record<T, string | number>>
 
 export class CustomMetric<T extends string> {
-	private values: { labels: LabelValues<T>; value: number }[] = []
+	private values = new Map<string, { labels: LabelValues<T>; value: number }>()
 
 	constructor(
 		private readonly options: {
@@ -14,11 +14,17 @@ export class CustomMetric<T extends string> {
 	}
 
 	reset() {
-		this.values = []
+		this.values.clear()
 	}
 
 	add(labels: LabelValues<T>, value: number) {
-		this.values.push({ labels, value })
+		const key = this.labelKey(labels)
+		const existing = this.values.get(key)
+		if (existing) {
+			existing.value += value
+		} else {
+			this.values.set(key, { labels, value })
+		}
 	}
 
 	get name() {
@@ -30,8 +36,16 @@ export class CustomMetric<T extends string> {
 			help: this.options.help,
 			name: this.options.name,
 			type: this.options.type,
-			values: this.values,
+			values: Array.from(this.values.values()),
 			aggregator: 'sum',
 		}
+	}
+
+	private labelKey(labels: LabelValues<T>): string {
+		const parts: string[] = []
+		for (const name of this.options.labelNames) {
+			parts.push(`${name}=${labels[name] ?? ''}`)
+		}
+		return parts.join('\x00')
 	}
 }


### PR DESCRIPTION
`CustomMetric.add()` blindly pushes every call into a `values[]` array. When the DB pool collector iterates an entries set that contains multiple `DatabaseMetricsEntry` objects sharing the same labels, prom-client emits the same series multiple times in `/metrics`. Prometheus then logs `Error on ingesting samples with different value but same timestamp` and drops samples — triggering the `PrometheusDuplicateTimestampsSummary` alert.

Fix: store values keyed by the label combination, summing on collision. Aligns runtime behavior with the existing `aggregator: 'sum'` declaration. Standard prom-client Counters already aggregate by labels; this brings `CustomMetric` in line.

Note: the underlying entries-set growth in `dbMetrics.ts` (entries with identical labels accumulating over time) is a separate concern worth a follow-up — but this fix makes the metric output correct regardless.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/848)
<!-- Reviewable:end -->
