### PR TITLE
ci: guard migration snapshot freshness and ordering

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,54 @@ jobs:
         run: ${{ matrix.run_script }}
 
 
+  snapshot:
+    # Guards that engine-{tenant,system}-api/src/migrations/snapshot.ts is in sync
+    # with the migrations: bootstraps two fresh DBs (full replay vs snapshot
+    # fast-path) and diffs their schemas. Fails if snapshot.ts drifted —
+    # regenerate with ./scripts/create-migrations-snapshot/run.sh <tenant|system>.
+    needs: [ ]
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+      - name: Install deps
+        run: |
+          bun --version
+          bun install --frozen-lockfile
+          sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Verify migrations snapshots
+        run: ./scripts/create-migrations-snapshot/verify.sh
+        env:
+          PGHOST: 127.0.0.1
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
+  migration-order:
+    # Guards that a PR does not introduce an engine migration whose filename
+    # sorts BEFORE the newest migration already on the base branch — such a
+    # migration would replay in a different relative order on a fresh DB than on
+    # an already-migrated production DB. Pure-git, no database needed.
+    needs: [ ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check migration ordering against base
+        run: ./scripts/migrations/check-migration-order.sh "origin/${{ github.base_ref || github.event.repository.default_branch }}"
+
   test-db:
     needs: [ ]
     runs-on: ubuntu-latest

--- a/scripts/create-migrations-snapshot/verify.sh
+++ b/scripts/create-migrations-snapshot/verify.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Verifies that the committed snapshot.ts is in sync with the migrations.
+#
+# Strategy (matches packages/engine-tenant-api/CLAUDE.md): bootstrap two fresh
+# databases through the REAL migrations runner and compare their schemas —
+#   A) CONTEMBER_MIGRATIONS_NO_SNAPSHOT=1  → replays every migration from scratch
+#   B) (default)                            → uses the snapshot fast-path
+# then schema-only pg_dump both and diff. They MUST be identical; a non-empty diff
+# means snapshot.ts drifted from the migrations and must be regenerated with:
+#   ./scripts/create-migrations-snapshot/run.sh <tenant|system>
+#
+# Why diff two live DBs instead of byte-comparing the committed snapshot.ts:
+# both dumps come from the SAME pg_dump binary, so client/server version quirks
+# (e.g. \restrict lines, formatting) cancel out. A byte-compare against the file
+# would flake across pg_dump versions; this checks the invariant we actually care
+# about — "snapshot bootstrap == full replay".
+#
+# Connects via standard PG* env vars, so it runs against a CI postgres service on
+# localhost as well as a local db. Override host/port/credentials via env:
+#   PGHOST (default 127.0.0.1) PGPORT (5432) PGUSER (contember) PGPASSWORD (contember)
+#
+# Usage:
+#   ./scripts/create-migrations-snapshot/verify.sh            # both tenant + system
+#   ./scripts/create-migrations-snapshot/verify.sh tenant
+#   ./scripts/create-migrations-snapshot/verify.sh system
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$( cd "$DIR/../.." && pwd )"
+
+export PGHOST="${PGHOST:-127.0.0.1}"
+export PGPORT="${PGPORT:-5432}"
+export PGUSER="${PGUSER:-contember}"
+export PGPASSWORD="${PGPASSWORD:-contember}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+command -v pg_dump >/dev/null || die "pg_dump not found on PATH (install postgresql-client)"
+command -v createdb >/dev/null || die "createdb not found on PATH (install postgresql-client)"
+
+# Normalize a dump so the two bootstraps compare cleanly. Applied IDENTICALLY to
+# both sides, so it can only remove constant noise — never hide a real difference.
+#   - comments carry the pg_dump version & timestamps; SET / set_config / \restrict
+#     are session setup, not schema.
+#   - strip the "<schema>." qualifier (constant, and pg_catalog refs are unqualified).
+#   - canonicalize uuid generation: replay creates & uses the migration-provided
+#     `uuid_generate_v4` fallback, while the snapshot uses built-in `gen_random_uuid`
+#     on modern PG (see snapshot-factory.ts / run.sh UUID_SED). That divergence is
+#     intentional and functionally equivalent, so we drop the fallback function's
+#     definition and map both names to one token before diffing.
+normalize() {
+	local schema="$1"
+	sed -E \
+		-e '/^--/d' \
+		-e '/^SET /d' \
+		-e '/^SELECT pg_catalog\.set_config/d' \
+		-e '/^\\(un)?restrict/d' \
+		-e "s/\"$schema\"\\.//g" \
+		-e '/^CREATE FUNCTION "uuid_generate_v4"\(\)/,/\$\$;/d' \
+		-e 's/"uuid_generate_v4"/"__random_uuid__"/g' \
+		-e 's/"gen_random_uuid"/"__random_uuid__"/g' \
+		-e '/^$/d'
+}
+
+dump_schema() {
+	local db="$1" schema="$2"
+	# exclude the migrations bookkeeping table/seq: replay has many rows & the
+	# table is framework-managed, snapshot excludes it too (see run.sh).
+	pg_dump --no-owner --no-acl --schema-only --schema="$schema" --quote-all-identifiers \
+		--exclude-table="$schema.migrations" --exclude-table="$schema.migrations_id_seq" \
+		--dbname="$db" | normalize "$schema"
+}
+
+verify_one() {
+	local type="$1" pkg schema
+	case "$type" in
+		tenant) pkg="engine-tenant-api"; schema="tenant" ;;
+		system) pkg="engine-system-api"; schema="system" ;;
+		*) die "invalid type: '$type' (expected tenant|system)" ;;
+	esac
+
+	local runner="$ROOT/packages/$pkg/src/bin/runMigrations.ts"
+	local db_replay="snapshot_verify_${type}_replay"
+	local db_snapshot="snapshot_verify_${type}_snapshot"
+
+	echo "→ [$type] bootstrapping two fresh databases on $PGHOST:$PGPORT"
+
+	for db in "$db_replay" "$db_snapshot"; do
+		dropdb --if-exists "$db" >/dev/null
+		createdb "$db" >/dev/null
+	done
+
+	# A) full replay of every migration
+	( cd "$ROOT" && PGDATABASE="$db_replay" CONTEMBER_MIGRATIONS_NO_SNAPSHOT=1 \
+		bun --conditions=typescript "$runner" >&2 )
+	# B) snapshot fast-path (fresh DB + no override → applies snapshot.ts only)
+	( cd "$ROOT" && PGDATABASE="$db_snapshot" \
+		bun --conditions=typescript "$runner" >&2 )
+
+	local diff_out
+	if diff_out="$(diff <(dump_schema "$db_replay" "$schema") <(dump_schema "$db_snapshot" "$schema"))"; then
+		echo "✓ [$type] snapshot matches migrations"
+		dropdb --if-exists "$db_replay" >/dev/null
+		dropdb --if-exists "$db_snapshot" >/dev/null
+		return 0
+	fi
+
+	echo "✗ [$type] snapshot.ts is OUT OF SYNC with the migrations" >&2
+	echo "  (< = full replay, > = snapshot fast-path)" >&2
+	echo "$diff_out" >&2
+	echo >&2
+	echo "  regenerate it with: ./scripts/create-migrations-snapshot/run.sh $type" >&2
+	dropdb --if-exists "$db_replay" >/dev/null
+	dropdb --if-exists "$db_snapshot" >/dev/null
+	return 1
+}
+
+types=("$@")
+[ ${#types[@]} -eq 0 ] && types=(tenant system)
+
+failed=0
+for t in "${types[@]}"; do
+	verify_one "$t" || failed=1
+done
+
+exit "$failed"

--- a/scripts/migrations/check-migration-order.sh
+++ b/scripts/migrations/check-migration-order.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Guards engine migration ordering.
+#
+# Engine migrations (packages/engine-{tenant,system}-api/src/migrations/*.ts) are
+# named YYYY-MM-DD-HHMMSS-<name>.ts and applied in that lexicographic order. A PR
+# must not introduce a migration that sorts BEFORE the newest migration already
+# on the base branch: such a "migration inserted in the past" would replay in a
+# different relative order on a fresh DB than on a production DB that already ran
+# the later migrations — diverging the two and breaking the snapshot invariant.
+#
+# This is a pure-git check (no database). For each package it compares the
+# migration set in the working tree against the base ref and fails if any NEW
+# migration name is <= the base branch's newest migration name.
+#
+# Usage:
+#   ./scripts/migrations/check-migration-order.sh [base-ref]   # default origin/main
+set -euo pipefail
+export LC_ALL=C   # deterministic byte-order string comparison/sort
+
+BASE="${1:-origin/main}"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$( cd "$DIR/../.." && pwd )"
+
+# YYYY-MM-DD-HHMMSS-<name>.ts — excludes runner.ts / snapshot.ts / index.ts.
+pat='^20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9]{6}-.*\.ts$'
+
+list_base() {    # $1 = repo-relative migrations dir
+	git -C "$ROOT" ls-tree -r --name-only "$BASE" -- "$1" 2>/dev/null \
+		| xargs -r -n1 basename | grep -E "$pat" | sort || true
+}
+list_current() { # $1 = absolute migrations dir
+	ls -1 "$1" 2>/dev/null | grep -E "$pat" | sort || true
+}
+
+git -C "$ROOT" rev-parse --verify --quiet "$BASE^{commit}" >/dev/null \
+	|| { echo "error: base ref '$BASE' not found (fetch it first, e.g. 'git fetch origin main')" >&2; exit 2; }
+
+failed=0
+for entry in "engine-tenant-api:tenant" "engine-system-api:system"; do
+	pkg="${entry%%:*}"
+	reldir="packages/$pkg/src/migrations"
+
+	base_list="$(list_base "$reldir")"
+	cur_list="$(list_current "$ROOT/$reldir")"
+
+	base_max="$(printf '%s\n' "$base_list" | grep -c . >/dev/null && printf '%s\n' "$base_list" | tail -n1 || true)"
+	if [ -z "$base_max" ]; then
+		echo "→ [$pkg] no migrations on $BASE — skipping"
+		continue
+	fi
+
+	# new = present now but not on the base ref
+	new_migrations="$(comm -13 <(printf '%s\n' "$base_list") <(printf '%s\n' "$cur_list") | grep -E "$pat" || true)"
+	if [ -z "$new_migrations" ]; then
+		echo "✓ [$pkg] no new migrations vs $BASE"
+		continue
+	fi
+
+	pkg_failed=0
+	while IFS= read -r m; do
+		[ -z "$m" ] && continue
+		if [[ ! "$m" > "$base_max" ]]; then
+			echo "✗ [$pkg] new migration '$m' sorts at or before base newest '$base_max'" >&2
+			pkg_failed=1
+		fi
+	done <<< "$new_migrations"
+
+	if [ "$pkg_failed" -eq 0 ]; then
+		count="$(printf '%s\n' "$new_migrations" | grep -c .)"
+		echo "✓ [$pkg] $count new migration(s) all sort after '$base_max'"
+	else
+		failed=1
+	fi
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo >&2
+	echo "A new migration must sort AFTER every migration already on the base branch." >&2
+	echo "Give it a current timestamp: YYYY-MM-DD-HHMMSS-<name>.ts" >&2
+fi
+exit "$failed"


### PR DESCRIPTION
Adds two CI jobs for engine migrations (`engine-{tenant,system}-api`), both previously unchecked.

## `snapshot` — snapshot drift guard
Bootstraps two fresh databases through the real migrations runner and diffs their schemas:
- **A)** `CONTEMBER_MIGRATIONS_NO_SNAPSHOT=1` → replays every migration from scratch
- **B)** default → uses the `snapshot.ts` fast-path

A non-empty diff means `snapshot.ts` drifted from the migrations and must be regenerated with `./scripts/create-migrations-snapshot/run.sh <tenant|system>`. Diffing two live DBs (rather than byte-comparing the committed file) means pg_dump version quirks cancel out — it checks the invariant we actually care about: *snapshot bootstrap == full replay*.

`verify.sh` is ported verbatim from `feat/tenant-security-bundle2`. Its only runtime dependency (`src/bin/runMigrations.ts`, which reads `PG*` env vars) already exists on `main` and is identical.

## `migration-order` — ordering guard
Pure-git check (no database): fails if a PR introduces a migration whose `YYYY-MM-DD-HHMMSS-*.ts` filename sorts **before** the newest migration already on the base branch. Such a "migration inserted in the past" would replay in a different relative order on a fresh DB than on an already-migrated production DB, diverging the two and breaking the snapshot invariant above.

## Why
Neither check existed. A stale snapshot was only caught indirectly (if e2e happened to hit a missing column); silent drift (missing index, wrong default, column order) slipped through. Migration ordering was entirely unguarded.

## Testing
- `snapshot`: runs against the postgres service in CI.
- `migration-order`: verified locally — old-timestamp new migration → fail with a clear message; future-timestamp → pass; no new migrations → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)