### PR TITLE
fix(react-repeater): initialize sortable item context in drag overlay

### DIFF
--- a/packages/react-repeater-dnd-kit/src/components/RepeaterSortableDragOverlay.tsx
+++ b/packages/react-repeater-dnd-kit/src/components/RepeaterSortableDragOverlay.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react'
-import { useRepeaterActiveEntity } from '../contexts'
+import { RepeaterSortableItemContext, useRepeaterActiveEntity } from '../contexts'
 import { Portal } from '@radix-ui/react-portal'
 import { DragOverlay } from '@dnd-kit/core'
-import { AccessorTree, Entity, useAccessorTreeState } from '@contember/react-binding'
+import { useSortable } from '@dnd-kit/sortable'
+import { AccessorTree, EntityAccessor, Entity, useAccessorTreeState } from '@contember/react-binding'
 import { RepeaterCurrentEntityContext } from '@contember/react-repeater'
 
 /**
@@ -22,11 +23,27 @@ export const RepeaterSortableDragOverlay = ({ children }: {
 				<AccessorTree state={accessorTreeState}>
 					<Entity accessor={activeItem}>
 						<RepeaterCurrentEntityContext.Provider value={activeItem}>
-							{children}
+							<RepeaterSortableDragOverlayItemContext activeItem={activeItem}>
+								{children}
+							</RepeaterSortableDragOverlayItemContext>
 						</RepeaterCurrentEntityContext.Provider>
 					</Entity>
 				</AccessorTree>
 			</DragOverlay>
 		</Portal>
+	)
+}
+
+const RepeaterSortableDragOverlayItemContext = ({ activeItem, children }: {
+	activeItem: EntityAccessor
+	children: ReactNode
+}) => {
+	const sortable = useSortable({
+		id: activeItem.id,
+	})
+	return (
+		<RepeaterSortableItemContext.Provider value={sortable}>
+			{children}
+		</RepeaterSortableItemContext.Provider>
 	)
 }

--- a/packages/react-repeater-dnd-kit/src/components/RepeaterSortableDragOverlay.tsx
+++ b/packages/react-repeater-dnd-kit/src/components/RepeaterSortableDragOverlay.tsx
@@ -3,7 +3,7 @@ import { RepeaterSortableItemContext, useRepeaterActiveEntity } from '../context
 import { Portal } from '@radix-ui/react-portal'
 import { DragOverlay } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
-import { AccessorTree, EntityAccessor, Entity, useAccessorTreeState } from '@contember/react-binding'
+import { AccessorTree, Entity, EntityAccessor, useAccessorTreeState } from '@contember/react-binding'
 import { RepeaterCurrentEntityContext } from '@contember/react-repeater'
 
 /**


### PR DESCRIPTION
## What & why

`RepeaterSortableDragOverlay` rendered its children without providing `RepeaterSortableItemContext`. As a result, calling `useRepeaterSortableItem` inside the drag overlay content threw, because the required context was never initialized there.

This wraps the overlay children with `RepeaterSortableItemContext.Provider`, initialized via `useSortable({ id: activeItem.id })` for the active/overlay item — mirroring how a normal sortable item provides that context in `RepeaterSortableEachItem`. No public API changes.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)