### PR TITLE
feat(engine-tenant-api): audit-log model extension + role/membership audit

### DIFF
--- a/packages/engine-tenant-api/src/migrations/2026-05-13-120000-auth-log-target-diff.ts
+++ b/packages/engine-tenant-api/src/migrations/2026-05-13-120000-auth-log-target-diff.ts
@@ -1,0 +1,20 @@
+import { MigrationBuilder } from '@contember/database-migrations'
+
+const sql = `
+ALTER TYPE auth_log_type ADD VALUE IF NOT EXISTS 'global_role_grant';
+ALTER TYPE auth_log_type ADD VALUE IF NOT EXISTS 'global_role_revoke';
+ALTER TYPE auth_log_type ADD VALUE IF NOT EXISTS 'project_membership_create';
+ALTER TYPE auth_log_type ADD VALUE IF NOT EXISTS 'project_membership_update';
+ALTER TYPE auth_log_type ADD VALUE IF NOT EXISTS 'project_membership_remove';
+
+ALTER TABLE person_auth_log
+	ADD COLUMN target_person_id UUID REFERENCES person(id) ON DELETE SET NULL,
+	ADD COLUMN change_diff JSONB;
+
+CREATE INDEX ON person_auth_log (target_person_id, created_at DESC)
+	WHERE target_person_id IS NOT NULL;
+`
+
+export default async function(builder: MigrationBuilder) {
+	builder.sql(sql)
+}

--- a/packages/engine-tenant-api/src/migrations/runner.ts
+++ b/packages/engine-tenant-api/src/migrations/runner.ts
@@ -40,6 +40,7 @@ import _20240620140000mailreply from './2024-06-20-140000-mail-reply'
 import _20240826120000passwordless from './2024-08-26-120000-passwordless'
 import _20250416180000configup from './2025-04-16-180000-config-up'
 import _20250417160000authlog from './2025-04-17-160000-auth-log'
+import _20260513120000authlogtargetdiff from './2026-05-13-120000-auth-log-target-diff'
 import snapshot from './snapshot'
 import { computeTokenHash, Providers } from '../model'
 import { Logger } from '@contember/logger'
