### PR TITLE
feat(engine-http): opt-in X-Contember-Force-Ok header to always return HTTP 200

### DIFF
--- a/docs/src/content/docs/reference/engine/content/advanced/force-http-ok.mdx
+++ b/docs/src/content/docs/reference/engine/content/advanced/force-http-ok.mdx
@@ -1,0 +1,50 @@
+---
+title: Forcing HTTP 200 responses
+---
+
+Some GraphQL clients cannot properly handle non-200 HTTP status codes — for example, on an authentication failure Contember returns `401`, which such a client may treat as a hard transport error instead of reading the GraphQL error payload from the body.
+
+To work around this, Contember exposes an **opt-in** request header that forces the HTTP status of a GraphQL API response to `200`, while keeping all error information in the JSON body.
+
+## Usage
+
+Send the `X-Contember-Force-Ok` header with a truthy value (`1`, `true`, `on`, or `yes`) on any request to the Content (`/content/...`), Tenant (`/tenant`), or System (`/system/...`) API:
+
+```http
+POST /tenant HTTP/1.1
+Authorization: Bearer <token>
+X-Contember-Force-Ok: true
+Content-Type: application/json
+
+{ "query": "{ me { id } }" }
+```
+
+If the request would normally fail with a non-200 status (e.g. `401` on auth failure, `400` on a validation error), the response status is coerced to `200`. The original status is preserved in the `X-Contember-Original-Status` response header so clients and proxies can still observe it.
+
+```http
+HTTP/1.1 200 OK
+X-Contember-Original-Status: 401
+Content-Type: application/json
+
+{ "errors": [{ "code": 401, "message": "Authentication required" }] }
+```
+
+When the header is absent (the default), Contember returns the real status code unchanged. The coercion is scoped to the GraphQL API endpoints with a JSON body, so non-JSON or transport-level responses are never mislabeled.
+
+## Disabling the header
+
+The capability is enabled by default. To forbid it entirely (so the header is ignored and real status codes are always returned), set the config flag:
+
+```bash
+CONTEMBER_HTTP_RESPONSE_STATUS_HEADER=false
+```
+
+or in the server config:
+
+```yaml
+server:
+  http:
+    responseStatusHeader: false
+```
+
+Accepted values are boolean-ish strings: `true`/`1`/`on` to enable, `false`/`0`/`off` to disable.

--- a/docs/src/lib/nav.ts
+++ b/docs/src/lib/nav.ts
@@ -162,6 +162,7 @@ export const nav: NavItem[] = [
 							doc('reference/engine/content/advanced/assume-identity'),
 							doc('reference/engine/content/advanced/assume-membership'),
 							doc('reference/engine/content/advanced/request-debugging'),
+							doc('reference/engine/content/advanced/force-http-ok'),
 							doc('reference/engine/content/advanced/caching'),
 							doc('reference/engine/content/advanced/test-transactions'),
 						],

--- a/e2e/cases/tenant/forceHttpOk.test.ts
+++ b/e2e/cases/tenant/forceHttpOk.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'bun:test'
+import supertest from 'supertest'
+import { apiUrl } from '../../src/tester'
+
+const meQuery = `query { me { id } }`
+
+// X-Contember-Force-Ok lets clients opt in to receiving HTTP 200 even on auth failure,
+// keeping the error information in the JSON body. Some GraphQL clients cannot handle
+// non-200 status codes. See issue #398.
+
+test('auth failure returns 401 by default (no force-ok header)', async () => {
+	const resp = await supertest(apiUrl)
+		.post('/tenant')
+		.set('Authorization', 'Bearer invalidtoken0000000000000000000000000000000000000000')
+		.send({ query: meQuery })
+	expect(resp.status).toBe(401)
+})
+
+test('X-Contember-Force-Ok coerces auth failure to HTTP 200 with errors in body', async () => {
+	const resp = await supertest(apiUrl)
+		.post('/tenant')
+		.set('Authorization', 'Bearer invalidtoken0000000000000000000000000000000000000000')
+		.set('X-Contember-Force-Ok', 'true')
+		.send({ query: meQuery })
+	expect(resp.status).toBe(200)
+	expect(resp.headers['x-contember-original-status']).toBe('401')
+	// error information is preserved in the JSON body
+	expect(Array.isArray(resp.body.errors)).toBe(true)
+})
+
+test('X-Contember-Force-Ok leaves successful responses untouched', async () => {
+	const resp = await supertest(apiUrl)
+		.post('/tenant')
+		.set('Authorization', 'Bearer invalidtoken0000000000000000000000000000000000000000')
+		.set('X-Contember-Force-Ok', 'false')
+		.send({ query: meQuery })
+	expect(resp.status).toBe(401)
+})

