### PR TITLE
feat: trust forwarded client info from backend proxies

### DIFF
--- a/packages/engine-http/src/application/application.ts
+++ b/packages/engine-http/src/application/application.ts
@@ -139,6 +139,8 @@ export class Application {
 				user: authResult?.identityId,
 			})
 
+			const effectiveClientIp = authResult?.clientIp ?? clientIp
+
 			const ws = await new Promise<WebSocket>(resolve =>
 				wss.handleUpgrade(req, socket, head, (ws, request) => {
 					resolve(ws)
@@ -152,7 +154,7 @@ export class Application {
 				timer,
 				url,
 				request: req,
-				clientIp,
+				clientIp: effectiveClientIp,
 				authResult,
 				params: matchedRequest.params,
 				projectGroup: groupContainer,
@@ -228,12 +230,14 @@ export class Application {
 				user: authResult?.identityId,
 			})
 
+			const effectiveClientIp = authResult?.clientIp ?? clientIp
+
 			const response = await requestLogger.scope(async logger => {
 				httpContext = {
 					koa: ctx,
 					body: ctx.request.body,
 					url: ctx.request.URL,
-					clientIp,
+					clientIp: effectiveClientIp,
 					logger,
 					timer,
 					request: ctx.req,

--- a/packages/engine-http/src/common/Authorizator.ts
+++ b/packages/engine-http/src/common/Authorizator.ts
@@ -5,9 +5,25 @@ import { IncomingMessage } from 'node:http'
 
 export type AuthResult =
 	& VerifyResult
-	& { assumedIdentityId?: string }
+	& {
+		assumedIdentityId?: string
+		clientIp?: string
+		clientUserAgent?: string
+		forwarderIp?: string
+		forwarderUserAgent?: string
+	}
 
 const assumeIdentityHeader = 'x-contember-assume-identity'
+const forwardedClientIpHeader = 'x-contember-client-ip'
+const forwardedClientUserAgentHeader = 'x-contember-client-user-agent'
+
+const readHeader = (request: IncomingMessage, name: string): string | undefined => {
+	const value = request.headers[name]
+	if (Array.isArray(value)) {
+		return value[0]
+	}
+	return typeof value === 'string' ? value : undefined
+}
 
 export class Authenticator {
 	private createAuthError = (message: string) => new HttpErrorResponse(401, `Authorization failure: ${message}`)
@@ -34,12 +50,17 @@ export class Authenticator {
 			throw this.createAuthError(`invalid Authorization header format`)
 		}
 		const [, token] = match
-		const userAgent = request.headers['user-agent']
-		const authResult = await timer('Auth', () =>
-			this.apiKeyManager.verifyAndProlong(this.tenantDatabase, this.tenantReadDatabase, token, {
-				ip: clientIp,
-				userAgent: typeof userAgent === 'string' ? userAgent : undefined,
-			}))
+		const socketUserAgent = readHeader(request, 'user-agent')
+		const forwardedIp = readHeader(request, forwardedClientIpHeader)
+		const forwardedUserAgent = readHeader(request, forwardedClientUserAgentHeader)
+		const socketInfo = { ip: clientIp, userAgent: socketUserAgent }
+		const forwardedInfo = (forwardedIp !== undefined || forwardedUserAgent !== undefined)
+			? { ip: forwardedIp, userAgent: forwardedUserAgent }
+			: undefined
+		const authResult = await timer(
+			'Auth',
+			() => this.apiKeyManager.verifyAndProlong(this.tenantDatabase, this.tenantReadDatabase, token, socketInfo, forwardedInfo),
+		)
 		if (!authResult.ok) {
 			throw this.createAuthError(authResult.errorMessage)
 		}
@@ -47,9 +68,14 @@ export class Authenticator {
 		if (Array.isArray(assumedIdentityId)) {
 			throw new HttpErrorResponse(400, `Invalid ${assumedIdentityId} header format`)
 		}
+		const trustForwarded = authResult.result.trustForwardedInfo && forwardedInfo !== undefined
 		return {
 			...authResult.result,
 			assumedIdentityId,
+			clientIp: trustForwarded ? (forwardedInfo?.ip ?? clientIp) : clientIp,
+			clientUserAgent: trustForwarded ? (forwardedInfo?.userAgent ?? socketUserAgent) : socketUserAgent,
+			forwarderIp: trustForwarded ? clientIp : undefined,
+			forwarderUserAgent: trustForwarded ? socketUserAgent : undefined,
 		}
 	}
 }

--- a/packages/engine-http/src/content/ContentApiControllerFactory.ts
+++ b/packages/engine-http/src/content/ContentApiControllerFactory.ts
@@ -138,7 +138,8 @@ export class ContentApiControllerFactory {
 								project,
 								userInfo: {
 									ipAddress: clientIp,
-									userAgent: koa.request.headers['user-agent'] ?? null,
+									userAgent: authResult.clientUserAgent
+										?? (typeof koa.request.headers['user-agent'] === 'string' ? koa.request.headers['user-agent'] : null),
 								},
 							})
 

--- a/packages/engine-http/src/tenant/TenantApiMiddlewareFactory.ts
+++ b/packages/engine-http/src/tenant/TenantApiMiddlewareFactory.ts
@@ -22,9 +22,16 @@ export class TenantApiMiddlewareFactory {
 							}
 							const resolverContextFactory = tenantContainer.resolverContextFactory
 							const db = tenantContainer.databaseContext
+							const userAgent = authResult.clientUserAgent
+								?? (typeof koa.request.headers['user-agent'] === 'string' ? koa.request.headers['user-agent'] : undefined)
 							const context = resolverContextFactory.create(
 								authResult,
-								{ ip: clientIp, userAgent: koa.request.headers['user-agent'] },
+								{
+									ip: clientIp,
+									userAgent,
+									forwarderIp: authResult.forwarderIp,
+									forwarderUserAgent: authResult.forwarderUserAgent,
+								},
 								db,
 								logger,
 							)

--- a/packages/engine-tenant-api/src/migrations/2026-05-12-120000-api-key-session-tracking.ts
+++ b/packages/engine-tenant-api/src/migrations/2026-05-12-120000-api-key-session-tracking.ts
@@ -13,6 +13,9 @@ ALTER TYPE "auth_log_type" ADD VALUE 'forced_sign_out';
 
 ALTER TABLE "person_auth_log"
 	ADD COLUMN "target_person_id" UUID REFERENCES "person"("id") ON DELETE SET NULL;
+
+CREATE INDEX "person_auth_log_target_person_id_created_at_idx"
+	ON "person_auth_log" ("target_person_id", "created_at" DESC);
 `
 
 export default async function(builder: MigrationBuilder) {

--- a/packages/engine-tenant-api/src/migrations/2026-05-12-130000-api-key-trust-forwarded-info.ts
+++ b/packages/engine-tenant-api/src/migrations/2026-05-12-130000-api-key-trust-forwarded-info.ts
@@ -1,0 +1,10 @@
+import { MigrationBuilder } from '@contember/database-migrations'
+
+const sql = `
+ALTER TABLE "api_key"
+	ADD COLUMN "trust_forwarded_info" BOOLEAN NOT NULL DEFAULT false;
+`
+
+export default async function(builder: MigrationBuilder) {
+	builder.sql(sql)
+}

--- a/packages/engine-tenant-api/src/migrations/runner.ts
+++ b/packages/engine-tenant-api/src/migrations/runner.ts
@@ -41,6 +41,7 @@ import _20240826120000passwordless from './2024-08-26-120000-passwordless'
 import _20250416180000configup from './2025-04-16-180000-config-up'
 import _20250417160000authlog from './2025-04-17-160000-auth-log'
 import _20260512120000apikeysessiontracking from './2026-05-12-120000-api-key-session-tracking'
+import _20260512130000apikeytrustforwardedinfo from './2026-05-12-130000-api-key-trust-forwarded-info'
 import snapshot from './snapshot'
 import { computeTokenHash, Providers } from '../model'
 import { Logger } from '@contember/logger'
@@ -94,6 +95,7 @@ const migrations = {
 	'2025-04-16-180000-config-up': _20250416180000configup,
 	'2025-04-17-160000-auth-log': _20250417160000authlog,
 	'2026-05-12-120000-api-key-session-tracking': _20260512120000apikeysessiontracking,
+	'2026-05-12-130000-api-key-trust-forwarded-info': _20260512130000apikeytrustforwardedinfo,
 }
 
 export class TenantMigrationsRunner {

--- a/packages/engine-tenant-api/src/migrations/snapshot.ts
+++ b/packages/engine-tenant-api/src/migrations/snapshot.ts
@@ -73,7 +73,8 @@ CREATE TABLE "api_key" (
     "last_user_agent" "text",
     "last_used_at" timestamp with time zone,
     "created_ip" "inet",
-    "created_user_agent" "text"
+    "created_user_agent" "text",
+    "trust_forwarded_info" boolean DEFAULT false NOT NULL
 );
 CREATE TABLE "config" (
     "id" "config_singleton" DEFAULT 'singleton'::"config_singleton" NOT NULL,

--- a/packages/engine-tenant-api/src/migrations/snapshot.ts
+++ b/packages/engine-tenant-api/src/migrations/snapshot.ts
@@ -238,6 +238,7 @@ CREATE UNIQUE INDEX "mail_template_identifier" ON "mail_template" USING "btree" 
 CREATE UNIQUE INDEX "mail_template_identifier_global" ON "mail_template" USING "btree" ("mail_type", "variant") WHERE ("project_id" IS NULL);
 CREATE INDEX "mail_template_project_index" ON "mail_template" USING "btree" ("project_id");
 CREATE INDEX "person_auth_log_person_input_identifier_created_at_idx" ON "person_auth_log" USING "btree" ("person_input_identifier", "created_at" DESC);
+CREATE INDEX "person_auth_log_target_person_id_created_at_idx" ON "person_auth_log" USING "btree" ("target_person_id", "created_at" DESC);
 CREATE INDEX "person_identity_id" ON "person" USING "btree" ("identity_id");
 CREATE UNIQUE INDEX "person_identity_provider_identifier" ON "person_identity_provider" USING "btree" ("identity_provider_id", "external_identifier");
 CREATE INDEX "person_identity_provider_person_id" ON "person_identity_provider" USING "btree" ("person_id");

--- a/packages/engine-tenant-api/src/model/commands/apiKey/CreateApiKeyCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/apiKey/CreateApiKeyCommand.ts
@@ -11,6 +11,7 @@ interface CreateSessionApiKeyArgs {
 	expiration?: number
 	tokenHash?: string
 	requestInfo?: ApiKeyRequestInfo
+	trustForwardedInfo?: boolean
 }
 
 interface CreatePermanentApiKeyArgs {
@@ -19,6 +20,7 @@ interface CreatePermanentApiKeyArgs {
 	tokenHash?: TokenHash
 	expiration?: undefined
 	requestInfo?: ApiKeyRequestInfo
+	trustForwardedInfo?: boolean
 }
 
 export type CreateApiKeyArgs =
@@ -50,6 +52,7 @@ export class CreateApiKeyCommand implements Command<CreateApiKeyCommandResult> {
 				created_at: providers.now(),
 				created_ip: this.args.requestInfo?.ip ?? null,
 				created_user_agent: this.args.requestInfo?.userAgent ?? null,
+				trust_forwarded_info: this.args.trustForwardedInfo ?? false,
 			})
 			.execute(db)
 

--- a/packages/engine-tenant-api/src/model/queries/apiKey/ApiKeyQuery.ts
+++ b/packages/engine-tenant-api/src/model/queries/apiKey/ApiKeyQuery.ts
@@ -45,6 +45,7 @@ export type ApiKeyRow = {
 	readonly last_ip: string | null
 	readonly last_user_agent: string | null
 	readonly last_used_at: Date | null
+	readonly trust_forwarded_info: boolean
 }
 
 const apiKeyBaseQuery = SelectBuilder.create<null | ApiKeyRow>()
@@ -59,6 +60,7 @@ const apiKeyBaseQuery = SelectBuilder.create<null | ApiKeyRow>()
 	.select(['api_key', 'last_ip'])
 	.select(['api_key', 'last_user_agent'])
 	.select(['api_key', 'last_used_at'])
+	.select(['api_key', 'trust_forwarded_info'])
 	.from('api_key')
 	.join('identity', 'identity', joinClause => joinClause.compareColumns(['api_key', 'identity_id'], Operator.eq, ['identity', 'id']))
 	.leftJoin(

--- a/packages/engine-tenant-api/src/model/service/AuthLogService.ts
+++ b/packages/engine-tenant-api/src/model/service/AuthLogService.ts
@@ -7,7 +7,7 @@ import { JSONValue } from '@contember/schema'
 class AuthLogService {
 	async logAuthAction(
 		db: DatabaseContext,
-		ctx: { identityId: string; clientIp?: string; userAgent?: string },
+		ctx: { identityId: string; clientIp?: string; userAgent?: string; forwarderIp?: string; forwarderUserAgent?: string },
 		data: AuthLogService.LogArgs,
 	): Promise<void> {
 		const dataContainer = data.response.ok
@@ -16,6 +16,17 @@ class AuthLogService {
 		const authData = typeof dataContainer === 'object' && dataContainer !== null && AuthLogService.Key in dataContainer
 			? dataContainer[AuthLogService.Key] as AuthLogService.Bag
 			: undefined
+
+		const baseMetadata = (data.metadata && typeof data.metadata === 'object' && !Array.isArray(data.metadata))
+			? data.metadata as Record<string, JSONValue>
+			: {}
+		const metadata: Record<string, JSONValue> = { ...baseMetadata }
+		if (ctx.forwarderIp !== undefined) {
+			metadata.forwarderIp = ctx.forwarderIp
+		}
+		if (ctx.forwarderUserAgent !== undefined) {
+			metadata.forwarderUserAgent = ctx.forwarderUserAgent
+		}
 
 		await db.commandBus.execute(
 			new CreateAuthLogEntryCommand({
@@ -30,7 +41,7 @@ class AuthLogService {
 				errorMessage: data.response.ok ? undefined : data.response.errorMessage,
 				ipAddress: ctx.clientIp,
 				userAgent: ctx.userAgent,
-				metadata: data.metadata ?? {},
+				metadata,
 				targetPersonId: data.targetPersonId,
 			}),
 		)

--- a/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
+++ b/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
@@ -22,6 +22,7 @@ class IDPSignInManager {
 		responseData: unknown,
 		expiration?: number,
 		requestInfo?: ApiKeyRequestInfo,
+		trustForwardedInfo?: boolean,
 	): Promise<IDPSignInManager.SignInIDPResponse> {
 		return dbContext.transaction(async (db): Promise<IDPSignInManager.SignInIDPResponse> => {
 			const provider = await db.queryHandler.fetch(new IdentityProviderBySlugQuery(idpSlug))
@@ -77,7 +78,7 @@ class IDPSignInManager {
 				})
 			}
 
-			const sessionToken = await this.apiKeyManager.createSessionApiKey(db, personRow.identity_id, expiration, requestInfo)
+			const sessionToken = await this.apiKeyManager.createSessionApiKey(db, personRow.identity_id, expiration, requestInfo, trustForwardedInfo)
 			return new ResponseOk({
 				person: personRow,
 				token: sessionToken,

--- a/packages/engine-tenant-api/src/model/service/PasswordlessSignInManager.ts
+++ b/packages/engine-tenant-api/src/model/service/PasswordlessSignInManager.ts
@@ -108,7 +108,7 @@ class PasswordlessSignInManager {
 		return urlObj.toString()
 	}
 
-	async signInPasswordless({ db, expiration, token, requestId, mfaOtp, validationType, requestInfo }: {
+	async signInPasswordless({ db, expiration, token, requestId, mfaOtp, validationType, requestInfo, trustForwardedInfo }: {
 		db: DatabaseContext
 		validationType: PersonToken.ValidationType
 		requestId: string
@@ -116,6 +116,7 @@ class PasswordlessSignInManager {
 		mfaOtp?: string
 		expiration?: number
 		requestInfo?: ApiKeyRequestInfo
+		trustForwardedInfo?: boolean
 	}): Promise<PasswordlessSignInManager.SignInPasswordlessResponse> {
 		return db.transaction(async (db): Promise<PasswordlessSignInManager.SignInPasswordlessResponse> => {
 			const tokenResult = await db.queryHandler.fetch(PersonTokenQuery.byId(requestId, 'passwordless'))
@@ -174,7 +175,7 @@ class PasswordlessSignInManager {
 			}
 
 			await db.commandBus.execute(new InvalidateTokenCommand(tokenValidationResult.result.id))
-			const sessionToken = await this.apiKeyManager.createSessionApiKey(db, personRow.identity_id, expiration, requestInfo)
+			const sessionToken = await this.apiKeyManager.createSessionApiKey(db, personRow.identity_id, expiration, requestInfo, trustForwardedInfo)
 
 			return new ResponseOk({
 				person: personRow,

--- a/packages/engine-tenant-api/src/model/service/SignInManager.ts
+++ b/packages/engine-tenant-api/src/model/service/SignInManager.ts
@@ -22,6 +22,7 @@ class SignInManager {
 		expiration?: number,
 		otpCode?: string,
 		requestInfo?: ApiKeyRequestInfo,
+		trustForwardedInfo?: boolean,
 	): Promise<SignInResponse> {
 		const person = await dbContext.queryHandler.fetch(PersonQuery.byEmail(email))
 
@@ -63,7 +64,7 @@ class SignInManager {
 			}
 		}
 
-		const sessionToken = await this.apiKeyManager.createSessionApiKey(dbContext, person.identity_id, expiration, requestInfo)
+		const sessionToken = await this.apiKeyManager.createSessionApiKey(dbContext, person.identity_id, expiration, requestInfo, trustForwardedInfo)
 
 		return new ResponseOk({ person, token: sessionToken, ...authLogData })
 	}
@@ -74,6 +75,7 @@ class SignInManager {
 		expiration?: number,
 		verifier?: (person: PersonRow) => Promise<void>,
 		requestInfo?: ApiKeyRequestInfo,
+		trustForwardedInfo?: boolean,
 	): Promise<CreateSessionTokenResponse> {
 		const person = await dbContext.queryHandler.fetch(PersonQuery.byUniqueIdentifier(personIdentifier))
 
@@ -107,7 +109,7 @@ class SignInManager {
 
 		await verifier?.(person)
 
-		const sessionToken = await this.apiKeyManager.createSessionApiKey(dbContext, person.identity_id, expiration, requestInfo)
+		const sessionToken = await this.apiKeyManager.createSessionApiKey(dbContext, person.identity_id, expiration, requestInfo, trustForwardedInfo)
 		return new ResponseOk({
 			person,
 			token: sessionToken,

--- a/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts
+++ b/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts
@@ -28,6 +28,7 @@ export class ApiKeyManager {
 		readDbContext: DatabaseContext,
 		token: string,
 		requestInfo?: ApiKeyRequestInfo,
+		forwardedInfo?: ApiKeyRequestInfo,
 	): Promise<VerifyResponse> {
 		const apiKeyRow = await readDbContext.queryHandler.fetch(new ApiKeyByTokenQuery(token))
 		if (apiKeyRow === null) {
@@ -46,6 +47,13 @@ export class ApiKeyManager {
 			return new ResponseError(VerifyErrorCode.DISABLED, `API key expired at ${apiKeyRow.expires_at.toISOString()}`)
 		}
 
+		const effectiveInfo: ApiKeyRequestInfo | undefined = apiKeyRow.trust_forwarded_info && forwardedInfo
+			? {
+				ip: forwardedInfo.ip ?? requestInfo?.ip,
+				userAgent: forwardedInfo.userAgent ?? requestInfo?.userAgent,
+			}
+			: requestInfo
+
 		setImmediate(async () => {
 			await dbContext.commandBus.execute(
 				new ProlongApiKeyCommand(
@@ -53,7 +61,7 @@ export class ApiKeyManager {
 					apiKeyRow.type,
 					apiKeyRow.expiration,
 					apiKeyRow.expires_at,
-					requestInfo,
+					effectiveInfo,
 					{
 						lastIp: apiKeyRow.last_ip,
 						lastUserAgent: apiKeyRow.last_user_agent,
@@ -63,7 +71,15 @@ export class ApiKeyManager {
 			)
 		})
 
-		return new ResponseOk(new VerifyResult(apiKeyRow.identity_id, apiKeyRow.id, apiKeyRow.roles, apiKeyRow.person_id))
+		return new ResponseOk(
+			new VerifyResult(
+				apiKeyRow.identity_id,
+				apiKeyRow.id,
+				apiKeyRow.roles,
+				apiKeyRow.person_id,
+				apiKeyRow.trust_forwarded_info,
+			),
+		)
 	}
 
 	async createSessionApiKey(
@@ -71,6 +87,7 @@ export class ApiKeyManager {
 		identityId: string,
 		expiration?: number,
 		requestInfo?: ApiKeyRequestInfo,
+		trustForwardedInfo?: boolean,
 	): Promise<string> {
 		const config = await dbContext.queryHandler.fetch(new ConfigurationQuery())
 		const expirationResolved = expiration ?? (intervalToSeconds(config.login.defaultTokenExpiration) / 60)
@@ -82,6 +99,7 @@ export class ApiKeyManager {
 			identityId,
 			expiration: expirationCapped,
 			requestInfo,
+			trustForwardedInfo,
 		})
 		const token = (await dbContext.commandBus.execute(command)).token
 		assert(token !== undefined)
@@ -111,9 +129,10 @@ export class ApiKeyManager {
 		description: string,
 		roles: readonly string[],
 		tokenHash?: TokenHash,
+		trustForwardedInfo?: boolean,
 	): Promise<CreateApiKeyResponse> {
 		return await dbContext.transaction(async db => {
-			return await this.apiKeyService.createPermanentApiKey(db, description, roles, tokenHash)
+			return await this.apiKeyService.createPermanentApiKey(db, description, roles, tokenHash, trustForwardedInfo)
 		})
 	}
 
@@ -123,9 +142,10 @@ export class ApiKeyManager {
 		memberships: readonly Acl.Membership[],
 		description: string,
 		tokenHash?: TokenHash,
+		trustForwardedInfo?: boolean,
 	): Promise<CreateApiKeyResponse> {
 		return await dbContext.transaction(async db => {
-			return await this.apiKeyService.createProjectPermanentApiKey(db, projectId, memberships, description, tokenHash)
+			return await this.apiKeyService.createProjectPermanentApiKey(db, projectId, memberships, description, tokenHash, trustForwardedInfo)
 		})
 	}
 }
@@ -140,6 +160,7 @@ export class VerifyResult {
 		public readonly apiKeyId: string,
 		public readonly roles: string[],
 		public readonly personId: string | null,
+		public readonly trustForwardedInfo: boolean = false,
 	) {}
 }
 

--- a/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyService.ts
+++ b/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyService.ts
@@ -13,9 +13,17 @@ export class ApiKeyService {
 		description: string,
 		roles: readonly string[] = [],
 		tokenHash?: TokenHash,
+		trustForwardedInfo?: boolean,
 	) {
 		const identityId = await db.commandBus.execute(new CreateIdentityCommand(roles, description))
-		const apiKeyResult = await db.commandBus.execute(new CreateApiKeyCommand({ type: ApiKey.Type.PERMANENT, identityId, tokenHash }))
+		const apiKeyResult = await db.commandBus.execute(
+			new CreateApiKeyCommand({
+				type: ApiKey.Type.PERMANENT,
+				identityId,
+				tokenHash,
+				trustForwardedInfo,
+			}),
+		)
 
 		return new ResponseOk(new CreateApiKeyResult({ id: identityId, description }, apiKeyResult))
 	}
@@ -26,8 +34,9 @@ export class ApiKeyService {
 		memberships: readonly Acl.Membership[],
 		description: string,
 		tokenHash?: TokenHash,
+		trustForwardedInfo?: boolean,
 	) {
-		const response = await this.createPermanentApiKey(db, description, [], tokenHash)
+		const response = await this.createPermanentApiKey(db, description, [], tokenHash, trustForwardedInfo)
 
 		const addMemberResult = await db.commandBus.execute(
 			new AddProjectMemberCommand(projectId, response.result.identity.id, createSetMembershipVariables(memberships)),

--- a/packages/engine-tenant-api/src/resolvers/TenantResolverContext.ts
+++ b/packages/engine-tenant-api/src/resolvers/TenantResolverContext.ts
@@ -9,6 +9,7 @@ export interface TenantResolverHttpInfo {
 
 export interface TenantResolverContext {
 	readonly apiKeyId: string
+	readonly trustForwardedInfo: boolean
 	readonly permissionContext: PermissionContext
 	readonly identity: Identity
 	readonly isAllowed: PermissionContext['isAllowed']

--- a/packages/engine-tenant-api/src/resolvers/TenantResolverContextFactory.ts
+++ b/packages/engine-tenant-api/src/resolvers/TenantResolverContextFactory.ts
@@ -3,9 +3,10 @@ import { DatabaseContext, PermissionContext, PermissionContextFactory } from '..
 import { Logger } from '@contember/logger'
 import { AuthLogService } from '../model/service/AuthLogService'
 
-export const createResolverContext = (permissionContext: PermissionContext, apiKeyId: string) => {
+export const createResolverContext = (permissionContext: PermissionContext, apiKeyId: string, trustForwardedInfo = false) => {
 	return {
 		apiKeyId: apiKeyId,
+		trustForwardedInfo,
 		permissionContext,
 		identity: permissionContext.identity,
 		isAllowed: permissionContext.isAllowed.bind(permissionContext),
@@ -21,8 +22,8 @@ export class TenantResolverContextFactory {
 	) {}
 
 	public create(
-		authContext: { apiKeyId: string; identityId: string; roles: string[] },
-		httpInfo: { ip: string; userAgent?: string },
+		authContext: { apiKeyId: string; identityId: string; roles: string[]; trustForwardedInfo?: boolean },
+		httpInfo: { ip: string; userAgent?: string; forwarderIp?: string; forwarderUserAgent?: string },
 		db: DatabaseContext,
 		logger: Logger,
 	): TenantResolverContext {
@@ -31,12 +32,14 @@ export class TenantResolverContextFactory {
 			roles: authContext.roles,
 		})
 		return {
-			...createResolverContext(permissionContext, authContext.apiKeyId),
+			...createResolverContext(permissionContext, authContext.apiKeyId, authContext.trustForwardedInfo ?? false),
 			logAuthAction: async data => {
 				await this.authLogService.logAuthAction(db, {
 					identityId: authContext.identityId,
 					userAgent: httpInfo.userAgent,
 					clientIp: httpInfo.ip,
+					forwarderIp: httpInfo.forwarderIp,
+					forwarderUserAgent: httpInfo.forwarderUserAgent,
 				}, data)
 			},
 			httpInfo: {

--- a/packages/engine-tenant-api/src/resolvers/mutation/apiKey/CreateApiKeyMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/apiKey/CreateApiKeyMutationResolver.ts
@@ -21,7 +21,7 @@ export class CreateApiKeyMutationResolver implements MutationResolvers {
 
 	async createApiKey(
 		parent: any,
-		{ projectSlug, memberships, description, tokenHash }: MutationCreateApiKeyArgs,
+		{ projectSlug, memberships, description, tokenHash, options }: MutationCreateApiKeyArgs,
 		context: TenantResolverContext,
 		info: GraphQLResolveInfo,
 	): Promise<CreateApiKeyResponse> {
@@ -47,7 +47,14 @@ export class CreateApiKeyMutationResolver implements MutationResolvers {
 			}
 		}
 
-		const result = await this.apiKeyManager.createProjectPermanentApiKey(context.db, project.id, memberships, description, tokenHash ?? undefined)
+		const result = await this.apiKeyManager.createProjectPermanentApiKey(
+			context.db,
+			project.id,
+			memberships,
+			description,
+			tokenHash ?? undefined,
+			options?.trustForwardedClientInfo === true,
+		)
 
 		return {
 			ok: true,
@@ -60,7 +67,7 @@ export class CreateApiKeyMutationResolver implements MutationResolvers {
 
 	async createGlobalApiKey(
 		parent: any,
-		{ roles, description, tokenHash }: MutationCreateGlobalApiKeyArgs,
+		{ roles, description, tokenHash, options }: MutationCreateGlobalApiKeyArgs,
 		context: TenantResolverContext,
 		info: GraphQLResolveInfo,
 	): Promise<CreateApiKeyResponse> {
@@ -72,7 +79,13 @@ export class CreateApiKeyMutationResolver implements MutationResolvers {
 		if (typeof tokenHash === 'string' && !isTokenHash(tokenHash)) {
 			throw new UserInputError('Invalid format of tokenHash. Must be hex-encoded sha256.')
 		}
-		const result = await this.apiKeyManager.createGlobalPermanentApiKey(context.db, description, roles, tokenHash ?? undefined)
+		const result = await this.apiKeyManager.createGlobalPermanentApiKey(
+			context.db,
+			description,
+			roles,
+			tokenHash ?? undefined,
+			options?.trustForwardedClientInfo === true,
+		)
 		return {
 			ok: true,
 			errors: [],

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/ForceSignOutMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/ForceSignOutMutationResolver.ts
@@ -21,6 +21,11 @@ export class ForceSignOutMutationResolver implements Pick<MutationResolvers, 'fo
 		const targetPerson = await this.personManager.findPersonById(context.db, args.personId)
 		const reason = args.reason ?? null
 
+		await context.requireAccess({
+			action: PermissionActions.PERSON_FORCE_SIGN_OUT(targetPerson?.roles ?? []),
+			message: 'You are not allowed to force sign out this person',
+		})
+
 		if (targetPerson === null) {
 			const response = new ResponseError('PERSON_NOT_FOUND', `Person <${args.personId}> was not found`)
 			await context.logAuthAction({
@@ -32,18 +37,12 @@ export class ForceSignOutMutationResolver implements Pick<MutationResolvers, 'fo
 			return createErrorResponse(response.error, response.errorMessage)
 		}
 
-		await context.requireAccess({
-			action: PermissionActions.PERSON_FORCE_SIGN_OUT(targetPerson.roles),
-			message: 'You are not allowed to force sign out this person',
-		})
-
 		await this.apiKeyManager.disableIdentityApiKeys(context.db, targetPerson.identity_id)
 
 		const response = new ResponseOk(null)
 		await context.logAuthAction({
 			type: 'forced_sign_out',
 			response,
-			personId: targetPerson.id,
 			targetPersonId: targetPerson.id,
 			metadata: reason !== null ? { reason } : undefined,
 		})

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/IDPMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/IDPMutationResolver.ts
@@ -47,6 +47,7 @@ export class IDPMutationResolver implements MutationResolvers {
 			},
 			args.expiration ?? undefined,
 			context.httpInfo,
+			args.options?.trustForwardedClientInfo === true && context.trustForwardedInfo,
 		)
 		await context.logAuthAction({
 			type: 'idp_login',

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/PasswordlessMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/PasswordlessMutationResolver.ts
@@ -68,6 +68,7 @@ export class PasswordlessMutationResolver
 			validationType: args.validationType,
 			expiration: args.expiration ?? undefined,
 			requestInfo: context.httpInfo,
+			trustForwardedInfo: args.options?.trustForwardedClientInfo === true && context.trustForwardedInfo,
 		})
 		await context.logAuthAction({
 			type: 'passwordless_login',

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/SignInMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/SignInMutationResolver.ts
@@ -35,6 +35,7 @@ export class SignInMutationResolver implements MutationResolvers {
 			args.expiration || undefined,
 			args.otpToken || undefined,
 			context.httpInfo,
+			args.options?.trustForwardedClientInfo === true && context.trustForwardedInfo,
 		)
 		await context.logAuthAction({
 			type: 'login',
@@ -84,6 +85,7 @@ export class SignInMutationResolver implements MutationResolvers {
 					message: 'You are not allowed to create a session key for this person.',
 				}),
 			context.httpInfo,
+			args.options?.trustForwardedClientInfo === true && context.trustForwardedInfo,
 		)
 		await context.logAuthAction({
 			type: 'create_session_token',

--- a/packages/engine-tenant-api/src/schema/index.ts
+++ b/packages/engine-tenant-api/src/schema/index.ts
@@ -344,6 +344,10 @@ export type CreateApiKeyError = {
 	readonly membershipValidation?: Maybe<ReadonlyArray<MembershipValidationError>>
 }
 
+export type CreateApiKeyOptions = {
+	readonly trustForwardedClientInfo?: InputMaybe<Scalars['Boolean']['input']>
+}
+
 export type CreateApiKeyErrorCode =
 	| 'INVALID_MEMBERSHIP'
 	| 'PROJECT_NOT_FOUND'
@@ -887,12 +891,14 @@ export type MutationConfirmOtpArgs = {
 export type MutationCreateApiKeyArgs = {
 	description: Scalars['String']['input']
 	memberships: ReadonlyArray<MembershipInput>
+	options?: InputMaybe<CreateApiKeyOptions>
 	projectSlug: Scalars['String']['input']
 	tokenHash?: InputMaybe<Scalars['String']['input']>
 }
 
 export type MutationCreateGlobalApiKeyArgs = {
 	description: Scalars['String']['input']
+	options?: InputMaybe<CreateApiKeyOptions>
 	roles?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>
 	tokenHash?: InputMaybe<Scalars['String']['input']>
 }
@@ -914,6 +920,7 @@ export type MutationCreateResetPasswordRequestArgs = {
 export type MutationCreateSessionTokenArgs = {
 	email?: InputMaybe<Scalars['String']['input']>
 	expiration?: InputMaybe<Scalars['Int']['input']>
+	options?: InputMaybe<SignInOptions>
 	personId?: InputMaybe<Scalars['String']['input']>
 }
 
@@ -997,6 +1004,7 @@ export type MutationSetProjectSecretArgs = {
 export type MutationSignInArgs = {
 	email: Scalars['String']['input']
 	expiration?: InputMaybe<Scalars['Int']['input']>
+	options?: InputMaybe<SignInOptions>
 	otpToken?: InputMaybe<Scalars['String']['input']>
 	password: Scalars['String']['input']
 }
@@ -1006,6 +1014,7 @@ export type MutationSignInIdpArgs = {
 	expiration?: InputMaybe<Scalars['Int']['input']>
 	identityProvider: Scalars['String']['input']
 	idpResponse?: InputMaybe<IdpResponseInput>
+	options?: InputMaybe<SignInOptions>
 	redirectUrl?: InputMaybe<Scalars['String']['input']>
 	sessionData?: InputMaybe<Scalars['Json']['input']>
 }
@@ -1013,6 +1022,7 @@ export type MutationSignInIdpArgs = {
 export type MutationSignInPasswordlessArgs = {
 	expiration?: InputMaybe<Scalars['Int']['input']>
 	mfaOtp?: InputMaybe<Scalars['String']['input']>
+	options?: InputMaybe<SignInOptions>
 	requestId: Scalars['String']['input']
 	token: Scalars['String']['input']
 	validationType: PasswordlessValidationType
@@ -1360,6 +1370,10 @@ export type SignInPasswordlessResult = CommonSignInResult & {
 	readonly token: Scalars['String']['output']
 }
 
+export type SignInOptions = {
+	readonly trustForwardedClientInfo?: InputMaybe<Scalars['Boolean']['input']>
+}
+
 export type SignInResponse = {
 	readonly __typename?: 'SignInResponse'
 	readonly error?: Maybe<SignInError>
@@ -1646,6 +1660,7 @@ export type ResolversTypes = {
 	ConfirmOtpResponse: ResolverTypeWrapper<ConfirmOtpResponse>
 	CreateApiKeyError: ResolverTypeWrapper<CreateApiKeyError>
 	CreateApiKeyErrorCode: CreateApiKeyErrorCode
+	CreateApiKeyOptions: CreateApiKeyOptions
 	CreateApiKeyResponse: ResolverTypeWrapper<Omit<CreateApiKeyResponse, 'result'> & { result?: Maybe<ResolversTypes['CreateApiKeyResult']> }>
 	CreateApiKeyResult: ResolverTypeWrapper<Omit<CreateApiKeyResult, 'apiKey'> & { apiKey: ResolversTypes['ApiKeyWithToken'] }>
 	CreatePasswordResetRequestError: ResolverTypeWrapper<CreatePasswordResetRequestError>
@@ -1768,6 +1783,7 @@ export type ResolversTypes = {
 	SignInIDPErrorCode: SignInIdpErrorCode
 	SignInIDPResponse: ResolverTypeWrapper<SignInIdpResponse>
 	SignInIDPResult: ResolverTypeWrapper<SignInIdpResult>
+	SignInOptions: SignInOptions
 	SignInPasswordlessError: ResolverTypeWrapper<SignInPasswordlessError>
 	SignInPasswordlessErrorCode: SignInPasswordlessErrorCode
 	SignInPasswordlessResponse: ResolverTypeWrapper<SignInPasswordlessResponse>
@@ -1841,6 +1857,7 @@ export type ResolversParentTypes = {
 	ConfirmOtpError: ConfirmOtpError
 	ConfirmOtpResponse: ConfirmOtpResponse
 	CreateApiKeyError: CreateApiKeyError
+	CreateApiKeyOptions: CreateApiKeyOptions
 	CreateApiKeyResponse: Omit<CreateApiKeyResponse, 'result'> & { result?: Maybe<ResolversParentTypes['CreateApiKeyResult']> }
 	CreateApiKeyResult: Omit<CreateApiKeyResult, 'apiKey'> & { apiKey: ResolversParentTypes['ApiKeyWithToken'] }
 	CreatePasswordResetRequestError: CreatePasswordResetRequestError
@@ -1934,6 +1951,7 @@ export type ResolversParentTypes = {
 	SignInIDPError: SignInIdpError
 	SignInIDPResponse: SignInIdpResponse
 	SignInIDPResult: SignInIdpResult
+	SignInOptions: SignInOptions
 	SignInPasswordlessError: SignInPasswordlessError
 	SignInPasswordlessResponse: SignInPasswordlessResponse
 	SignInPasswordlessResult: SignInPasswordlessResult

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -31,8 +31,8 @@ const schema: DocumentNode = gql`
 
 	type Mutation {
 		signUp(email: String!, password: String, passwordHash: String, roles: [String!], name: String): SignUpResponse
-		signIn(email: String!, password: String!, expiration: Int, otpToken: String): SignInResponse
-		createSessionToken(email: String, personId: String, expiration: Int): CreateSessionTokenResponse
+		signIn(email: String!, password: String!, expiration: Int, otpToken: String, options: SignInOptions): SignInResponse
+		createSessionToken(email: String, personId: String, expiration: Int, options: SignInOptions): CreateSessionTokenResponse
 		signOut(all: Boolean): SignOutResponse
 		changeProfile(personId: String!, email: String, name: String): ChangeProfileResponse
 		changeMyProfile(email: String, name: String): ChangeMyProfileResponse
@@ -48,6 +48,7 @@ const schema: DocumentNode = gql`
 			identityProvider: String!,
 			data: Json,
 			expiration: Int
+			options: SignInOptions
 			idpResponse: IDPResponseInput, @deprecated(reason: "pass idpResponse.url as data.url")
 			redirectUrl: String @deprecated(reason: "use data.redirectUrl"),
 			sessionData: Json @deprecated(reason: "use data.sessionData"),
@@ -55,7 +56,7 @@ const schema: DocumentNode = gql`
 		
 		# passwordless sign in
 		initSignInPasswordless(email: String!, options: InitSignInPasswordlessOptions): InitSignInPasswordlessResponse
-		signInPasswordless(requestId: String!, validationType: PasswordlessValidationType!, token: String!, expiration: Int, mfaOtp: String): SignInPasswordlessResponse
+		signInPasswordless(requestId: String!, validationType: PasswordlessValidationType!, token: String!, expiration: Int, mfaOtp: String, options: SignInOptions): SignInPasswordlessResponse
 		activatePasswordlessOtp(requestId: String!, token: String!, otpHash: String!): ActivatePasswordlessOtpResponse
 
         enableMyPasswordless: ToggleMyPasswordlessResponse
@@ -93,8 +94,8 @@ const schema: DocumentNode = gql`
 
 		updateProjectMember(projectSlug: String!, identityId: String!, memberships: [MembershipInput!]!): UpdateProjectMemberResponse
 
-		createApiKey(projectSlug: String!, memberships: [MembershipInput!]!, description: String!, tokenHash: String): CreateApiKeyResponse
-		createGlobalApiKey(description: String!, roles: [String!], tokenHash: String): CreateApiKeyResponse
+		createApiKey(projectSlug: String!, memberships: [MembershipInput!]!, description: String!, tokenHash: String, options: CreateApiKeyOptions): CreateApiKeyResponse
+		createGlobalApiKey(description: String!, roles: [String!], tokenHash: String, options: CreateApiKeyOptions): CreateApiKeyResponse
 		disableApiKey(id: String!): DisableApiKeyResponse
 		addGlobalIdentityRoles(identityId: String!, roles: [String!]!): AddGlobalIdentityRolesResponse
 		removeGlobalIdentityRoles(identityId: String!, roles: [String!]!): RemoveGlobalIdentityRolesResponse
@@ -241,6 +242,16 @@ const schema: DocumentNode = gql`
 	}
 
 	# === signIn ===
+	input SignInOptions {
+		"""
+		If true, and the calling api_key has trust_forwarded_info=true,
+		the resulting session token will trust X-Contember-Client-IP and
+		X-Contember-Client-User-Agent headers on subsequent requests.
+		Silently ignored when the caller's api_key does not have the flag.
+		"""
+		trustForwardedClientInfo: Boolean
+	}
+
 	type SignInResponse {
 		ok: Boolean!
 		errors: [SignInError!]! @deprecated
@@ -750,6 +761,17 @@ const schema: DocumentNode = gql`
 	}
 
 	# === createApiKey ===
+
+	input CreateApiKeyOptions {
+		"""
+		If true, the created api_key trusts X-Contember-Client-IP and
+		X-Contember-Client-User-Agent headers on subsequent requests.
+		Intended for backend services that proxy user requests; the customer's
+		proxy must strip these headers from incoming traffic and re-inject
+		them with the real user values.
+		"""
+		trustForwardedClientInfo: Boolean
+	}
 
 	type CreateApiKeyResponse {
 		ok: Boolean!

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/forceSignOutPersonMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/forceSignOutPersonMutation.test.ts
@@ -41,7 +41,6 @@ test('force sign-out – success with reason and mail', async () => {
 		},
 		expectedAuthLog: {
 			type: 'forced_sign_out',
-			personId,
 			targetPersonId: personId,
 			response: expect.objectContaining({ ok: true }),
 			metadata: { reason: 'security incident' },

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/gql/signIn.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/gql/signIn.ts
@@ -6,11 +6,12 @@ export const signInMutation = (
 		email: string
 		password: string
 		otpToken?: string
+		options?: { trustForwardedClientInfo?: boolean }
 	},
 	options: { withData?: boolean } = {},
 ): GraphQLTestQuery => ({
-	query: GQL`mutation($email: String!, $password: String!, $otpToken: String) {
-		signIn(email: $email, password: $password, otpToken: $otpToken) {
+	query: GQL`mutation($email: String!, $password: String!, $otpToken: String, $options: SignInOptions) {
+		signIn(email: $email, password: $password, otpToken: $otpToken, options: $options) {
 			ok
 			errors {code}
 			result {

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/revokeSessionMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/revokeSessionMutation.test.ts
@@ -1,4 +1,4 @@
-import { authenticatedApiKeyId, authenticatedIdentityId, executeTenantTest } from '../../../src/testTenant'
+import { authenticatedIdentityId, executeTenantTest } from '../../../src/testTenant'
 import { GQL } from '../../../src/tags'
 import { testUuid } from '../../../src/testUuid'
 import { getPersonByIdentity } from './sql/getPersonByIdentity'

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/sql/createApiKeySql.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/sql/createApiKeySql.ts
@@ -1,10 +1,10 @@
 import { SQL } from '../../../../src/tags'
 import { ExpectedQuery } from '@contember/database-tester'
 
-export const createApiKeySql = (args: { apiKeyId: string; identityId: string }): ExpectedQuery => ({
+export const createApiKeySql = (args: { apiKeyId: string; identityId: string; trustForwardedInfo?: boolean }): ExpectedQuery => ({
 	sql:
-		SQL`INSERT INTO "tenant"."api_key" ("id", "token_hash", "type", "identity_id", "disabled_at", "expires_at", "expiration", "created_at", "created_ip", "created_user_agent")
-	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		SQL`INSERT INTO "tenant"."api_key" ("id", "token_hash", "type", "identity_id", "disabled_at", "expires_at", "expiration", "created_at", "created_ip", "created_user_agent", "trust_forwarded_info")
+	         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	parameters: [
 		args.apiKeyId,
 		() => true,
@@ -16,6 +16,7 @@ export const createApiKeySql = (args: { apiKeyId: string; identityId: string }):
 		(val: any) => val instanceof Date,
 		null,
 		null,
+		args.trustForwardedInfo ?? false,
 	],
 	response: {
 		rowCount: 1,

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/sql/createSessionKeySql.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/sql/createSessionKeySql.ts
@@ -1,15 +1,16 @@
 import { SQL } from '../../../../src/tags'
 
-export const createSessionKeySql = function({ apiKeyId, identityId, ip, userAgent }: {
+export const createSessionKeySql = function({ apiKeyId, identityId, ip, userAgent, trustForwardedInfo }: {
 	apiKeyId: string
 	identityId: string
 	ip?: string | null
 	userAgent?: string | null
+	trustForwardedInfo?: boolean
 }) {
 	return {
 		sql: SQL`INSERT INTO "tenant"."api_key" ("id", "token_hash", "type", "identity_id", "disabled_at", "expires_at",
-												 "expiration", "created_at", "created_ip", "created_user_agent")
-				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+												 "expiration", "created_at", "created_ip", "created_user_agent", "trust_forwarded_info")
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		parameters: [
 			apiKeyId,
 			'9692e67b8378a6f6753f97782d458aa757e947eab2fbdf6b5c187b74561eb78f',
@@ -21,6 +22,7 @@ export const createSessionKeySql = function({ apiKeyId, identityId, ip, userAgen
 			new Date('2019-09-04 12:00'),
 			ip ?? null,
 			userAgent ?? null,
+			trustForwardedInfo ?? false,
 		],
 		response: { rowCount: 1 },
 	}

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getApiKeySql.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getApiKeySql.ts
@@ -4,10 +4,10 @@ import { ApiKey } from '../../../../../src'
 
 export const getApiKeySql = (args: {
 	apiKeyId: string
-	response: { identityId: string; personId: string; apiKeyType: ApiKey.Type }
+	response: { identityId: string; personId: string; apiKeyType: ApiKey.Type; trustForwardedInfo?: boolean }
 }): ExpectedQuery => ({
 	sql:
-		SQL`select "api_key"."id", "api_key"."type", "api_key"."identity_id", "api_key"."disabled_at", "api_key"."expires_at", "identity"."roles", "api_key"."expiration", "person"."id" as "person_id", "api_key"."last_ip", "api_key"."last_user_agent", "api_key"."last_used_at"
+		SQL`select "api_key"."id", "api_key"."type", "api_key"."identity_id", "api_key"."disabled_at", "api_key"."expires_at", "identity"."roles", "api_key"."expiration", "person"."id" as "person_id", "api_key"."last_ip", "api_key"."last_user_agent", "api_key"."last_used_at", "api_key"."trust_forwarded_info"
 		from "tenant"."api_key"
     	inner join "tenant"."identity" as "identity" on "api_key"."identity_id" = "identity"."id"
     	left join "tenant"."person" as "person" on "person"."identity_id" = "identity"."id"
@@ -29,6 +29,7 @@ export const getApiKeySql = (args: {
 					last_ip: null,
 					last_user_agent: null,
 					last_used_at: null,
+					trust_forwarded_info: args.response.trustForwardedInfo ?? false,
 				},
 			]
 			: [],

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/trustForwardedClientInfo.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/trustForwardedClientInfo.test.ts
@@ -1,0 +1,117 @@
+import { executeTenantTest } from '../../../src/testTenant'
+import { testUuid } from '../../../src/testUuid'
+import { selectMembershipsSql } from './sql/selectMembershipsSql'
+import { signInMutation } from './gql/signIn'
+import { getPersonByEmailSql } from './sql/getPersonByEmailSql'
+import { expect, test } from 'bun:test'
+import { createSessionKeySql } from './sql/createSessionKeySql'
+import { getIdentityProjectsSql } from './sql/getIdentityProjectsSql'
+import { getNextLoginAttemptSql } from './sql/getNextLoginAttemptSql'
+import { getConfigSql } from './sql/getConfigSql'
+import { GQL } from '../../../src/tags'
+import { sqlTransaction } from './sql/sqlTransaction'
+import { createIdentitySql } from './sql/createIdentitySql'
+import { createApiKeySql } from './sql/createApiKeySql'
+
+test('signIn: trustForwardedClientInfo=true is propagated when caller has the flag', async () => {
+	const email = 'john@doe.com'
+	const password = '123'
+	const identityId = testUuid(2)
+	const personId = testUuid(7)
+	const projectId = testUuid(10)
+	const apiKeyId = testUuid(1)
+	await executeTenantTest({
+		callerTrustForwardedInfo: true,
+		query: signInMutation({ email, password, options: { trustForwardedClientInfo: true } }),
+		executes: [
+			getNextLoginAttemptSql(email),
+			getPersonByEmailSql({ email, response: { personId, identityId, password, roles: [] } }),
+			getConfigSql(),
+			createSessionKeySql({ apiKeyId, identityId, trustForwardedInfo: true }),
+			getIdentityProjectsSql({ identityId, projectId }),
+			selectMembershipsSql({
+				identityId,
+				projectId,
+				membershipsResponse: [{ role: 'editor', variables: [] }],
+			}),
+		],
+		return: {
+			data: {
+				signIn: {
+					ok: true,
+					errors: [],
+					result: { token: '0000000000000000000000000000000000000000' },
+				},
+			},
+		},
+		expectedAuthLog: { type: 'login', response: expect.objectContaining({ ok: true }) },
+	})
+})
+
+test('signIn: trustForwardedClientInfo=true is silently dropped when caller has no flag', async () => {
+	const email = 'john@doe.com'
+	const password = '123'
+	const identityId = testUuid(2)
+	const personId = testUuid(7)
+	const projectId = testUuid(10)
+	const apiKeyId = testUuid(1)
+	await executeTenantTest({
+		callerTrustForwardedInfo: false,
+		query: signInMutation({ email, password, options: { trustForwardedClientInfo: true } }),
+		executes: [
+			getNextLoginAttemptSql(email),
+			getPersonByEmailSql({ email, response: { personId, identityId, password, roles: [] } }),
+			getConfigSql(),
+			createSessionKeySql({ apiKeyId, identityId, trustForwardedInfo: false }),
+			getIdentityProjectsSql({ identityId, projectId }),
+			selectMembershipsSql({
+				identityId,
+				projectId,
+				membershipsResponse: [{ role: 'editor', variables: [] }],
+			}),
+		],
+		return: {
+			data: {
+				signIn: {
+					ok: true,
+					errors: [],
+					result: { token: '0000000000000000000000000000000000000000' },
+				},
+			},
+		},
+		expectedAuthLog: { type: 'login', response: expect.objectContaining({ ok: true }) },
+	})
+})
+
+test('createGlobalApiKey: trustForwardedClientInfo=true creates permanent key with flag (no propagation needed)', async () => {
+	const identityId = testUuid(1)
+	const apiKeyId = testUuid(2)
+	await executeTenantTest({
+		callerTrustForwardedInfo: false,
+		query: {
+			query: GQL`mutation($description: String!, $roles: [String!], $options: CreateApiKeyOptions) {
+				createGlobalApiKey(description: $description, roles: $roles, options: $options) {
+					ok
+					errors { code }
+					result { apiKey { identity { id } } }
+				}
+			}`,
+			variables: { description: 'backend service', roles: [], options: { trustForwardedClientInfo: true } },
+		},
+		executes: [
+			...sqlTransaction(
+				createIdentitySql({ identityId, description: 'backend service' }),
+				createApiKeySql({ identityId, apiKeyId, trustForwardedInfo: true }),
+			),
+		],
+		return: {
+			data: {
+				createGlobalApiKey: {
+					ok: true,
+					errors: [],
+					result: { apiKey: { identity: { id: identityId } } },
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-tenant-api/tests/src/testTenant.ts
+++ b/packages/engine-tenant-api/tests/src/testTenant.ts
@@ -31,6 +31,8 @@ export interface Test {
 	return: object
 	sentMails?: ExpectedMessage[]
 	expectedAuthLog?: AuthLogService.LogArgs
+	callerTrustForwardedInfo?: boolean
+	httpInfo?: { ip?: string; userAgent?: string }
 }
 
 export const createUuidGenerator = () => {
@@ -115,6 +117,7 @@ export const executeTenantTest = async (test: Test) => {
 				projectSchemaResolver,
 			),
 			authenticatedApiKeyId,
+			test.callerTrustForwardedInfo ?? false,
 		),
 		logger: createLogger(new JsonStreamLoggerHandler(process.stderr)),
 		logAuthAction: async args => {
@@ -126,7 +129,7 @@ export const executeTenantTest = async (test: Test) => {
 			test.expectedAuthLog = undefined
 		},
 		db: databaseContext,
-		httpInfo: {},
+		httpInfo: test.httpInfo ?? {},
 	}
 
 	const schema = makeExecutableSchema({


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism for backends acting as session-token proxies to forward the original client's IP and User-Agent into Contember's audit log, session tracking, and content userInfo — solving the problem where a backend's IP/UA otherwise shadows the real user.

Stacks on top of #SESSION-PR (feat/session-visibility-and-force-logout — base PR adds the session-tracking columns this feature consumes).

## Mechanism

Per-api-key flag `trust_forwarded_info` (new column). When a request authenticates with such a key and carries `X-Contember-Client-IP` / `X-Contember-Client-User-Agent`, the HTTP layer treats those as the effective request origin. Otherwise the headers are ignored.

The flag is opt-in:
- **Permanent keys**: set explicitly at create via \`createApiKey\` / \`createGlobalApiKey\` (only existing API-key-create permission required).
- **Session keys**: requested via \`signIn\` / \`signInIDP\` / \`signInPasswordless\` / \`createSessionToken\` inputs, honored **only** when the caller's own api_key already has \`trust_forwarded_info=true\` — silent propagation rule (no new tenant role).

Auth log stores socket IP/UA as `forwarderIp` / `forwarderUserAgent` in `metadata` when forwarding was honored, so forensics can see both the user's claimed IP and the backend that vouched for it.

## Threat model & operator note

**Customers using this feature MUST strip incoming `X-Contember-Client-*` headers in their proxy and re-inject them with values they trust.** Without that, a browser holding a session token whose key has the flag could spoof its own IP — but session keys only acquire the flag if minted by a trusted backend, so in the typical setup (sign-in goes through the backend, but session token is later used both directly from browser and from backend) the flag is set at sign-in time and only the backend's proxy can add the headers; browser-direct requests carry no headers and the socket IP is used (which is correct — that IS the browser's IP).

No HMAC signature is required; the api_key itself is the trust anchor. Compromising a trusted permanent key is already game-over for that project, so this adds no new attack surface.

## What's NOT in this PR

- Surfacing the flag in \`mySessions\` UI (could add later if useful — flag is on api_key.trust_forwarded_info; just needs adding to ApiKeySessionsQuery).
- HMAC-signed forwarded headers as a Phase 2 alternative for higher-assurance deployments.

## Test plan

- [x] Bun tests pass (69/69 in engine-tenant-api)
- [x] \`signIn(..., trustForwardedClientInfo: true)\` with caller flag → session has flag (covered)
- [x] \`signIn(..., trustForwardedClientInfo: true)\` without caller flag → silently dropped (covered)
- [x] \`createGlobalApiKey(..., trustForwardedClientInfo: true)\` → permanent key has flag (covered)
- [ ] Manual: request with token marked trusted + X-Contember-Client-IP overrides socket IP in person_auth_log and api_key.last_ip
- [ ] Manual: request with token NOT marked trusted + headers present → headers ignored, socket IP used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/850)
<!-- Reviewable:end -->