@@ -92,6 +93,7 @@ const migrations = {
 	'2024-08-26-120000-passwordless': _20240826120000passwordless,
 	'2025-04-16-180000-config-up': _20250416180000configup,
 	'2025-04-17-160000-auth-log': _20250417160000authlog,
+	'2026-05-13-120000-auth-log-target-diff': _20260513120000authlogtargetdiff,
 }
 
 export class TenantMigrationsRunner {

--- a/packages/engine-tenant-api/src/migrations/snapshot.ts
+++ b/packages/engine-tenant-api/src/migrations/snapshot.ts
@@ -17,7 +17,12 @@ CREATE TYPE "auth_log_type" AS ENUM (
     'passwordless_login_init',
     'passwordless_login_exchange',
     'passwordless_login',
-    'person_disable'
+    'person_disable',
+    'global_role_grant',
+    'global_role_revoke',
+    'project_membership_create',
+    'project_membership_update',
+    'project_membership_remove'
 );
 CREATE TYPE "config_policy" AS ENUM (
     'always',
@@ -141,7 +146,9 @@ CREATE TABLE "person_auth_log" (
     "ip_address" "inet",
     "user_agent" "text",
     "identity_provider_id" "uuid",
-    "metadata" "jsonb"
+    "metadata" "jsonb",
+    "target_person_id" "uuid",
+    "change_diff" "jsonb"
 );
 CREATE TABLE "person_identity_provider" (
     "id" "uuid" NOT NULL,
@@ -230,6 +237,7 @@ CREATE UNIQUE INDEX "mail_template_identifier" ON "mail_template" USING "btree" 
 CREATE UNIQUE INDEX "mail_template_identifier_global" ON "mail_template" USING "btree" ("mail_type", "variant") WHERE ("project_id" IS NULL);
 CREATE INDEX "mail_template_project_index" ON "mail_template" USING "btree" ("project_id");
 CREATE INDEX "person_auth_log_person_input_identifier_created_at_idx" ON "person_auth_log" USING "btree" ("person_input_identifier", "created_at" DESC);
+CREATE INDEX "person_auth_log_target_person_id_created_at_idx" ON "person_auth_log" USING "btree" ("target_person_id", "created_at" DESC) WHERE ("target_person_id" IS NOT NULL);
 CREATE INDEX "person_identity_id" ON "person" USING "btree" ("identity_id");
 CREATE UNIQUE INDEX "person_identity_provider_identifier" ON "person_identity_provider" USING "btree" ("identity_provider_id", "external_identifier");
 CREATE INDEX "person_identity_provider_person_id" ON "person_identity_provider" USING "btree" ("person_id");
@@ -257,6 +265,8 @@ ALTER TABLE ONLY "person_auth_log"
     ADD CONSTRAINT "person_auth_log_person_id_fkey" FOREIGN KEY ("person_id") REFERENCES "person"("id") ON DELETE SET NULL;
 ALTER TABLE ONLY "person_auth_log"
     ADD CONSTRAINT "person_auth_log_person_token_id_fkey" FOREIGN KEY ("person_token_id") REFERENCES "person_token"("id") ON DELETE SET NULL;
+ALTER TABLE ONLY "person_auth_log"
+    ADD CONSTRAINT "person_auth_log_target_person_id_fkey" FOREIGN KEY ("target_person_id") REFERENCES "person"("id") ON DELETE SET NULL;
 ALTER TABLE ONLY "person"
     ADD CONSTRAINT "person_identity_id_fkey" FOREIGN KEY ("identity_id") REFERENCES "identity"("id");
 ALTER TABLE ONLY "person_identity_provider"

--- a/packages/engine-tenant-api/src/model/commands/authLog/CreateAuthLogEntryCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/authLog/CreateAuthLogEntryCommand.ts
@@ -26,6 +26,8 @@ export class CreateAuthLogEntryCommand implements Command<void> {
 				user_agent: this.data.userAgent,
 				identity_provider_id: this.data.identityProviderId,
 				metadata: this.data.metadata ?? {},
+				target_person_id: this.data.targetPersonId,
+				change_diff: this.data.changeDiff,
 			})
 			.execute(db)
 	}
@@ -45,5 +47,7 @@ namespace CreateAuthLogEntryCommand {
 		userAgent?: string
 		identityProviderId?: string
 		metadata?: JSONValue
+		targetPersonId?: string
+		changeDiff?: JSONValue
 	}
 }

--- a/packages/engine-tenant-api/src/model/service/AuthLogService.ts
+++ b/packages/engine-tenant-api/src/model/service/AuthLogService.ts
@@ -2,6 +2,7 @@ import { DatabaseContext } from '../utils'
 import { CreateAuthLogEntryCommand } from '../commands/authLog/CreateAuthLogEntryCommand'
 import { Response } from '../utils/Response'
 import { AuthActionType } from '../type/AuthLog'
+import { JSONValue } from '@contember/schema'
 
 class AuthLogService {
 	async logAuthAction(
@@ -30,6 +31,8 @@ class AuthLogService {
 				ipAddress: ctx.clientIp,
 				userAgent: ctx.userAgent,
 				metadata: {},
+				targetPersonId: data.targetPersonId,
+				changeDiff: data.changeDiff,
 			}),
 		)
 	}
