### PR TITLE
feat(engine-http): HTTP-bound test transactions

### DIFF
--- a/docs/docs/reference/engine/content/advanced/test-transactions.md
+++ b/docs/docs/reference/engine/content/advanced/test-transactions.md
@@ -1,0 +1,103 @@
+---
+title: Test transactions
+---
+
+Test transactions let a test suite wrap a sequence of HTTP requests in a single database
+transaction that is rolled back when the test finishes. Each test then starts from the same
+already-seeded, committed baseline — without truncating and reseeding the database between tests.
+
+Inside such a transaction, writes from one request are visible to later requests in the same
+session, but nothing is ever committed: when the test ends, the whole transaction is rolled back
+and the baseline is restored.
+
+:::danger
+This feature pins and holds database connections and exposes uncommitted data, so it is a denial-of-service
+and data-visibility vector. It is **off by default** and the engine **refuses to start** with it
+enabled under `NODE_ENV=production`. Only enable it in test/CI environments.
+:::
+
+## Enabling
+
+Test transactions are opt-in via server configuration. When disabled (the default) the routes below
+are not registered and the session header is ignored.
+
+| Config | Environment variable | Default | Meaning |
+| --- | --- | --- | --- |
+| `test.transactions` | `CONTEMBER_TEST_TRANSACTIONS` | `false` | Enables the feature and registers the `/test/transaction` routes. |
+| `test.transactionTtlSeconds` | `CONTEMBER_TEST_TRANSACTION_TTL_SECONDS` | `60` | After this many seconds of inactivity, an abandoned session is automatically rolled back, so a crashed test cannot leak a pinned connection until the next restart. |
+
+```bash
+CONTEMBER_TEST_TRANSACTIONS=true \
+CONTEMBER_TEST_TRANSACTION_TTL_SECONDS=60 \
+node ./dist/server.js
+```
+
+## How it works
+
+- `POST /test/transaction` creates a **session** and returns a token. No database work happens yet.
+- Any Content API request that carries the `X-Contember-Test-Session: <token>` header is served over
+  the session's pinned transaction instead of the normal project connection. The transaction is
+  opened lazily — once per `(session, project)` — on the **write** connection and serves all reads
+  *and* writes, so a later request observes earlier requests' uncommitted changes.
+- The application's own `client.transaction()` calls nest as `SAVEPOINT`s inside the pinned
+  transaction (the engine's normal behavior), so nothing is committed.
+- `DELETE /test/transaction` with the `X-Contember-Test-Session` header rolls back every pinned
+  transaction of the session and drops it.
+
+The session header is read explicitly at the Content API controller — connection selection is
+deterministic and does not rely on async-context propagation.
+
+:::note
+Test transactions only affect the **Content API** (`/content/...`). Tenant and System API requests
+are not routed through the pinned transaction.
+:::
+
+A request that carries an unknown or expired session token is rejected with HTTP `400`.
+
+## Endpoints
+
+| Method | Path | Headers | Result |
+| --- | --- | --- | --- |
+| `POST` | `/test/transaction` | — | `200` with `{ "token": "<uuid>" }` |
+| `DELETE` | `/test/transaction` | `X-Contember-Test-Session: <token>` | `200` with `{ "ok": true }`, or `404` if the session is unknown |
+
+Then, on each Content API request that should run inside the transaction:
+
+```
+X-Contember-Test-Session: <token>
+```
+
+## Example
+
+```typescript
+const apiUrl = 'http://localhost:4000'
+
+async function withTestTransaction<T>(fn: (sessionHeaders: Record<string, string>) => Promise<T>): Promise<T> {
+  const beginRes = await fetch(`${apiUrl}/test/transaction`, { method: 'POST' })
+  if (!beginRes.ok) {
+    throw new Error(`Failed to begin test transaction (HTTP ${beginRes.status}). Is CONTEMBER_TEST_TRANSACTIONS=true?`)
+  }
+  const { token } = await beginRes.json() as { token: string }
+  try {
+    return await fn({ 'X-Contember-Test-Session': token })
+  } finally {
+    await fetch(`${apiUrl}/test/transaction`, {
+      method: 'DELETE',
+      headers: { 'X-Contember-Test-Session': token },
+    })
+  }
+}
+
+// Every request inside the callback runs in one transaction that is rolled back afterwards.
+await withTestTransaction(async sessionHeaders => {
+  await fetch(`${apiUrl}/content/my-project/live`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer <token>', ...sessionHeaders },
+    body: JSON.stringify({ query: `mutation { createAuthor(data: { name: "Kafka" }) { ok } }` }),
+  })
+
+  // A later request in the same session sees the uncommitted write above.
+  // ...
+})
+// After the callback the baseline is restored — the author above no longer exists.
+```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -168,6 +168,7 @@ const sidebars: SidebarsConfig = {
 								'reference/engine/content/advanced/assume-membership',
 								'reference/engine/content/advanced/request-debugging',
 								'reference/engine/content/advanced/caching',
+								'reference/engine/content/advanced/test-transactions',
 							],
 						},
 					],

