### PR TITLE
test(e2e): deflake trustForwardedClientInfo session tracking

### DIFF
--- a/e2e/cases/tenant/trustForwardedClientInfo.test.ts
+++ b/e2e/cases/tenant/trustForwardedClientInfo.test.ts
@@ -72,27 +72,43 @@ test('signIn options.trustForwardedClientInfo: honored when caller api_key has t
 	// Path B: caller (root token) has trust=false → option is silently dropped → resulting session trust=false.
 	const untrustedToken = await signInWith(rootToken, email, password, { trustForwardedClientInfo: true })
 
-	// Warm-up: ensure last_* is populated for both keys by making one authenticated request with the headers.
 	const forwardedHeaders = {
 		'X-Contember-Client-IP': FORWARDED_IP,
 		'X-Contember-Client-User-Agent': FORWARDED_UA,
 	}
-	expect((await tenantWithHeaders(trustedToken, { query: `{ me { id } }` }, forwardedHeaders)).status).toBe(200)
-	expect((await tenantWithHeaders(untrustedToken, { query: `{ me { id } }` }, forwardedHeaders)).status).toBe(200)
 
-	const sessionsResp = await tenantWithHeaders(
-		trustedToken,
-		{ query: `{ me { sessions { id isCurrent trustForwardedClientInfo lastIp lastUserAgent } } }` },
-		forwardedHeaders,
-	)
-	expect(sessionsResp.status).toBe(200)
-	const sessions = sessionsResp.body.data.me.sessions as {
+	type Session = {
 		id: string
 		isCurrent: boolean
 		trustForwardedClientInfo: boolean
 		lastIp: string | null
 		lastUserAgent: string | null
-	}[]
+	}
+
+	// Session tracking (last_ip/last_user_agent/last_used_at) is written fire-and-forget via
+	// setImmediate after the auth response returns (see ApiKeyManager.verifyAndProlong), so it is
+	// eventually consistent. Re-trigger both sessions and poll until their lastIp lands, instead of
+	// reading once and racing the async write.
+	const readSessions = async (): Promise<Session[]> => {
+		expect((await tenantWithHeaders(trustedToken, { query: `{ me { id } }` }, forwardedHeaders)).status).toBe(200)
+		expect((await tenantWithHeaders(untrustedToken, { query: `{ me { id } }` }, forwardedHeaders)).status).toBe(200)
+		const resp = await tenantWithHeaders(
+			trustedToken,
+			{ query: `{ me { sessions { id isCurrent trustForwardedClientInfo lastIp lastUserAgent } } }` },
+			forwardedHeaders,
+		)
+		expect(resp.status).toBe(200)
+		return resp.body.data.me.sessions as Session[]
+	}
+
+	let sessions: Session[] = []
+	for (let attempt = 0; attempt < 20; attempt++) {
+		sessions = await readSessions()
+		if (sessions.length === 2 && sessions.every(s => s.lastIp !== null)) {
+			break
+		}
+		await Bun.sleep(50)
+	}
 	expect(sessions).toHaveLength(2)
 
 	const trusted = sessions.find(s => s.isCurrent)!


### PR DESCRIPTION
## Problem

The e2e test `signIn options.trustForwardedClientInfo …` is flaky in CI — intermittently failing on `expect(trusted.lastIp).toBe(FORWARDED_IP)` with `Expected: "198.51.100.5"`.

## Root cause

Session tracking (`last_ip` / `last_user_agent` / `last_used_at`) is written **fire-and-forget** via `setImmediate` *after* the auth response returns — see `ApiKeyManager.verifyAndProlong` (`packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts`). It's therefore eventually consistent. The test fired its warm-up requests and then read `{ me { sessions { lastIp } } }` immediately, racing that async write — so the read sometimes landed before the tracking commit and saw a null/stale `lastIp`.

## Fix

Poll the sessions query (re-triggering both sessions each round) until both `lastIp` values land, instead of reading once. **Production behaviour is unchanged** — the async tracking write is intentional and should not block the auth response.

Verified locally: ran the test 8× in a row against a fresh engine/DB, 8/8 green (previously raced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/contember/contember/868)
<!-- Reviewable:end -->