@@ -42,6 +45,8 @@ namespace AuthLogService {
 		personInput?: string // e.g. email
 		tokenId?: string
 		identityProviderId?: string
+		targetPersonId?: string
+		changeDiff?: JSONValue
 	}
 
 	export type LogArgs = {

--- a/packages/engine-tenant-api/src/model/type/AuthLog.ts
+++ b/packages/engine-tenant-api/src/model/type/AuthLog.ts
@@ -12,3 +12,8 @@ export type AuthActionType =
 	| 'passwordless_login_exchange'
 	| 'passwordless_login'
 	| 'person_disable'
+	| 'global_role_grant'
+	| 'global_role_revoke'
+	| 'project_membership_create'
+	| 'project_membership_update'
+	| 'project_membership_remove'

--- a/packages/engine-tenant-api/src/resolvers/mutation/identity/GlobalRolesMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/identity/GlobalRolesMutationResolver.ts
@@ -7,9 +7,11 @@ import {
 } from '../../../schema'
 import { GraphQLResolveInfo } from 'graphql'
 import { TenantResolverContext } from '../../TenantResolverContext'
-import { PermissionActions } from '../../../model'
+import { PermissionActions, RolesManager } from '../../../model'
 import { createErrorResponse } from '../../errorUtils'
-import { RolesManager } from '../../../model'
+import { IdentityQuery } from '../../../model/queries/identity/IdentityQuery'
+import { PersonByIdentityBatchQuery } from '../../../model/queries/person/PersonByIdentityBatchQuery'
+import { ResponseOk } from '../../../model/utils/Response'
 
 export class IdentityGlobalRolesMutationResolver implements MutationResolvers {
 	constructor(
@@ -28,11 +30,14 @@ export class IdentityGlobalRolesMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to add global roles',
 		})
 
+		const [before] = await context.db.queryHandler.fetch(new IdentityQuery([identityId]))
 		const result = await this.rolesManager.addGlobalRoles(context.db, identityId, roles)
 
 		if (!result.ok) {
 			return createErrorResponse(result.error, result.errorMessage)
 		}
+
+		await this.logRolesChange(context, identityId, 'global_role_grant', before?.roles ?? [])
 
 		return {
 			ok: true,
@@ -53,11 +58,14 @@ export class IdentityGlobalRolesMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to remove global roles',
 		})
 
+		const [before] = await context.db.queryHandler.fetch(new IdentityQuery([identityId]))
 		const result = await this.rolesManager.removeGlobalRoles(context.db, identityId, roles)
 
 		if (!result.ok) {
 			return createErrorResponse(result.error, result.errorMessage)
 		}
+
+		await this.logRolesChange(context, identityId, 'global_role_revoke', before?.roles ?? [])
 
 		return {
 			ok: true,
@@ -65,5 +73,24 @@ export class IdentityGlobalRolesMutationResolver implements MutationResolvers {
 				identity: { id: identityId, projects: [] },
 			},
 		}
+	}
+
+	private async logRolesChange(
+		context: TenantResolverContext,
+		identityId: string,
+		auditType: 'global_role_grant' | 'global_role_revoke',
+		beforeRoles: readonly string[],
+	): Promise<void> {
+		const [after] = await context.db.queryHandler.fetch(new IdentityQuery([identityId]))
+		const [targetPerson] = await context.db.queryHandler.fetch(new PersonByIdentityBatchQuery([identityId]))
+		await context.logAuthAction({
+			type: auditType,
+			response: new ResponseOk(null),
+			targetPersonId: targetPerson?.id,
+			changeDiff: {
+				before: { roles: beforeRoles },
+				after: { roles: after?.roles ?? [] },
+			},
+		})
 	}
 }

--- a/packages/engine-tenant-api/src/resolvers/mutation/projectMember/AddProjectMemberMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/projectMember/AddProjectMemberMutationResolver.ts
@@ -3,6 +3,7 @@ import { TenantResolverContext } from '../../TenantResolverContext'
 import { MembershipValidator, PermissionActions, ProjectManager, ProjectMemberManager } from '../../../model'
 import { createMembershipValidationErrorResult } from '../../membershipUtils'
 import { createErrorResponse, createProjectNotFoundResponse } from '../../errorUtils'