--- a/e2e/cases/test-transaction.test.ts
+++ b/e2e/cases/test-transaction.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from 'bun:test'
+import { apiUrl, createTester, gql, withTestTransaction } from '../src/tester'
+import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
+
+namespace AuthorModel {
+	export class Author {
+		name = def.stringColumn().notNull()
+	}
+}
+
+// Test transactions are opt-in (CONTEMBER_TEST_TRANSACTIONS) and refuse to run under
+// NODE_ENV=production, so the endpoint is absent in the standard CI e2e run. Probe once and
+// skip when unavailable; run locally with the flag enabled.
+const testTransactionsAvailable = await (async (): Promise<boolean> => {
+	try {
+		const res = await fetch(apiUrl + '/test/transaction', { method: 'POST' })
+		if (!res.ok) {
+			return false
+		}
+		const { token } = await res.json() as { token: string }
+		await fetch(apiUrl + '/test/transaction', { method: 'DELETE', headers: { 'X-Contember-Test-Session': token } })
+		return true
+	} catch {
+		return false
+	}
+})()
+
+const countAuthors = async (tester: Awaited<ReturnType<typeof createTester>>): Promise<number> => {
+	const res = await tester(gql`query { paginateAuthor { pageInfo { totalCount } } }`).expect(200)
+	return res.body.data.paginateAuthor.pageInfo.totalCount
+}
+
+const createAuthor = (tester: Awaited<ReturnType<typeof createTester>>, name: string) =>
+	tester(gql`mutation($name: String!) { createAuthor(data: { name: $name }) { ok } }`, { variables: { name } }).expect(200)
+
+test.skipIf(!testTransactionsAvailable)('test transaction: writes inside are rolled back', async () => {
+	const tester = await createTester(createSchema(AuthorModel))
+
+	expect(await countAuthors(tester)).toBe(0)
+
+	await withTestTransaction(async () => {
+		await createAuthor(tester, 'Kafka')
+		await createAuthor(tester, 'Čapek')
+		// a later request in the same session sees earlier uncommitted writes
+		expect(await countAuthors(tester)).toBe(2)
+	})
+
+	// after rollback the baseline is restored
+	expect(await countAuthors(tester)).toBe(0)
+})
+
+test.skipIf(!testTransactionsAvailable)('test transaction: consecutive tests are isolated', async () => {
+	const tester = await createTester(createSchema(AuthorModel))
+
+	for (const name of ['a', 'b', 'c']) {
+		await withTestTransaction(async () => {
+			expect(await countAuthors(tester)).toBe(0)
+			await createAuthor(tester, name)
+			expect(await countAuthors(tester)).toBe(1)
+		})
+	}
+
+	expect(await countAuthors(tester)).toBe(0)
+})

--- a/e2e/src/tester.ts
+++ b/e2e/src/tester.ts
@@ -34,14 +34,22 @@ afterEach(() => {
 	// }
 })
 