--- a/e2e/cases/tenant/forceHttpOk.test.ts
+++ b/e2e/cases/tenant/forceHttpOk.test.ts
@@ -1,17 +1,22 @@
 import { expect, test } from 'bun:test'
 import supertest from 'supertest'
-import { apiUrl } from '../../src/tester'
+import { apiUrl, rootToken } from '../../src/tester.js'
 
 const meQuery = `query { me { id } }`
+const invalidToken = 'invalidtoken0000000000000000000000000000000000000000'
 
 // X-Contember-Force-Ok lets clients opt in to receiving HTTP 200 even on auth failure,
 // keeping the error information in the JSON body. Some GraphQL clients cannot handle
 // non-200 status codes. See issue #398.
+//
+// Note: the kill-switch (http.responseStatusHeader: false) cannot be exercised here — the
+// e2e engine runs with a single, default (enabled) config. That path is covered by the
+// shouldForceHttpOk unit tests in packages/engine-http.
 
 test('auth failure returns 401 by default (no force-ok header)', async () => {
 	const resp = await supertest(apiUrl)
 		.post('/tenant')
-		.set('Authorization', 'Bearer invalidtoken0000000000000000000000000000000000000000')
+		.set('Authorization', 'Bearer ' + invalidToken)
 		.send({ query: meQuery })
 	expect(resp.status).toBe(401)
 })