+import { logProjectMembershipChange } from './audit'
 
 export class AddProjectMemberMutationResolver implements MutationResolvers {
 	constructor(
@@ -40,6 +41,8 @@ export class AddProjectMemberMutationResolver implements MutationResolvers {
 		if (!result.ok) {
 			return createErrorResponse(result.error, result.errorMessage)
 		}
+
+		await logProjectMembershipChange(context, 'project_membership_create', project.id, identityId, [])
 
 		return {
 			ok: true,

--- a/packages/engine-tenant-api/src/resolvers/mutation/projectMember/RemoveProjectMemberMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/projectMember/RemoveProjectMemberMutationResolver.ts
@@ -2,6 +2,8 @@ import { MutationRemoveProjectMemberArgs, MutationResolvers, RemoveProjectMember
 import { TenantResolverContext } from '../../TenantResolverContext'
 import { PermissionActions, ProjectManager, ProjectMemberManager } from '../../../model'
 import { createErrorResponse, createProjectNotFoundResponse } from '../../errorUtils'
+import { ProjectMembershipByIdentityQuery } from '../../../model/queries'
+import { logProjectMembershipChange } from './audit'
 
 export class RemoveProjectMemberMutationResolver implements MutationResolvers {
 	constructor(
@@ -36,11 +38,14 @@ export class RemoveProjectMemberMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to remove a project member',
 		})
 
+		const before = await context.db.queryHandler.fetch(new ProjectMembershipByIdentityQuery({ id: project.id }, [identityId]))
 		const result = await this.projectMemberManager.removeProjectMember(context.db, project.id, identityId)
 
 		if (!result.ok) {
 			return createErrorResponse(result.error, result.errorMessage)
 		}
+
+		await logProjectMembershipChange(context, 'project_membership_remove', project.id, identityId, before)
 
 		return {
 			ok: true,

--- a/packages/engine-tenant-api/src/resolvers/mutation/projectMember/UpdateProjectMemberMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/projectMember/UpdateProjectMemberMutationResolver.ts
@@ -5,6 +5,8 @@ import { createMembershipValidationErrorResult } from '../../membershipUtils'
 import { createMembershipModification } from '../../../model/service/membershipUtils'
 import { createErrorResponse, createProjectNotFoundResponse } from '../../errorUtils'
 import { Acl } from '@contember/schema'
+import { ProjectMembershipByIdentityQuery } from '../../../model/queries'
+import { logProjectMembershipChange } from './audit'
 
 export class UpdateProjectMemberMutationResolver implements MutationResolvers {
 	constructor(
@@ -62,11 +64,14 @@ export class UpdateProjectMemberMutationResolver implements MutationResolvers {
 			}
 		}
 
+		const before = await context.db.queryHandler.fetch(new ProjectMembershipByIdentityQuery({ id: project.id }, [identityId]))
 		const result = await this.projectMemberManager.updateProjectMember(context.db, project.id, identityId, membershipPatch)
 
 		if (!result.ok) {
 			return createErrorResponse(result.error, result.errorMessage)
 		}
+
+		await logProjectMembershipChange(context, 'project_membership_update', project.id, identityId, before)
 
 		return {
 			ok: true,

--- a/packages/engine-tenant-api/src/resolvers/mutation/projectMember/audit.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/projectMember/audit.ts
@@ -1,0 +1,35 @@
+import { Acl, JSONValue } from '@contember/schema'
+import { TenantResolverContext } from '../../TenantResolverContext'
+import { ProjectMembershipByIdentityQuery } from '../../../model/queries'
+import { PersonByIdentityBatchQuery } from '../../../model/queries/person/PersonByIdentityBatchQuery'
+import { ResponseOk } from '../../../model/utils/Response'
+import { AuthActionType } from '../../../model/type/AuthLog'
+
+export const logProjectMembershipChange = async (
+	context: TenantResolverContext,
+	auditType: Extract<AuthActionType, 'project_membership_create' | 'project_membership_update' | 'project_membership_remove'>,
+	projectId: string,
+	identityId: string,
+	before: readonly Acl.Membership[],
+): Promise<void> => {
+	const after = auditType === 'project_membership_remove'
+		? []
+		: await context.db.queryHandler.fetch(new ProjectMembershipByIdentityQuery({ id: projectId }, [identityId]))
+	const [targetPerson] = await context.db.queryHandler.fetch(new PersonByIdentityBatchQuery([identityId]))
+	await context.logAuthAction({
+		type: auditType,
+		response: new ResponseOk(null),
+		targetPersonId: targetPerson?.id,
+		changeDiff: {
+			projectId,
+			identityId,
+			before: before.map(membershipToJson),
+			after: after.map(membershipToJson),
+		},
+	})
+}
+
+const membershipToJson = ({ role, variables }: Acl.Membership): JSONValue => ({
+	role,
+	variables: variables.map(({ name, values }) => ({ name, values: [...values] })),
+})

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/addProjectMemberMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/addProjectMemberMutation.test.ts
@@ -1,10 +1,12 @@
-import { executeTenantTest } from '../../../src/testTenant'
+import { authenticatedIdentityId, executeTenantTest } from '../../../src/testTenant'
 import { testUuid } from '../../../src/testUuid'
 import { addProjectMemberMutation } from './gql/addProjectMember'
 import { getProjectBySlugSql } from './sql/getProjectBySlugSql'
 import { createMembershipSql } from './sql/createMembershipSql'
 import { createMembershipVariableSql } from './sql/createMembershipVariableSql'
 import { getProjectMembershipSql } from './sql/getProjectMembershipSql'
+import { selectMembershipsSql } from './sql/selectMembershipsSql'
+import { getPersonsByIdentitySql } from './sql/getPersonsByIdentitySql'
 import { sqlTransaction } from './sql/sqlTransaction'
 import { test } from 'bun:test'
 
@@ -14,6 +16,7 @@ test('add project member', async () => {
 	const projectSlug = 'blog'
 	const membershipId = testUuid(1)
 	const projectId = testUuid(5)
+	const personId = testUuid(7)
 	const role = 'editor'
 	const variableId = testUuid(2)
 	const variableName = 'language'
@@ -31,6 +34,15 @@ test('add project member', async () => {
 				createMembershipSql({ membershipId, projectId, identityId, role }),
 				createMembershipVariableSql({ variableId, membershipId, variableName, values }),
 			),
+			selectMembershipsSql({
+				identityId,
+				projectId,
+				membershipsResponse: [{ role, variables: [{ name: variableName, values }] }],
+			}),
+			getPersonsByIdentitySql({
+				identityIds: [identityId],
+				response: [{ personId, identityId, email: 'john@doe.com' }],
+			}),
 		],
 		return: {
 			data: {
@@ -38,6 +50,17 @@ test('add project member', async () => {
 					ok: true,
 					errors: [],
 				},
+			},
+		},
+		expectedAuthLog: {
+			type: 'project_membership_create',
+			response: { ok: true, result: null },
+			targetPersonId: personId,
+			changeDiff: {
+				projectId,
+				identityId,
+				before: [],
+				after: [{ role, variables: [{ name: variableName, values }] }],
 			},
 		},
 	})

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/globalIdentityRolesMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/globalIdentityRolesMutation.test.ts
@@ -1,0 +1,108 @@
+import { GQL, SQL } from '../../../src/tags'
+import { testUuid } from '../../../src/testUuid'
+import { executeTenantTest } from '../../../src/testTenant'
+import { getPersonsByIdentitySql } from './sql/getPersonsByIdentitySql'
+import { test } from 'bun:test'
+import { ExpectedQuery } from '@contember/database-tester'
+
+const selectIdentitySql = (args: { identityId: string; roles: readonly string[] }): ExpectedQuery => ({
+	sql: SQL`SELECT "id", "description", "roles" FROM "tenant"."identity" WHERE "id" IN (?)`,
+	parameters: [args.identityId],
+	response: {
+		rows: [{ id: args.identityId, description: null, roles: args.roles }],
+	},
+})
+
+const patchIdentityRolesSql = (args: {
+	identityId: string
+	add: readonly string[]
+	remove: readonly string[]
+}): ExpectedQuery => ({
+	sql: SQL`UPDATE "tenant"."identity" SET "roles" = (
+				SELECT JSONB_AGG(DISTINCT out_role)
+				FROM JSONB_ARRAY_ELEMENTS_TEXT(roles || ?::jsonb) t(out_role)
+				WHERE NOT(out_role = ANY (?::text[]))
+			) WHERE "id" = ?`,
+	parameters: [JSON.stringify(args.add), args.remove, args.identityId],
+	response: { rowCount: 1 },
+})
+
+test('adds a global identity role', async () => {
+	const identityId = testUuid(6)
+	const personId = testUuid(7)
+	const role = 'super_admin'
+	await executeTenantTest({
+		query: GQL`mutation {
+			addGlobalIdentityRoles(identityId: "${identityId}", roles: ["${role}"]) {
+				ok
+				error { code }
+			}
+		}`,
+		executes: [
+			selectIdentitySql({ identityId, roles: [] }),
+			patchIdentityRolesSql({ identityId, add: [role], remove: [] }),
+			selectIdentitySql({ identityId, roles: [role] }),
+			getPersonsByIdentitySql({
+				identityIds: [identityId],
+				response: [{ personId, identityId, email: 'john@doe.com' }],
+			}),
+		],
+		return: {
+			data: {
+				addGlobalIdentityRoles: {
+					ok: true,
+					error: null,
+				},
+			},
+		},
+		expectedAuthLog: {
+			type: 'global_role_grant',
+			response: { ok: true, result: null },
+			targetPersonId: personId,
+			changeDiff: {
+				before: { roles: [] },
+				after: { roles: [role] },
+			},
+		},
+	})
+})
+
+test('removes a global identity role', async () => {
+	const identityId = testUuid(6)
+	const personId = testUuid(7)
+	const role = 'super_admin'
+	await executeTenantTest({
+		query: GQL`mutation {
+			removeGlobalIdentityRoles(identityId: "${identityId}", roles: ["${role}"]) {
+				ok
+				error { code }
+			}
+		}`,
+		executes: [
+			selectIdentitySql({ identityId, roles: [role] }),
+			patchIdentityRolesSql({ identityId, add: [], remove: [role] }),
+			selectIdentitySql({ identityId, roles: [] }),
+			getPersonsByIdentitySql({
+				identityIds: [identityId],
+				response: [{ personId, identityId, email: 'john@doe.com' }],
+			}),
+		],
+		return: {
+			data: {
+				removeGlobalIdentityRoles: {
+					ok: true,
+					error: null,
+				},
+			},
+		},
+		expectedAuthLog: {
+			type: 'global_role_revoke',
+			response: { ok: true, result: null },
+			targetPersonId: personId,
+			changeDiff: {
+				before: { roles: [role] },
+				after: { roles: [] },
+			},
+		},
+	})
+})

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/removeProjectMemberMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/removeProjectMemberMutation.test.ts
@@ -4,11 +4,15 @@ import { executeTenantTest } from '../../../src/testTenant'
 import { selectMembershipsSql } from './sql/selectMembershipsSql'
 import { getProjectBySlugSql } from './sql/getProjectBySlugSql'
 import { sqlTransaction } from './sql/sqlTransaction'
+import { getPersonsByIdentitySql } from './sql/getPersonsByIdentitySql'
 import { test } from 'bun:test'
 
 test('removes a project member', async () => {
 	const identityId = testUuid(6)
 	const projectId = testUuid(5)
+	const personId = testUuid(7)
+	const role = 'editor'
+	const beforeMemberships = [{ role, variables: [] }]
 	await executeTenantTest({
 		query: GQL`mutation {
           removeProjectMember(projectSlug: "blog", identityId: "${identityId}") {
@@ -23,7 +27,12 @@ test('removes a project member', async () => {
 			selectMembershipsSql({
 				identityId,
 				projectId,
-				membershipsResponse: [{ role: 'editor', variables: [] }],
+				membershipsResponse: beforeMemberships,
+			}),
+			selectMembershipsSql({
+				identityId,
+				projectId,
+				membershipsResponse: beforeMemberships,
 			}),
 			...sqlTransaction({
 				sql: SQL`DELETE
@@ -34,6 +43,10 @@ test('removes a project member', async () => {
 					rowCount: 1,
 				},
 			}),
+			getPersonsByIdentitySql({
+				identityIds: [identityId],
+				response: [{ personId, identityId, email: 'john@doe.com' }],
+			}),
 		],
 		return: {
 			data: {
@@ -41,6 +54,17 @@ test('removes a project member', async () => {
 					ok: true,
 					errors: [],
 				},
+			},
+		},
+		expectedAuthLog: {
+			type: 'project_membership_remove',
+			response: { ok: true, result: null },
+			targetPersonId: personId,
+			changeDiff: {
+				projectId,
+				identityId,
+				before: beforeMemberships,
+				after: [],
 			},
 		},
 	})

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getPersonsByIdentitySql.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getPersonsByIdentitySql.ts
@@ -1,0 +1,23 @@
+import { ExpectedQuery } from '@contember/database-tester'
+import { SQL } from '../../../../src/tags'
+
+export const getPersonsByIdentitySql = (args: {
+	identityIds: readonly string[]
+	response: readonly { personId: string; identityId: string; email: string; password?: string; roles?: readonly string[] }[]
+}): ExpectedQuery => ({
+	sql:
+		SQL`SELECT "person"."id", "person"."password_hash", "person"."otp_uri", "person"."otp_activated_at", "person"."identity_id", "person"."email", "person"."name", "person"."disabled_at", "person"."passwordless_enabled", "identity"."roles"
+	         FROM "tenant"."person"
+		              INNER JOIN "tenant"."identity" AS "identity" ON "identity"."id" = "person"."identity_id"
+	         WHERE "person"."identity_id" IN (${args.identityIds.map(() => '?').join(', ')})`,
+	parameters: [...args.identityIds],
+	response: {
+		rows: args.response.map(it => ({
+			id: it.personId,
+			password_hash: it.password ? `BCRYPTED-${it.password}` : null,
+			identity_id: it.identityId,
+			roles: it.roles ?? [],
+			email: it.email,
+		})),
+	},
+})

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/updateProjectMemberMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/updateProjectMemberMutation.test.ts
@@ -6,6 +6,7 @@ import { getProjectBySlugSql } from './sql/getProjectBySlugSql'
 import { sqlTransaction } from './sql/sqlTransaction'
 import { getProjectMembershipSql } from './sql/getProjectMembershipSql'
 import { createMembershipSql } from './sql/createMembershipSql'
+import { getPersonsByIdentitySql } from './sql/getPersonsByIdentitySql'
 import { updateProjectMemberMutation } from './gql/updateProjectMember'
 import { test } from 'bun:test'
 
@@ -17,6 +18,7 @@ test('update project member', async () => {
 	const variableId = testUuid(2)
 	const languageId1 = testUuid(600)
 	const languageId2 = testUuid(500)
+	const personId = testUuid(7)
 	const role = 'editor'
 	const variableName = 'language'
 	await executeTenantTest({
@@ -35,6 +37,11 @@ test('update project member', async () => {
 				projectId: projectId,
 				membershipsResponse: [{ role, variables: [{ name: variableName, values: [languageId2] }] }],
 			}),
+			selectMembershipsSql({
+				identityId: identityId,
+				projectId: projectId,
+				membershipsResponse: [{ role, variables: [{ name: variableName, values: [languageId2] }] }],
+			}),
 			...sqlTransaction(
 				getProjectMembershipSql({ projectId, identityId }, true),
 				createMembershipSql({ identityId, projectId, membershipId, role }),
@@ -46,6 +53,15 @@ test('update project member', async () => {
 					id: variableId,
 				}),
 			),
+			selectMembershipsSql({
+				identityId,
+				projectId,
+				membershipsResponse: [{ role, variables: [{ name: variableName, values: [languageId1] }] }],
+			}),
+			getPersonsByIdentitySql({
+				identityIds: [identityId],
+				response: [{ personId, identityId, email: 'john@doe.com' }],
+			}),
 		],
 		return: {
 			data: {
@@ -53,6 +69,17 @@ test('update project member', async () => {
 					ok: true,
 					errors: [],
 				},
+			},
+		},
+		expectedAuthLog: {
+			type: 'project_membership_update',
+			response: { ok: true, result: null },
+			targetPersonId: personId,
+			changeDiff: {
+				projectId,
+				identityId,
+				before: [{ role, variables: [{ name: variableName, values: [languageId2] }] }],
+				after: [{ role, variables: [{ name: variableName, values: [languageId1] }] }],
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Implements PR 2 from the audit-log roadmap (spans F2 + A22):

- **F2** — extends `person_auth_log` with `target_person_id UUID NULL` (FK to `person`, `ON DELETE SET NULL`) and `change_diff JSONB NULL`. Adds five new `auth_log_type` values: `global_role_grant`, `global_role_revoke`, `project_membership_create`, `project_membership_update`, `project_membership_remove`. `AuthLogService.LogArgs` + `CreateAuthLogEntryCommand` accept the two new optional fields; existing call-sites untouched.
- **A22** — wires audit logging into `addGlobalIdentityRoles`, `removeGlobalIdentityRoles`, `addProjectMember`, `updateProjectMember`, `removeProjectMember`. Each writes an entry on success with `target_person_id` (resolved from affected identity → person) and a plain `{ before, after }` JSON diff.

### Design notes

- **Diff format**: plain `{ before, after }` snapshot (per PR plan recommendation — RFC 6902 is more precise but harder to grep in audit logs).
- **Audit layer**: lives at the resolver, not inside `RolesManager` / `ProjectMemberManager`. Keeps the public `Response<null, ...>` shapes unchanged and matches the existing `context.logAuthAction` pattern used by sign-in, change-password, disable-person, etc.
- **Signature flexibility for A23**: `logAuthAction(actionType, targetPersonId?, changeDiff?)` already supports adding more call-sites in `InviteManager`, `ApiKeyService`, `ProjectManager.createProject` etc. without further model changes.

### Conflict note

This PR independently adds `target_person_id` to `person_auth_log`. The parallel `feat/session-visibility-and-force-logout` branch (PR 1) also adds `target_person_id` in its own migration. When PR 1 lands first, this PR will need a rebase that drops the duplicate `ADD COLUMN` and keeps only `change_diff` + the new enum values.

## Test plan

- [x] `bun test packages/engine-tenant-api` — 56/56 pass
- [x] full repo `bun run test` — 1146/1146 pass (3 unrelated skips)
- [x] `bun run lint` — clean
- [x] `bun run format:check` — clean
- [x] `bun run ts:build` — no new errors (pre-existing `graphql-client-*` codegen errors are unrelated)
- [ ] Manual: run migration against a dev DB and verify `person_auth_log` schema + new enum values
- [ ] Manual: exercise mutations via GraphQL playground and inspect audit rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/851)
<!-- Reviewable:end -->