+// PoC: when set, every GraphQL request carries the test-session header, so the engine
+// (with CONTEMBER_TEST_TRANSACTIONS=true) routes it through a rolled-back transaction.
+let testSessionToken: string | undefined
+
 export const executeGraphql = (
 	path: string,
 	query: string,
 	options: { authorizationToken?: string; variables?: Record<string, any>; keepExtensions?: boolean },
 ) => {
-	const result = supertest(apiUrl)
+	const request = supertest(apiUrl)
 		.post(path)
 		.set('Authorization', 'Bearer ' + (options.authorizationToken || rootToken))
+	if (testSessionToken) {
+		request.set('X-Contember-Test-Session', testSessionToken)
+	}
+	const result = request
 		.send({
 			query,
 			variables: options.variables || {},
@@ -99,6 +107,28 @@ const executeMigrations = async (projectSlug: string, modifications: Migration.M
 }
 
 export const rand = () => Math.random().toString(36).slice(2)
+
+/**
+ * PoC: run `fn` with all GraphQL requests bound to a fresh server-side transaction that is
+ * rolled back afterwards. Requires the engine to run with `CONTEMBER_TEST_TRANSACTIONS=true`.
+ */
+export const withTestTransaction = async <T>(fn: () => Promise<T>): Promise<T> => {
+	const beginRes = await fetch(apiUrl + '/test/transaction', { method: 'POST' })
+	if (!beginRes.ok) {
+		throw new Error(`Failed to begin test transaction (HTTP ${beginRes.status}). Is CONTEMBER_TEST_TRANSACTIONS=true?`)
+	}
+	const { token } = await beginRes.json() as { token: string }
+	testSessionToken = token
+	try {
+		return await fn()
+	} finally {
+		testSessionToken = undefined
+		await fetch(apiUrl + '/test/transaction', {
+			method: 'DELETE',
+			headers: { 'X-Contember-Test-Session': token },
+		})
+	}
+}
 
 export const createTester = async (schema: Schema) => {
 	const projectSlug = 'test_' + rand()

--- a/packages/engine-http/src/MasterContainer.ts
+++ b/packages/engine-http/src/MasterContainer.ts
@@ -48,6 +48,7 @@ import {
 } from './transfer'
 import { CryptoWrapper } from './utils/CryptoWrapper'
 import { ApplicationWorkerManager } from './workers'
+import { TestTransactionService } from './testing'
 
 export type ProcessType =
 	| 'singleNode'
@@ -201,18 +202,33 @@ export class MasterContainerFactory {
 					projectGroupContainerResolver,
 				)
 			})
+			.addService('testTransactionService', ({ serverConfig }) =>
+				new TestTransactionService(
+					serverConfig.test?.transactions ?? false,
+					(serverConfig.test?.transactionTtlSeconds ?? 60) * 1000,
+				))
 			.addService('notModifiedChecker', () => new NotModifiedChecker())
 			.addService('contentQueryHandlerFactory', ({ debugMode }) => new ContentQueryHandlerFactory(debugMode))
 			.addService('projectContextResolver', () => new ProjectContextResolver())
 			.addService(
 				'contentApiMiddlewareFactory',
-				({ projectContextResolver, notModifiedChecker, executionContainerFactory, contentQueryHandlerFactory, graphQlSchemaFactory }) =>
+				(
+					{
+						projectContextResolver,
+						notModifiedChecker,
+						executionContainerFactory,
+						contentQueryHandlerFactory,
+						graphQlSchemaFactory,
+						testTransactionService,
+					},
+				) =>
 					new ContentApiControllerFactory(
 						notModifiedChecker,
 						executionContainerFactory,
 						contentQueryHandlerFactory,
 						projectContextResolver,
 						graphQlSchemaFactory,
+						testTransactionService,
 					),
 			)
 			.addService('tenantApiMiddlewareFactory', () => new TenantApiMiddlewareFactory())
@@ -258,7 +274,14 @@ export class MasterContainerFactory {
 				'application',
 				(
 					it,
-					{ contentApiMiddlewareFactory, tenantApiMiddlewareFactory, systemApiMiddlewareFactory, importApiMiddlewareFactory, exportApiMiddlewareFactory },
+					{
+						contentApiMiddlewareFactory,
+						tenantApiMiddlewareFactory,
+						systemApiMiddlewareFactory,
+						importApiMiddlewareFactory,
+						exportApiMiddlewareFactory,
+						testTransactionService,
+					},
 				) => {
 					it.addRoute('content', '/content/:projectSlug/:stageSlug', contentApiMiddlewareFactory.create())
 					it.addRoute('tenant', '/tenant', tenantApiMiddlewareFactory.create())
@@ -270,6 +293,21 @@ export class MasterContainerFactory {
 					it.addInternalRoute('internal', '/health', () => {
 						return new HttpResponse(200, 'OK')
 					})
+
+					if (testTransactionService.isEnabled()) {
+						it.addInternalRoute('test', '/test/transaction', async ({ koa }) => {
+							const method = koa.request.method
+							if (method === 'POST') {
+								return new HttpResponse(200, JSON.stringify({ token: testTransactionService.begin() }), 'application/json')
+							}
+							if (method === 'DELETE') {
+								const token = koa.get('x-contember-test-session')
+								const ok = token ? await testTransactionService.rollback(token) : false
+								return new HttpResponse(ok ? 200 : 404, JSON.stringify({ ok }), 'application/json')
+							}
+							return new HttpResponse(405, JSON.stringify({ error: 'Method not allowed' }), 'application/json')
+						})
+					}
 				},
 			)
 			.addService('initializer', ({ projectGroupContainer }) => new Initializer(projectGroupContainer))

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -175,6 +175,10 @@ export const serverConfigSchema = Typesafe.partial({
 	monitoringPort: Typesafe.number,
 	workerCount: Typesafe.union(Typesafe.number, Typesafe.string),
 	applicationWorker: Typesafe.string,
+	test: Typesafe.partial({
+		transactions: Typesafe.boolean,
+		transactionTtlSeconds: Typesafe.number,
+	}),
 })
 
 export const stageConfig = Typesafe.record(

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -103,5 +103,9 @@ export const configTemplate: any = {
 				dsn: '%?env.SENTRY_DSN%',
 			},
 		},
+		test: {
+			transactions: '%?env.CONTEMBER_TEST_TRANSACTIONS::bool%',
+			transactionTtlSeconds: '%?env.CONTEMBER_TEST_TRANSACTION_TTL_SECONDS::number%',
+		},
 	},
 }

--- a/packages/engine-http/src/content/ContentApiControllerFactory.ts
+++ b/packages/engine-http/src/content/ContentApiControllerFactory.ts
@@ -1,5 +1,6 @@
 import { createAclVariables, ExecutionContainerFactory } from '@contember/engine-content-api'
 import { StageBySlugQuery } from '@contember/engine-system-api'
+import { Client } from '@contember/database'
 import { GraphQLSchema } from 'graphql'
 import { HttpController } from '../application'
 import { HttpErrorResponse, HttpResponse } from '../common'
@@ -8,8 +9,10 @@ import { ProjectContextResolver } from '../project-common'
 import { ContentQueryHandler, ContentQueryHandlerFactory } from './ContentQueryHandlerFactory'
 import { GraphQlSchemaFactory } from './GraphQlSchemaFactory'
 import { NotModifiedChecker } from './NotModifiedChecker'
+import { TestTransactionService } from '../testing'
 
 const debugHeader = 'x-contember-debug'
+const testSessionHeader = 'x-contember-test-session'
 
 export class ContentApiControllerFactory {
 	constructor(
@@ -18,6 +21,7 @@ export class ContentApiControllerFactory {
 		private readonly handlerFactory: ContentQueryHandlerFactory,
 		private readonly projectContextResolver: ProjectContextResolver,
 		private readonly graphQlSchemaFactory: GraphQlSchemaFactory,
+		private readonly testTransactionService: TestTransactionService,
 	) {
 	}
 
@@ -90,6 +94,27 @@ export class ContentApiControllerFactory {
 
 			const schemaDatabaseMetadata = await projectContainer.projectDatabaseMetadataResolver.resolveDatabaseMetadata(systemDatabase, schema, stage.schema)
 
+			// Test-transaction mode: if the request carries a session header, bind its content DB
+			// client to the session's pinned (rolled-back-later) transaction. Decided here, from the
+			// request itself — no async-context routing.
+			let testContentDatabase: Client | undefined
+			if (this.testTransactionService.isEnabled()) {
+				const headerValue = request.headers[testSessionHeader]
+				if (headerValue !== undefined) {
+					const token = Array.isArray(headerValue) ? headerValue[0] : headerValue
+					testContentDatabase = await this.testTransactionService.resolveContentClient(
+						token,
+						project.slug,
+						projectContainer.connection,
+						stage.schema,
+						{ module: 'content' },
+					)
+					if (!testContentDatabase) {
+						return new HttpErrorResponse(400, 'Unknown or expired test transaction session')
+					}
+				}
+			}
+
 			const handler = await (async () => {
 				const existingHandler = handlerCache.get(graphQlSchema)
 				if (existingHandler) {
@@ -113,7 +138,7 @@ export class ContentApiControllerFactory {
 							}
 
 							const connection = operation === 'query' ? projectContainer.readConnection : projectContainer.connection
-							const contentDatabase = connection.createClient(stage.schema, { module: 'content' })
+							const contentDatabase = testContentDatabase ?? connection.createClient(stage.schema, { module: 'content' })
 
 							const identityVariables = createAclVariables(schema.acl, memberships)
 							let identityId = authResult.identityId

--- a/packages/engine-http/src/index.ts
+++ b/packages/engine-http/src/index.ts
@@ -23,6 +23,7 @@ export * from './projectGroup/ProjectGroupContainer'
 export * from './projectGroup/ProjectGroupResolver'
 export type { ProjectGroupContainerResolver } from './projectGroup/ProjectGroupContainerResolver'
 
+export * from './testing'
 export * from './utils/serverStartup'
 export * from './utils/serverTermination'
 export * from './utils/sentry'

--- a/packages/engine-http/src/testing/TestTransactions.ts
+++ b/packages/engine-http/src/testing/TestTransactions.ts
@@ -1,0 +1,237 @@
+import { randomUUID } from 'node:crypto'
+import { Client, Connection, EventManager } from '@contember/database'
+
+/**
+ * HTTP-bound test transactions.
+ *
+ * Lets a test suite wrap a sequence of HTTP requests in a single database transaction that is
+ * rolled back afterwards, so each test starts from the same (already-seeded, committed) baseline
+ * without truncating/reseeding.
+ *
+ * Mechanism:
+ *  - `POST /test/transaction` creates a *session* (just a token, no DB work yet).
+ *  - The content API controller reads the `X-Contember-Test-Session` header off the request and,
+ *    when present, builds its DB client over the session's pinned transaction (via
+ *    {@link TestTransactionService.resolveContentClient}) instead of the project connection.
+ *    The pinned transaction is opened lazily, once per (session, project), on the *write*
+ *    connection and serves all reads + writes — so a later request observes earlier requests'
+ *    uncommitted changes.
+ *  - The app's own `client.transaction()` calls nest as SAVEPOINTs (existing behaviour), so
+ *    nothing is really committed.
+ *  - `DELETE /test/transaction` rolls the pinned transaction(s) back and drops the session.
+ *
+ * The header is read explicitly at the controller (no AsyncLocalStorage), so connection
+ * selection is deterministic and does not depend on async-context propagation.
+ *
+ * Enabled via `serverConfig.test.transactions` (env `CONTEMBER_TEST_TRANSACTIONS`). MUST NOT be
+ * enabled in production: a header that pins and holds DB transactions is a trivial DoS /
+ * data-visibility hole. Guards:
+ *  - hard refusal to construct when enabled together with `NODE_ENV=production`,
+ *  - abandoned sessions are auto-rolled-back after a TTL (`serverConfig.test.transactionTtlSeconds`,
+ *    env `CONTEMBER_TEST_TRANSACTION_TTL_SECONDS`, default 60s), so a crashed test cannot leak a
+ *    pinned connection until restart,
+ *  - service methods assert the feature is enabled (belt-and-suspenders on top of route gating).
+ */
+
+const SET_ISOLATION_LEVEL = /^\s*set\s+transaction\s+isolation\s+level/i
+const DEFAULT_SESSION_TTL_MS = 60_000
+
+interface ParkedTransaction {
+	transaction: Connection.TransactionLike
+	rollback: () => Promise<void>
+}
+
+interface TestSession {
+	token: string
+	/** Pinned transaction per project slug, opened lazily on first DB access. */
+	transactions: Map<string, Promise<ParkedTransaction>>
+	/** Wall-clock of the last activity; used to expire abandoned sessions. */
+	lastActiveAt: number
+}
+
+/**
+ * Opens a real transaction (BEGIN) and *parks* it open, returning a handle. The transaction
+ * stays open until `rollback()` is called, surviving across multiple HTTP requests.
+ *
+ * Implemented on top of the callback-scoped `connection.transaction()` API by holding the
+ * callback at an internal gate until rollback is requested.
+ */
+const openParkedTransaction = (connection: Connection): Promise<ParkedTransaction> => {
+	return new Promise<ParkedTransaction>((resolveHandle, rejectHandle) => {
+		let releaseGate: () => void = () => {}
+		const gate = new Promise<void>(resolve => {
+			releaseGate = resolve
+		})
+
+		const done = connection.transaction(async transaction => {
+			resolveHandle({
+				transaction,
+				rollback: async () => {
+					releaseGate()
+					await done
+				},
+			})
+			await gate
+			if (!transaction.isClosed) {
+				await transaction.rollback()
+			}
+		})
+
+		// surface a failure that happens before the handle is resolved (e.g. BEGIN failed)
+		done.catch(rejectHandle)
+	})
+}
+
+/**
+ * Wraps a TransactionLike and turns `SET TRANSACTION ISOLATION LEVEL ...` into a no-op.
+ * Inside an already-open transaction (we run the app inside the pinned one), setting the
+ * isolation level is illegal in PostgreSQL — and the content API issues it unconditionally
+ * at the start of every mutation transaction (MapperFactory). Swallowing it keeps that path
+ * working when it nests as a savepoint.
+ */
+class IsolationFilteringTransaction implements Connection.TransactionLike {
+	public readonly on: Connection.TransactionLike['on']
+
+	constructor(private readonly inner: Connection.TransactionLike) {
+		this.on = inner.on.bind(inner)
+	}
+
+	get eventManager(): EventManager {
+		return this.inner.eventManager
+	}
+
+	get isClosed(): boolean {
+		return this.inner.isClosed
+	}
+
+	async scope<Result>(
+		callback: (connection: Connection.TransactionLike) => Promise<Result> | Result,
+		options?: { eventManager?: EventManager },
+	): Promise<Result> {
+		return this.inner.scope(connection => callback(new IsolationFilteringTransaction(connection)), options)
+	}
+
+	async transaction<Result>(
+		callback: (connection: Connection.TransactionLike) => Promise<Result> | Result,
+		options?: { eventManager?: EventManager },
+	): Promise<Result> {
+		return this.inner.transaction(transaction => callback(new IsolationFilteringTransaction(transaction)), options)
+	}
+
+	async query<Row extends Record<string, any>>(
+		sql: string,
+		parameters: readonly any[] = [],
+		meta: Record<string, any> = {},
+	): Promise<Connection.Result<Row>> {
+		if (SET_ISOLATION_LEVEL.test(sql)) {
+			return { command: 'SET', rowCount: null, rows: [] }
+		}
+		return this.inner.query<Row>(sql, parameters as any[], meta)
+	}
+
+	async rollback(): Promise<void> {
+		return this.inner.rollback()
+	}
+
+	async commit(): Promise<void> {
+		return this.inner.commit()
+	}
+}
+
+export class TestTransactionService {
+	private readonly sessions = new Map<string, TestSession>()
+
+	constructor(
+		private readonly enabled: boolean,
+		private readonly ttlMs: number = DEFAULT_SESSION_TTL_MS,
+	) {
+		if (enabled && process.env.NODE_ENV === 'production') {
+			throw new Error(
+				'Test transactions (CONTEMBER_TEST_TRANSACTIONS) must not be enabled with NODE_ENV=production. '
+					+ 'This feature pins and holds database connections and exposes uncommitted data — it is a DoS / data-leak vector.',
+			)
+		}
+		if (enabled) {
+			// Auto-roll-back abandoned sessions so a crashed test cannot leak a pinned connection.
+			const sweep = setInterval(() => this.sweepExpired(), Math.max(1_000, Math.floor(ttlMs / 2)))
+			sweep.unref?.()
+		}
+	}
+
+	public isEnabled(): boolean {
+		return this.enabled
+	}
+
+	public hasSession(token: string): boolean {
+		return this.sessions.has(token)
+	}
+
+	private assertEnabled(): void {
+		if (!this.enabled) {
+			throw new Error('Test transactions are not enabled')
+		}
+	}
+
+	private sweepExpired(): void {
+		const now = Date.now()
+		for (const session of [...this.sessions.values()]) {
+			if (now - session.lastActiveAt > this.ttlMs) {
+				void this.rollback(session.token)
+			}
+		}
+	}
+
+	/** Create a new session and return its token. No DB work happens here. */
+	public begin(): string {
+		this.assertEnabled()
+		const token = randomUUID()
+		this.sessions.set(token, { token, transactions: new Map(), lastActiveAt: Date.now() })
+		return token
+	}
+
+	/** Roll back every pinned transaction of the session and drop it. */
+	public async rollback(token: string): Promise<boolean> {
+		const session = this.sessions.get(token)
+		if (!session) {
+			return false
+		}
+		this.sessions.delete(token)
+		await Promise.all(
+			[...session.transactions.values()].map(async parked => {
+				try {
+					await (await parked).rollback()
+				} catch {
+					// connection may already be gone; nothing to roll back to
+				}
+			}),
+		)
+		return true
+	}
+
+	/**
+	 * Build a content-API DB client backed by the session's pinned transaction for `projectSlug`,
+	 * opening (and pinning) that transaction on `writeConnection` on first use.
+	 * Returns undefined when the token does not refer to a known session.
+	 */
+	public async resolveContentClient(
+		token: string,
+		projectSlug: string,
+		writeConnection: Connection,
+		schema: string,
+		queryMeta: Record<string, any>,
+	): Promise<Client | undefined> {
+		this.assertEnabled()
+		const session = this.sessions.get(token)
+		if (!session) {
+			return undefined
+		}
+		session.lastActiveAt = Date.now()
+		let parked = session.transactions.get(projectSlug)
+		if (!parked) {
+			parked = openParkedTransaction(writeConnection)
+			session.transactions.set(projectSlug, parked)
+		}
+		const transaction = new IsolationFilteringTransaction((await parked).transaction)
+		return new Client(transaction, schema, queryMeta, new EventManager(transaction.eventManager))
+	}
+}

--- a/packages/engine-http/src/testing/index.ts
+++ b/packages/engine-http/src/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './TestTransactions'


### PR DESCRIPTION
## What

Adds an opt-in **test-transaction** mode to the engine so a test suite (userland apps or our own e2e) can wrap a sequence of HTTP requests in a single database transaction that is **rolled back afterwards**. Each test starts from the same committed baseline (seed) — no truncating, no reseeding between tests, deterministic data.

## How

- `POST /test/transaction` → creates a session (token only, no DB work).
- Requests carrying the `X-Contember-Test-Session` header have their **content DB client** built over the session's pinned transaction. The connection is chosen **explicitly at `ContentApiControllerFactory`** from the request — no `AsyncLocalStorage`, so selection is deterministic.
- The pinned transaction is opened lazily per project on the **write** connection and serves all reads + writes, so a later request in the same session observes earlier (uncommitted) writes. The app's own `client.transaction()` calls nest as **savepoints**, so nothing is committed.
- `DELETE /test/transaction` → rolls the pinned transaction(s) back and drops the session.

Only the content client is wrapped; schema/stage reads and migrations keep hitting the real connection (the committed baseline). A small `IsolationFilteringTransaction` turns the unconditional `SET TRANSACTION ISOLATION LEVEL` (issued by `MapperFactory`) into a no-op, since it is illegal inside the already-open pinned transaction.

Wired through DI as `testTransactionService`; the enable flag and TTL come from config.

## Safety / gating

- **Off by default** (`serverConfig.test.transactions`, env `CONTEMBER_TEST_TRANSACTIONS`).
- **Hard refusal to start** when enabled together with `NODE_ENV=production`.
- **Inert when disabled**: route is not registered, controller skips the path, header is ignored.
- **TTL auto-rollback** of abandoned sessions so a crashed test cannot leak a pinned connection (`serverConfig.test.transactionTtlSeconds`, env `CONTEMBER_TEST_TRANSACTION_TTL_SECONDS`, default 60s).
- **400** on unknown/expired session tokens (never a silent commit to the real DB).
- Defensive `assertEnabled()` on service methods.

> ⚠️ Not yet done (intentionally): authentication on the `/test/transaction` lifecycle endpoints. They are unauthenticated internal routes, protected today only by the enable flag + NODE_ENV guard.

## Testing

- Typecheck: `tsc --build engine-http` clean.
- e2e (`e2e/cases/test-transaction.test.ts`) against the docker engine with `CONTEMBER_TEST_TRANSACTIONS=true`: writes rolled back, later request sees earlier uncommitted writes, consecutive tests isolated. Regression (`events.test.ts`) passes with the flag on but no header (fallback).
- Verified live: NODE_ENV=production guard refuses start; TTL sweep removes an abandoned session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/858)
<!-- Reviewable:end -->
