### PR TITLE
fix(schema-definition): do not require onDelete on view entity relations in strict mode

### DIFF
--- a/packages/schema-definition/src/createSchema.ts
+++ b/packages/schema-definition/src/createSchema.ts
@@ -17,13 +17,14 @@ export const createSchema = (definitions: Record<string, any>, modifyCallback?: 
 		strictDefinitionValidator: strictDefinitionValidator,
 		defaultCollation: options?.defaultCollation,
 	})
+	strictDefinitionValidator.validateModel(model)
 	const validation = InputValidation.parseDefinition(definitions)
 	const acl = AclDefinition.createAcl(definitions, model)
 	const actions = ActionsDefinition.createActions(definitions)
 	const schema = { ...emptySchema, model, validation, acl, actions }
 
 	if (strictDefinitionValidator.warnings.length > 0) {
-		throw `Strict schema validation failed: \n${strictDefinitionValidator.warnings.map(it => `- ${it.message}`).join('\n')}`
+		throw `Strict schema validation failed:\n${strictDefinitionValidator.warnings.map(it => `- ${it.message}`).join('\n')}`
 	}
 
 	return modifyCallback ? modifyCallback(schema) : schema

--- a/packages/schema-definition/src/strict.ts
+++ b/packages/schema-definition/src/strict.ts
@@ -12,8 +12,16 @@ export const allStrict: StrictOptions = {
 
 export type Warning = { message: string }
 
+type OnDeleteValidation = {
+	entityName: string
+	field: string
+	hasOnDelete: boolean
+}
+
 export class StrictDefinitionValidator {
 	public readonly warnings: Warning[] = []
+
+	private readonly onDeleteValidations: OnDeleteValidation[] = []
 
 	constructor(
 		private readonly options: StrictOptions,
@@ -27,10 +35,27 @@ export class StrictDefinitionValidator {
 	}
 
 	public validateOnCascade(entityName: string, field: string, definition: { onDelete?: Model.OnDelete }): void {
-		if (!definition.onDelete && this.options.requireOnDelete) {
-			this.registerWarning(
-				`${entityName}.${field}: onDelete behaviour is not set. Use one of cascadeOnDelete(), setNullOnDelete() or restrictOnDelete().`,
-			)
+		// View entities are read-only and have no real delete semantics, so onDelete validation is
+		// deferred to validateModel() where we know which entities are views.
+		this.onDeleteValidations.push({ entityName, field, hasOnDelete: definition.onDelete !== undefined })
+	}
+
+	public validateModel(model: Model.Schema): void {
+		for (const { entityName, field, hasOnDelete } of this.onDeleteValidations) {
+			const isView = model.entities[entityName]?.view !== undefined
+			if (isView) {
+				if (hasOnDelete) {
+					this.registerWarning(
+						`${entityName}.${field}: onDelete behaviour must not be set on a relation of a view entity. Views are read-only and have no delete semantics.`,
+					)
+				}
+				continue
+			}
+			if (!hasOnDelete && this.options.requireOnDelete) {
+				this.registerWarning(
+					`${entityName}.${field}: onDelete behaviour is not set. Use one of cascadeOnDelete(), setNullOnDelete() or restrictOnDelete().`,
+				)
+			}
 		}
 	}
 

--- a/packages/schema-definition/tests/cases/unit/createSchema.test.ts
+++ b/packages/schema-definition/tests/cases/unit/createSchema.test.ts
@@ -113,7 +113,56 @@ test('strict test', () => {
 			settings: settingsPresets['v1.3'],
 		}), { strict: true })
 
-	expect(cb).toThrow(`Strict schema validation failed: 
+	expect(cb).toThrow(`Strict schema validation failed:
 - Book.genre: inverse side of the relation is not defined.
 - Book.genre: onDelete behaviour is not set. Use one of cascadeOnDelete(), setNullOnDelete() or restrictOnDelete().`)
+})
+
+namespace StrictViewModel {
+	export class Author {
+		name = c.stringColumn()
+		stats = c.oneHasOneInverse(AuthorStats, 'author')
+	}
+
+	@c.View('SELECT 1')
+	export class AuthorStats {
+		author = c.oneHasOne(Author, 'stats')
+		postCount = c.intColumn().notNull()
+	}
+}
+
+test('strict test: onDelete is not required on a view entity relation', () => {
+	const cb = () =>
+		createSchema(StrictViewModel, schema => ({
+			...schema,
+			settings: settingsPresets['v1.3'],
+		}), { strict: true })
+
+	// AuthorStats.author has an inverse side defined and is a view relation, so neither the
+	// inverse-side nor the onDelete strict checks should fire.
+	expect(cb).not.toThrow()
+})
+
+namespace StrictViewWithOnDeleteModel {
+	export class Author {
+		name = c.stringColumn()
+		stats = c.oneHasOneInverse(AuthorStats, 'author')
+	}
+
+	@c.View('SELECT 1')
+	export class AuthorStats {
+		author = c.oneHasOne(Author, 'stats').cascadeOnDelete()
+		postCount = c.intColumn().notNull()
+	}
+}
+
+test('strict test: onDelete must not be set on a view entity relation', () => {
+	const cb = () =>
+		createSchema(StrictViewWithOnDeleteModel, schema => ({
+			...schema,
+			settings: settingsPresets['v1.3'],
+		}), { strict: true })
+
+	expect(cb).toThrow(`Strict schema validation failed:
+- AuthorStats.author: onDelete behaviour must not be set on a relation of a view entity. Views are read-only and have no delete semantics.`)
 })


### PR DESCRIPTION
## What & why

With `strict: true` schema validation, relations must declare an `onDelete` behaviour (`cascadeOnDelete()` / `setNullOnDelete()` / `restrictOnDelete()`). For `View` entities — read-only, backed by an SQL view, with no real FK or delete semantics — this requirement is meaningless.

This PR:

- **Primary fix:** No longer requires `onDelete` on relations whose owning entity is a `View`. The strict `onDelete` check is deferred to a post-build pass over the assembled `Model.Schema` (in `createSchema`), where view entities are known (`entity.view !== undefined`); view relations are skipped.
- **Secondary improvement (per the issue):** Emits a strict validation error when `onDelete` *is* explicitly set on a relation of a `View` entity, since it has no effect there.

### Implementation notes

The strict `onDelete` validation previously ran per-field during `createField`, which happens *before* the `@View(...)` entity extension is applied — so view status wasn't yet known at that point. The validator now records the per-relation onDelete state during field creation (preserving whether the user explicitly set it) and resolves it against the final model in `validateModel(model)`, invoked from `createSchema` right after the model is built. The inverse-side strict check is unchanged.

### Tests

Extended `packages/schema-definition/tests/cases/unit/createSchema.test.ts`:
- a view-relation model with no `onDelete` no longer throws under strict mode
- a view-relation model with `cascadeOnDelete()` throws the new "must not be set" error
- the existing non-view strict test still throws as before

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)