@@ -19,7 +24,7 @@ test('auth failure returns 401 by default (no force-ok header)', async () => {
 test('X-Contember-Force-Ok coerces auth failure to HTTP 200 with errors in body', async () => {
 	const resp = await supertest(apiUrl)
 		.post('/tenant')
-		.set('Authorization', 'Bearer invalidtoken0000000000000000000000000000000000000000')
+		.set('Authorization', 'Bearer ' + invalidToken)
 		.set('X-Contember-Force-Ok', 'true')
 		.send({ query: meQuery })
 	expect(resp.status).toBe(200)
@@ -28,11 +33,44 @@ test('X-Contember-Force-Ok coerces auth failure to HTTP 200 with errors in body'
 	expect(Array.isArray(resp.body.errors)).toBe(true)
 })
 
-test('X-Contember-Force-Ok leaves successful responses untouched', async () => {
+test('X-Contember-Force-Ok=false (falsy) does not coerce an auth failure', async () => {
 	const resp = await supertest(apiUrl)
 		.post('/tenant')
-		.set('Authorization', 'Bearer invalidtoken0000000000000000000000000000000000000000')
+		.set('Authorization', 'Bearer ' + invalidToken)
 		.set('X-Contember-Force-Ok', 'false')
 		.send({ query: meQuery })
 	expect(resp.status).toBe(401)
+	expect(resp.headers['x-contember-original-status']).toBeUndefined()
+})
+
+test('X-Contember-Force-Ok leaves a genuine 200 success untouched (no original-status header)', async () => {
+	const resp = await supertest(apiUrl)
+		.post('/tenant')
+		.set('Authorization', 'Bearer ' + rootToken)
+		.set('X-Contember-Force-Ok', 'true')
+		.send({ query: meQuery })
+	expect(resp.status).toBe(200)
+	// a real success must not be tagged as coerced
+	expect(resp.headers['x-contember-original-status']).toBeUndefined()
+	expect(resp.body.data?.me?.id).toBeDefined()
+})
+
+test('X-Contember-Force-Ok coerces auth failure on the system API', async () => {
+	const resp = await supertest(apiUrl)
+		.post('/system/nonexistent')
+		.set('Authorization', 'Bearer ' + invalidToken)
+		.set('X-Contember-Force-Ok', 'true')
+		.send({ query: `query { stages { id } }` })
+	expect(resp.status).toBe(200)
+	expect(resp.headers['x-contember-original-status']).toBe('401')
+})
+
+test('X-Contember-Force-Ok coerces auth failure on the content API', async () => {
+	const resp = await supertest(apiUrl)
+		.post('/content/nonexistent/live')
+		.set('Authorization', 'Bearer ' + invalidToken)
+		.set('X-Contember-Force-Ok', 'true')
+		.send({ query: `query { __typename }` })
+	expect(resp.status).toBe(200)
+	expect(resp.headers['x-contember-original-status']).toBe('401')
 })

--- a/packages/engine-http/CLAUDE.md
+++ b/packages/engine-http/CLAUDE.md
@@ -38,6 +38,7 @@ Two resolution modes:
 ## Key Files
 
 - `application/application.ts` — Koa app, route registration, request lifecycle
+- `application/forceHttpOk.ts` — opt-in `X-Contember-Force-Ok` header that coerces GraphQL API responses to HTTP 200 (errors stay in the JSON body); gated by `http.responseStatusHeader` config
 - `MasterContainer.ts` — DI container factory with all service definitions
 - `content/ContentApiControllerFactory.ts` — Content API: schema resolution, membership check, GraphQL execution
 - `projectGroup/ProjectGroupResolver.ts` — Tenant resolution

--- a/packages/engine-http/src/application/application.ts
+++ b/packages/engine-http/src/application/application.ts
@@ -17,7 +17,7 @@ import { URL } from 'node:url'
 import { cpuUsage, memoryUsage } from 'node:process'
 import { performance } from 'node:perf_hooks'
 import { getClientIP } from '../utils/remoteAddress.js'
-import { isForceHttpOkRequested, isGraphqlModule } from './forceHttpOk.js'
+import { isForceHttpOkRequested, shouldForceHttpOk } from './forceHttpOk.js'
 
 type Route<C> = { match: RequestMatcher; controller: C; module: string }
 export class Application {
@@ -311,19 +311,14 @@ export class Application {
 	 * are not mislabeled. Default behavior (real status codes) is preserved when the header is absent.
 	 */
 	private maybeForceHttpOk(ctx: KoaContext<{}>, module: string | undefined) {
-		if (!this.forceHttpOkEnabled) {
-			return
-		}
-		if (ctx.status === 200) {
-			return
-		}
-		if (!isGraphqlModule(module)) {
-			return
-		}
-		if (ctx.body === undefined || ctx.body === null) {
-			return
-		}
-		if (!isForceHttpOkRequested(ctx.req)) {
+		const coerce = shouldForceHttpOk({
+			enabled: this.forceHttpOkEnabled,
+			status: ctx.status,
+			module,
+			hasBody: ctx.body !== undefined && ctx.body !== null,
+			headerRequested: isForceHttpOkRequested(ctx.req),
+		})
+		if (!coerce) {
 			return
 		}
 		ctx.set('X-Contember-Original-Status', String(ctx.status))

--- a/packages/engine-http/src/application/application.ts
+++ b/packages/engine-http/src/application/application.ts
@@ -17,6 +17,7 @@ import { URL } from 'node:url'
 import { cpuUsage, memoryUsage } from 'node:process'
 import { performance } from 'node:perf_hooks'
 import { getClientIP } from '../utils/remoteAddress.js'
+import { isForceHttpOkRequested, isGraphqlModule } from './forceHttpOk.js'
 
 type Route<C> = { match: RequestMatcher; controller: C; module: string }
 export class Application {
@@ -28,6 +29,7 @@ export class Application {
 
 	private suppressAccessLog: boolean | RegExp
 	private trustedProxies: string[]
+	private forceHttpOkEnabled: boolean
 
 	constructor(
 		private readonly projectGroupResolver: ProjectGroupResolver,
@@ -39,6 +41,7 @@ export class Application {
 		const suppressAccessLogRaw = serverConfig.http?.suppressAccessLog
 		this.suppressAccessLog = suppressAccessLogRaw === true ? true : suppressAccessLogRaw ? new RegExp(suppressAccessLogRaw) : false
 		this.trustedProxies = serverConfig.http?.trustedProxies ?? []
+		this.forceHttpOkEnabled = serverConfig.http?.responseStatusHeader ?? true
 	}
 
 	addMiddleware(middleware: KoaMiddleware<any>) {
@@ -262,6 +265,7 @@ export class Application {
 				requestLogger.error(e)
 			}
 		} finally {
+			this.maybeForceHttpOk(ctx, matchedRequest?.module)
 			sendTimer({
 				req: ctx.req,
 				response: ctx.res,
@@ -298,6 +302,32 @@ export class Application {
 				this.logger.error(e)
 			}
 		}
+	}
+
+	/**
+	 * When the X-Contember-Force-Ok header is present (and the capability is enabled in config),
+	 * coerce the HTTP status of a GraphQL API response (content/tenant/system) to 200, keeping the
+	 * error information in the JSON body. Scoped to those modules so non-JSON / non-GraphQL responses
+	 * are not mislabeled. Default behavior (real status codes) is preserved when the header is absent.
+	 */
+	private maybeForceHttpOk(ctx: KoaContext<{}>, module: string | undefined) {
+		if (!this.forceHttpOkEnabled) {
+			return
+		}
+		if (ctx.status === 200) {
+			return
+		}
+		if (!isGraphqlModule(module)) {
+			return
+		}
+		if (ctx.body === undefined || ctx.body === null) {
+			return
+		}
+		if (!isForceHttpOkRequested(ctx.req)) {
+			return
+		}
+		ctx.set('X-Contember-Original-Status', String(ctx.status))
+		ctx.status = 200
 	}
 
 	private sendHttpResponse(ctx: KoaContext<{}>, response: HttpResponse) {

--- a/packages/engine-http/src/application/forceHttpOk.ts
+++ b/packages/engine-http/src/application/forceHttpOk.ts
@@ -29,3 +29,42 @@ export const isForceHttpOkRequested = (request: IncomingMessage): boolean => {
 }
 
 export const isGraphqlModule = (module: string | undefined): boolean => module !== undefined && graphqlModules.has(module)
+
+export interface ForceHttpOkDecisionInput {
+	/** Whether the capability is enabled in config (http.responseStatusHeader). */
+	enabled: boolean
+	/** The current HTTP response status. */
+	status: number
+	/** The matched route module, if any. */
+	module: string | undefined
+	/** Whether the response carries a (JSON) body. */
+	hasBody: boolean
+	/** Whether the client requested coercion via the X-Contember-Force-Ok header. */
+	headerRequested: boolean
+}
+
+/**
+ * Pure decision for whether a response status should be coerced to 200.
+ *
+ * Coercion happens only when ALL of the following hold:
+ * - the capability is enabled in config (kill-switch off),
+ * - the status is not already 200,
+ * - the matched module is a GraphQL API module (content/tenant/system),
+ * - the response has a body (so non-JSON / transport responses are not mislabeled),
+ * - the client opted in via the X-Contember-Force-Ok header.
+ */
+export const shouldForceHttpOk = ({ enabled, status, module, hasBody, headerRequested }: ForceHttpOkDecisionInput): boolean => {
+	if (!enabled) {
+		return false
+	}
+	if (status === 200) {
+		return false
+	}
+	if (!isGraphqlModule(module)) {
+		return false
+	}
+	if (!hasBody) {
+		return false
+	}
+	return headerRequested
+}

--- a/packages/engine-http/src/application/forceHttpOk.ts
+++ b/packages/engine-http/src/application/forceHttpOk.ts
@@ -1,0 +1,31 @@
+import { IncomingMessage } from 'node:http'
+
+/**
+ * Opt-in mechanism to coerce the HTTP status of a GraphQL API response to 200.
+ *
+ * Some GraphQL clients cannot properly handle non-200 HTTP status codes (e.g. on
+ * authentication failure). When a request carries the `X-Contember-Force-Ok` header
+ * with a truthy value, the response status is forced to 200 while the error information
+ * remains in the JSON body.
+ *
+ * This is scoped to the GraphQL API endpoints (content/tenant/system) where a JSON body
+ * with `errors`/`data` is returned, so that fatal/non-JSON responses are not mislabeled.
+ *
+ * The capability can be disabled globally via the `http.responseStatusHeader` config flag.
+ */
+export const forceHttpOkHeader = 'x-contember-force-ok'
+
+const graphqlModules = new Set(['content', 'tenant', 'system'])
+
+const truthyValues = new Set(['1', 'true', 'on', 'yes'])
+
+export const isForceHttpOkRequested = (request: IncomingMessage): boolean => {
+	const raw = request.headers[forceHttpOkHeader]
+	const value = Array.isArray(raw) ? raw[0] : raw
+	if (value === undefined) {
+		return false
+	}
+	return truthyValues.has(value.trim().toLowerCase())
+}
+
+export const isGraphqlModule = (module: string | undefined): boolean => module !== undefined && graphqlModules.has(module)

--- a/packages/engine-http/src/application/index.ts
+++ b/packages/engine-http/src/application/index.ts
@@ -1,2 +1,3 @@
 export * from './application.js'
+export * from './forceHttpOk.js'
 export * from './types.js'

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -103,6 +103,21 @@ export const serverConfigSchema = Typesafe.partial({
 	port: Typesafe.number,
 	http: Typesafe.partial({
 		requestBodySize: Typesafe.string,
+		// Allows clients to opt in (via the X-Contember-Force-Ok request header) to receiving HTTP 200
+		// for GraphQL API responses, keeping error info in the JSON body. Defaults to enabled; set to
+		// false to forbid the header entirely. Accepts boolean-ish strings ('true'/'1'/'on'/...).
+		responseStatusHeader: (val: unknown) => {
+			if (val === undefined || val === null || val === '') {
+				return undefined
+			}
+			if (val === true || val === 'true' || val === '1' || val === 'on') {
+				return true
+			}
+			if (val === false || val === 'false' || val === '0' || val === 'off') {
+				return false
+			}
+			return Typesafe.fail([])
+		},
 		suppressAccessLog: (val: unknown) => {
 			if (!val) {
 				return undefined

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -86,6 +86,7 @@ export const configTemplate: any = {
 			requestBodySize: '%?env.CONTEMBER_HTTP_REQUEST_BODY_SIZE::string%',
 			suppressAccessLog: '%?env.CONTEMBER_HTTP_SUPPRESS_ACCESS_LOG::string%',
 			trustedProxies: '%?env.CONTEMBER_HTTP_TRUSTED_PROXIES::string%',
+			responseStatusHeader: '%?env.CONTEMBER_HTTP_RESPONSE_STATUS_HEADER::string%',
 		},
 		contentApi: {
 			schemaCacheTtlSeconds: '%?env.CONTEMBER_CONTENT_API_SCHEMA_CACHE_TTL_SECONDS::number%',

--- a/packages/engine-http/tests/cases/unit/forceHttpOk.test.ts
+++ b/packages/engine-http/tests/cases/unit/forceHttpOk.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'bun:test'
+import { IncomingMessage } from 'node:http'
+import { isForceHttpOkRequested, isGraphqlModule } from '../../../src/application/forceHttpOk'
+import { serverConfigSchema } from '../../../src/config/configSchema'
+
+const requestWith = (headers: Record<string, string | string[] | undefined>): IncomingMessage => ({ headers } as unknown as IncomingMessage)
+
+test('isForceHttpOkRequested: false when header absent', () => {
+	expect(isForceHttpOkRequested(requestWith({}))).toBe(false)
+})
+
+test('isForceHttpOkRequested: truthy values', () => {
+	for (const value of ['1', 'true', 'on', 'yes', 'TRUE', ' True ']) {
+		expect(isForceHttpOkRequested(requestWith({ 'x-contember-force-ok': value }))).toBe(true)
+	}
+})
+
+test('isForceHttpOkRequested: falsy/unrecognized values', () => {
+	for (const value of ['0', 'false', 'off', 'no', '']) {
+		expect(isForceHttpOkRequested(requestWith({ 'x-contember-force-ok': value }))).toBe(false)
+	}
+})
+
+test('isForceHttpOkRequested: array header uses first value', () => {
+	expect(isForceHttpOkRequested(requestWith({ 'x-contember-force-ok': ['true', 'false'] }))).toBe(true)
+	expect(isForceHttpOkRequested(requestWith({ 'x-contember-force-ok': ['false', 'true'] }))).toBe(false)
+})
+
+test('isGraphqlModule: only content/tenant/system', () => {
+	expect(isGraphqlModule('content')).toBe(true)
+	expect(isGraphqlModule('tenant')).toBe(true)
+	expect(isGraphqlModule('system')).toBe(true)
+	expect(isGraphqlModule('transfer')).toBe(false)
+	expect(isGraphqlModule('misc')).toBe(false)
+	expect(isGraphqlModule(undefined)).toBe(false)
+})
+
+const responseStatusHeader = (val: unknown): unknown => serverConfigSchema({ http: { responseStatusHeader: val } }).http?.responseStatusHeader
+
+test('config responseStatusHeader: undefined when absent', () => {
+	expect(serverConfigSchema({}).http?.responseStatusHeader).toBeUndefined()
+})
+
+test('config responseStatusHeader: accepts boolean and boolean-ish strings', () => {
+	expect(responseStatusHeader(true)).toBe(true)
+	expect(responseStatusHeader('true')).toBe(true)
+	expect(responseStatusHeader('1')).toBe(true)
+	expect(responseStatusHeader('on')).toBe(true)
+	expect(responseStatusHeader(false)).toBe(false)
+	expect(responseStatusHeader('false')).toBe(false)
+	expect(responseStatusHeader('0')).toBe(false)
+	expect(responseStatusHeader('off')).toBe(false)
+})
+
+test('config responseStatusHeader: invalid value throws', () => {
+	expect(() => responseStatusHeader('maybe')).toThrow()
+})

--- a/packages/engine-http/tests/cases/unit/forceHttpOk.test.ts
+++ b/packages/engine-http/tests/cases/unit/forceHttpOk.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test'
 import { IncomingMessage } from 'node:http'
-import { isForceHttpOkRequested, isGraphqlModule } from '../../../src/application/forceHttpOk'
-import { serverConfigSchema } from '../../../src/config/configSchema'
+import { isForceHttpOkRequested, isGraphqlModule, shouldForceHttpOk } from '../../../src/application/forceHttpOk.js'
+import { serverConfigSchema } from '../../../src/config/configSchema.js'
 
 const requestWith = (headers: Record<string, string | string[] | undefined>): IncomingMessage => ({ headers } as unknown as IncomingMessage)
 
@@ -54,4 +54,39 @@ test('config responseStatusHeader: accepts boolean and boolean-ish strings', () 
 
 test('config responseStatusHeader: invalid value throws', () => {
 	expect(() => responseStatusHeader('maybe')).toThrow()
+})
+
+const baseDecision = {
+	enabled: true,
+	status: 401,
+	module: 'tenant' as string | undefined,
+	hasBody: true,
+	headerRequested: true,
+}
+
+test('shouldForceHttpOk: coerces when all conditions hold', () => {
+	expect(shouldForceHttpOk(baseDecision)).toBe(true)
+})
+
+test('shouldForceHttpOk: kill-switch (enabled=false) suppresses coercion even with header', () => {
+	expect(shouldForceHttpOk({ ...baseDecision, enabled: false })).toBe(false)
+})
+
+test('shouldForceHttpOk: no coercion when header not requested', () => {
+	expect(shouldForceHttpOk({ ...baseDecision, headerRequested: false })).toBe(false)
+})
+
+test('shouldForceHttpOk: leaves a successful (200) response untouched', () => {
+	expect(shouldForceHttpOk({ ...baseDecision, status: 200 })).toBe(false)
+})
+
+test('shouldForceHttpOk: only GraphQL modules are coerced', () => {
+	expect(shouldForceHttpOk({ ...baseDecision, module: 'content' })).toBe(true)
+	expect(shouldForceHttpOk({ ...baseDecision, module: 'system' })).toBe(true)
+	expect(shouldForceHttpOk({ ...baseDecision, module: 'transfer' })).toBe(false)
+	expect(shouldForceHttpOk({ ...baseDecision, module: undefined })).toBe(false)
+})
+
+test('shouldForceHttpOk: no coercion without a (JSON) body', () => {
+	expect(shouldForceHttpOk({ ...baseDecision, hasBody: false })).toBe(false)
 })


### PR DESCRIPTION
## What & why

Some GraphQL clients cannot properly handle non-200 HTTP status codes — for example, on an authentication failure Contember returns `401`, which such a client may treat as a hard transport error instead of reading the GraphQL error payload from the body.

This PR adds an **opt-in** request header that forces the HTTP status of a GraphQL API response to `200`, while keeping all error information in the JSON body.

Closes #398

## How it works

- Send `X-Contember-Force-Ok: true` (also accepts `1`/`on`/`yes`) on any request to the Content (`/content/...`), Tenant (`/tenant`) or System (`/system/...`) API.
- When the request would otherwise return a non-200 status (e.g. `401` auth failure, `400` validation), the status is coerced to `200`. Errors stay in the JSON body.
- The original status is preserved in the `X-Contember-Original-Status` response header.
- Scoped to the GraphQL API modules with a JSON body, so non-JSON / transport-level responses (404 route-not-found, health checks, import/export, etc.) are never mislabeled.
- **Default behavior is unchanged** when the header is absent.

## Configuration

- Enabled by default. The capability can be disabled entirely via the `http.responseStatusHeader` config flag (env: `CONTEMBER_HTTP_RESPONSE_STATUS_HEADER=false`). When disabled, the header is ignored and real status codes are always returned.
- Accepts boolean-ish strings: `true`/`1`/`on` to enable, `false`/`0`/`off` to disable.

## Implementation

- `packages/engine-http/src/application/forceHttpOk.ts` — header parsing + module scoping helpers.
- `packages/engine-http/src/application/application.ts` — `maybeForceHttpOk` runs in the request `finally`, covering both the auth-failure path (`HttpErrorResponse` → `sendHttpResponse`) and the GraphQL handler path (which writes status directly on the Koa response).
- `config/configSchema.ts` + `configTemplate.ts` — the `responseStatusHeader` flag and its env var.

## Tests

- Unit tests for header parsing, module scoping and the config flag.
- An e2e test (`e2e/cases/tenant/forceHttpOk.test.ts`) exercising the real HTTP behavior: `401` by default, coerced to `200` (with `X-Contember-Original-Status: 401` and errors in the body) when the header is present.

## Docs

- New reference page `reference/engine/content/advanced/force-http-ok` (added to the sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)