### PR TITLE
feat(database): configurable lock_timeout (lockTimeoutMs)

### DIFF
--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -23,5 +23,6 @@ export interface DatabaseConfig {
 	readonly ssl?: boolean
 	readonly queryTimeoutMs?: number
 	readonly statementTimeoutMs?: number
+	readonly lockTimeoutMs?: number
 	readonly connectionTimeoutMs?: number
 }

--- a/packages/database/src/utils/pgClientFactory.ts
+++ b/packages/database/src/utils/pgClientFactory.ts
@@ -3,10 +3,11 @@ import { DatabaseConfig } from '../types'
 import { PgClient } from '../client/PgClient'
 
 export type PgClientFactory = () => PgClient
-export const createPgClientFactory = ({ queryTimeoutMs, statementTimeoutMs, connectionTimeoutMs, ...config }: DatabaseConfig) => () => {
+export const createPgClientFactory = ({ queryTimeoutMs, statementTimeoutMs, lockTimeoutMs, connectionTimeoutMs, ...config }: DatabaseConfig) => () => {
 	return new pg.Client({
 		query_timeout: queryTimeoutMs,
 		statement_timeout: statementTimeoutMs,
+		lock_timeout: lockTimeoutMs,
 		connectionTimeoutMillis: connectionTimeoutMs,
 		...config,
 	})

--- a/packages/database/src/utils/pgClientFactory.ts
+++ b/packages/database/src/utils/pgClientFactory.ts
@@ -3,12 +3,16 @@ import { DatabaseConfig } from '../types'
 import { PgClient } from '../client/PgClient'
 
 export type PgClientFactory = () => PgClient
-export const createPgClientFactory = ({ queryTimeoutMs, statementTimeoutMs, lockTimeoutMs, connectionTimeoutMs, ...config }: DatabaseConfig) => () => {
-	return new pg.Client({
-		query_timeout: queryTimeoutMs,
-		statement_timeout: statementTimeoutMs,
-		lock_timeout: lockTimeoutMs,
-		connectionTimeoutMillis: connectionTimeoutMs,
-		...config,
-	})
-}
+export const createPgClientFactory =
+	({ queryTimeoutMs, statementTimeoutMs, lockTimeoutMs, connectionTimeoutMs, ...config }: DatabaseConfig) => () => {
+		// `lock_timeout` is supported by pg at runtime but missing from the installed @types/pg version,
+		// so it is typed explicitly here.
+		const clientConfig: pg.ClientConfig & { lock_timeout?: number } = {
+			query_timeout: queryTimeoutMs,
+			statement_timeout: statementTimeoutMs,
+			lock_timeout: lockTimeoutMs,
+			connectionTimeoutMillis: connectionTimeoutMs,
+			...config,
+		}
+		return new pg.Client(clientConfig)
+	}

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -14,6 +14,7 @@ const dbConfigOptional = {
 	ssl: Typesafe.boolean,
 	queryTimeoutMs: Typesafe.number,
 	statementTimeoutMs: Typesafe.number,
+	lockTimeoutMs: Typesafe.number,
 	connectionTimeoutMs: Typesafe.number,
 	pool: Typesafe.partial({
 		maxConnections: Typesafe.number,

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -3,6 +3,7 @@ const createDbConfigTemplate = (prefix: string) => {
 		ssl: `%?${prefix}_SSL::bool%`,
 		queryTimeoutMs: `%?${prefix}_QUERY_TIMEOUT_MS::number%`,
 		statementTimeoutMs: `%?${prefix}_STATEMENT_TIMEOUT_MS::number%`,
+		lockTimeoutMs: `%?${prefix}_LOCK_TIMEOUT_MS::number%`,
 		connectionTimeoutMs: `%?${prefix}_CONNECTION_TIMEOUT_MS::number%`,
 		pool: {
 			maxConnections: `%?${prefix}_POOL_MAX_CONNECTIONS::number%`,

--- a/packages/engine-http/src/transfer/ExportExecutor.ts
+++ b/packages/engine-http/src/transfer/ExportExecutor.ts
@@ -69,6 +69,7 @@ export class ExportExecutor {
 		const that = this
 		yield* asyncIterableTransaction(db, async function*(db) {
 			await db.query('SET LOCAL statement_timeout = 0')
+			await db.query('SET LOCAL lock_timeout = 0')
 			await db.query('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE')
 			for (const table of Object.values(mapping.tables)) {
 				yield* that.exportSequences(db, table)

--- a/packages/engine-http/src/transfer/ImportExecutor.ts
+++ b/packages/engine-http/src/transfer/ImportExecutor.ts
@@ -161,7 +161,7 @@ export class ImportExecutor {
 		const mapping = this.contentSchemaTransferMappingFactory.createContentSchemaMapping(contentSchema.schema)
 
 		return await contentDatabaseClient.transaction(async db => {
-			await this.disableStatementTimeout(db)
+			await this.disableTimeouts(db)
 			await this.disableTriggers(db, options.tables)
 			await this.lockTables(db, options.tables)
 			await this.truncateTables(db, options.tables)
@@ -200,7 +200,7 @@ export class ImportExecutor {
 		const mapping = this.systemSchemaTransferMappingFactory.build()
 
 		return await systemDatabaseContext.client.transaction(async db => {
-			await this.disableStatementTimeout(db)
+			await this.disableTimeouts(db)
 			await this.truncateTables(db, options.tables)
 
 			const metadata = await this.databaseMetadataResolver.resolveMetadata(db, db.schema)
@@ -348,8 +348,9 @@ export class ImportExecutor {
 		await db.query(`TRUNCATE ${tableNamesQuoted.join(', ')}`)
 	}
 
-	private async disableStatementTimeout(db: Client) {
+	private async disableTimeouts(db: Client) {
 		await db.query('SET LOCAL statement_timeout = 0')
+		await db.query('SET LOCAL lock_timeout = 0')
 	}
 
 	private async insertRows(db: Client, context: InsertContext) {

--- a/packages/engine-http/tests/cases/unit/configResolver.test.ts
+++ b/packages/engine-http/tests/cases/unit/configResolver.test.ts
@@ -44,6 +44,36 @@ it('resolves tenant config', () => {
 		secrets: {},
 	})
 })
+it('resolves tenant config with statement and lock timeouts', () => {
+	const envWithTimeouts = {
+		...env,
+		TENANT_DB_STATEMENT_TIMEOUT_MS: '30000',
+		TENANT_DB_LOCK_TIMEOUT_MS: '5000',
+	}
+	const tenantResolver = createTenantConfigResolver(envWithTimeouts, configTemplate.tenant)
+	const resolvedTenantConfig = tenantResolver('test', tenantConfig)
+	assert.deepEqual(resolvedTenantConfig, {
+		db: {
+			host: 'c0.cluster-abc.eu-west-1.rds.amazonaws.com',
+			port: 5432,
+			user: 'u_test_e',
+			password: 'PASSWD',
+			database: 'p_test_e',
+			connectionTimeoutMs: 5000,
+			statementTimeoutMs: 30000,
+			lockTimeoutMs: 5000,
+			pool: { maxConnections: 1000, maxConnecting: 10, idleTimeoutMs: 60000 },
+			read: {
+				host: 'c0.cluster-ro-abc.eu-west-1.rds.amazonaws.com',
+				pool: {},
+			},
+		},
+		mailer: {},
+		credentials: {},
+		secrets: {},
+	})
+})
+
 it('resolves tenant config with group slug env prefix', () => {
 	const envWithGroup = {
 		...env,


### PR DESCRIPTION
## What & why

Issue #410 asks for both statement and lock timeouts to be configurable in the database config. `statementTimeoutMs` was already implemented; this PR adds the missing `lockTimeoutMs`, mirroring the statement-timeout implementation end-to-end.

PostgreSQL's `lock_timeout` aborts any statement that waits longer than the given interval for a lock, which is useful to fail fast instead of blocking behind long-held locks. The `pg` client supports it natively as a connection option, exactly like `statement_timeout`.

## Changes

- `packages/database` — add `readonly lockTimeoutMs?: number` to `DatabaseConfig` and pass `lock_timeout: lockTimeoutMs` to the `pg.Client` in `pgClientFactory`.
- `packages/engine-http/config` — add `lockTimeoutMs` to the DB config schema and the config template, resolved from the `*_DB_LOCK_TIMEOUT_MS` env var (e.g. `TENANT_DB_LOCK_TIMEOUT_MS`, `PROJECT`/`DEFAULT_DB_LOCK_TIMEOUT_MS`, read-replica variants).
- `packages/engine-http/transfer` — import/export run as long transactions and already disable `statement_timeout`; they now also `SET LOCAL lock_timeout = 0` so a configured lock timeout cannot abort a transfer while locking/truncating tables. The import helper was renamed `disableStatementTimeout` → `disableTimeouts`.
- Test — extended `configResolver.test.ts` to assert both `statementTimeoutMs` and `lockTimeoutMs` resolve from env via the template.

## New config option

| Config key | Env var | Meaning |
|---|---|---|
| `db.lockTimeoutMs` | `<PREFIX>_DB_LOCK_TIMEOUT_MS` | Postgres `lock_timeout` in ms; aborts statements waiting too long for a lock. Optional. |

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)