### PR TITLE
feat(system-api): log truncate operation in event log

### DIFF
--- a/packages/engine-system-api/src/migrations/2026-06-01-120000-event-truncate.ts
+++ b/packages/engine-system-api/src/migrations/2026-06-01-120000-event-truncate.ts
@@ -1,0 +1,18 @@
+import { MigrationBuilder } from '@contember/database-migrations'
+
+// The new domain constraint is a strict superset of the old one (it only adds 'truncate'),
+// so every existing `event_data` row is already known-valid. We add it as NOT VALID to skip
+// the full validation scan of `event_data` — which is the content event log and typically the
+// largest table in the system schema — that PostgreSQL would otherwise run while holding locks
+// inside the migration transaction. New/updated rows are still checked, and no VALIDATE is needed.
+const sql = `
+ALTER DOMAIN "event_data_type" DROP CONSTRAINT "event_data_type_check";
+ALTER DOMAIN "event_data_type"
+	ADD CONSTRAINT "event_data_type_check" CHECK ((VALUE = ANY (ARRAY['create'::"text", 'update'::"text", 'delete'::"text", 'truncate'::"text"]))) NOT VALID;
+ALTER TABLE "event_data" ALTER COLUMN "table_name" DROP NOT NULL;
+ALTER TABLE "event_data" ALTER COLUMN "row_ids" DROP NOT NULL;
+`
+
+export default async function(builder: MigrationBuilder) {
+	builder.sql(sql)
+}

--- a/packages/engine-system-api/src/migrations/runner.ts
+++ b/packages/engine-system-api/src/migrations/runner.ts
@@ -30,6 +30,7 @@ import _20240628153000schema from './2024-06-28-153000-schema.js'
 import _20240628153001schemainit from './2024-06-28-153001-schema-init.js'
 import _20240729150000eventdataindex from './2024-07-29-150000-event-data-index.js'
 import _20250314110000fixmissingindex from './2025-03-14-110000-fix-missing-index.js'
+import _20260601120000eventtruncate from './2026-06-01-120000-event-truncate.js'
 import snapshot from './snapshot.js'
 
 import { Connection, createDatabaseIfNotExists, DatabaseConfig, DatabaseMetadataResolver } from '@contember/database'
@@ -64,6 +65,7 @@ const migrations = {
 	'2024-06-28-153001-schema-init': _20240628153001schemainit,
 	'2024-07-29-150000-event-data-index': _20240729150000eventdataindex,
 	'2025-03-14-110000-fix-missing-index': _20250314110000fixmissingindex,
+	'2026-06-01-120000-event-truncate': _20260601120000eventtruncate,
 }
 
 export class SystemMigrationsRunner {

--- a/packages/engine-system-api/src/migrations/snapshot-template-start.txt
+++ b/packages/engine-system-api/src/migrations/snapshot-template-start.txt
@@ -1,2 +1,2 @@
-import { snapshotMigration } from './snapshot-factory'
+import { snapshotMigration } from './snapshot-factory.js'
 export default snapshotMigration(({randomUuidFn}) => `

--- a/packages/engine-system-api/src/migrations/snapshot.ts
+++ b/packages/engine-system-api/src/migrations/snapshot.ts
@@ -1,7 +1,6 @@
 import { snapshotMigration } from './snapshot-factory.js'
 export default snapshotMigration(({ randomUuidFn }) => `
-CREATE DOMAIN "event_data_type" AS "text"
-	CONSTRAINT "event_data_type_check" CHECK ((VALUE = ANY (ARRAY['create'::"text", 'update'::"text", 'delete'::"text"])));
+CREATE DOMAIN "event_data_type" AS "text";
 CREATE DOMAIN "event_type" AS "text"
 	CONSTRAINT "event_type_check" CHECK ((VALUE = ANY (ARRAY['init'::"text", 'create'::"text", 'update'::"text", 'delete'::"text", 'run_migration'::"text"])));
 CREATE TYPE "schema_migration_type" AS ENUM (
@@ -110,8 +109,8 @@ $$;
 CREATE TABLE "event_data" (
     "id" "uuid" NOT NULL,
     "type" "event_data_type" NOT NULL,
-    "table_name" "text" NOT NULL,
-    "row_ids" "jsonb" NOT NULL,
+    "table_name" "text",
+    "row_ids" "jsonb",
     "values" "jsonb",
     "created_at" timestamp with time zone DEFAULT "clock_timestamp"() NOT NULL,
     "schema_id" integer NOT NULL,
@@ -148,6 +147,8 @@ CREATE TABLE "stage_transaction" (
 );
 ALTER TABLE ONLY "event_data"
     ADD CONSTRAINT "event_data_pkey" PRIMARY KEY ("id");
+ALTER DOMAIN "event_data_type"
+    ADD CONSTRAINT "event_data_type_check" CHECK ((VALUE = ANY (ARRAY['create'::"text", 'update'::"text", 'delete'::"text", 'truncate'::"text"]))) NOT VALID;
 ALTER TABLE ONLY "schema_migration"
     ADD CONSTRAINT "schema_migration_name_key" UNIQUE ("name");
 ALTER TABLE ONLY "schema_migration"

--- a/packages/engine-system-api/src/model/ProjectTruncateExecutor.ts
+++ b/packages/engine-system-api/src/model/ProjectTruncateExecutor.ts
@@ -7,7 +7,7 @@ import { wrapIdentifier } from '@contember/database'
 import { StagesQuery } from './queries/index.js'
 
 export class ProjectTruncateExecutor {
-	public async truncateProject(db: DatabaseContext, project: ProjectConfig, schema: Schema) {
+	public async truncateProject(db: DatabaseContext, project: ProjectConfig, schema: Schema, identityId: string) {
 		const tableNames = Object.values(schema.model.entities).filter(it => !it.view).map(it => it.tableName)
 		const junctionTableNames = getJunctionTables(schema.model).map(it => it.tableName)
 		const allTableNames = [...tableNames, ...junctionTableNames]
@@ -16,13 +16,13 @@ export class ProjectTruncateExecutor {
 		}
 		await db.transaction(async trx => {
 			await trx.client.query('SET CONSTRAINTS ALL DEFERRED')
-			const stages = await db.queryHandler.fetch(new StagesQuery())
+			const stages = await trx.queryHandler.fetch(new StagesQuery())
 			for (const stage of stages) {
 				const wrappedNames = allTableNames.map(it => `${wrapIdentifier(stage.schema)}.${wrapIdentifier(it)}`)
 				await trx.client.query(`TRUNCATE ${wrappedNames}`)
 			}
 			await trx.client.query('SET CONSTRAINTS ALL IMMEDIATE')
-			await trx.commandBus.execute(new TruncateEventsCommand())
+			await trx.commandBus.execute(new TruncateEventsCommand(identityId, stages.map(it => it.id)))
 		})
 	}
 }

--- a/packages/engine-system-api/src/model/commands/events/TruncateEventsCommand.ts
+++ b/packages/engine-system-api/src/model/commands/events/TruncateEventsCommand.ts
@@ -1,8 +1,48 @@
-import { DeleteBuilder } from '@contember/database'
+import { ConflictActionType, DeleteBuilder, InsertBuilder } from '@contember/database'
 import { Command } from '../Command.js'
 
-export class TruncateEventsCommand implements Command<number> {
-	public async execute({ db }: Command.Args): Promise<number> {
-		return await DeleteBuilder.create().from('event_data').execute(db)
+/**
+ * Clears the whole content event log and records a single `truncate` event in its place,
+ * so the truncate operation itself is auditable through the event log (consistent with
+ * how create/update/delete content mutations are logged). The truncate event is linked to
+ * every stage via `stage_transaction` so it shows up in each stage's event stream.
+ */
+export class TruncateEventsCommand implements Command<void> {
+	constructor(
+		private readonly identityId: string,
+		private readonly stageIds: string[],
+	) {}
+
+	public async execute({ db, providers }: Command.Args): Promise<void> {
+		await DeleteBuilder.create().from('event_data').execute(db)
+
+		const transactionId = providers.uuid()
+
+		await InsertBuilder.create()
+			.into('event_data')
+			.values({
+				id: providers.uuid(),
+				type: 'truncate',
+				table_name: null,
+				row_ids: null,
+				values: null,
+				created_at: expr => expr.raw('clock_timestamp()'),
+				schema_id: expr => expr.raw('(SELECT MAX("id") FROM "schema_migration")'),
+				identity_id: this.identityId,
+				transaction_id: transactionId,
+			})
+			.execute(db)
+
+		for (const stageId of this.stageIds) {
+			await InsertBuilder.create()
+				.into('stage_transaction')
+				.values({
+					transaction_id: transactionId,
+					stage_id: stageId,
+					applied_at: expr => expr.raw('clock_timestamp()'),
+				})
+				.onConflict(ConflictActionType.doNothing, ['transaction_id', 'stage_id'])
+				.execute(db)
+		}
 	}
 }

--- a/packages/engine-system-api/src/model/events/EventResponseBuilder.ts
+++ b/packages/engine-system-api/src/model/events/EventResponseBuilder.ts
@@ -1,5 +1,5 @@
 import { ContentEvent, EventType } from './types.js'
-import { CreateEvent, DeleteEvent, EventType as ApiEventType, UpdateEvent } from '../../schema/index.js'
+import { CreateEvent, DeleteEvent, EventType as ApiEventType, TruncateEvent, UpdateEvent } from '../../schema/index.js'
 import { assertNever } from '../../utils/index.js'
 import { IdentityFetcher } from '../dependencies/index.js'
 import { formatIdentity } from './identityUtils.js'
@@ -8,11 +8,12 @@ import { appendCreateSpecificData, appendDeleteSpecificData, appendUpdateSpecifi
 export class EventResponseBuilder {
 	constructor(private readonly identityFetcher: IdentityFetcher) {}
 
-	public async buildResponse(events: ContentEvent[]): Promise<(CreateEvent | DeleteEvent | UpdateEvent)[]> {
+	public async buildResponse(events: ContentEvent[]): Promise<(CreateEvent | DeleteEvent | TruncateEvent | UpdateEvent)[]> {
 		const apiEventTypeMapping = {
 			[EventType.create]: ApiEventType.Create,
 			[EventType.update]: ApiEventType.Update,
 			[EventType.delete]: ApiEventType.Delete,
+			[EventType.truncate]: ApiEventType.Truncate,
 		}
 		const identityIds = events.map(it => it.identityId).filter((it, index, ids) => ids.indexOf(it) === index)
 		const identities = await this.identityFetcher.fetchIdentities(identityIds)
@@ -36,6 +37,8 @@ export class EventResponseBuilder {
 					return ((): UpdateEvent => appendUpdateSpecificData(commonData, it))()
 				case EventType.delete:
 					return ((): DeleteEvent => appendDeleteSpecificData(commonData, it))()
+				case EventType.truncate:
+					return ((): TruncateEvent => ({ ...commonData, tableName: null, primaryKey: null }))()
 			}
 			assertNever(it)
 		})
@@ -49,6 +52,8 @@ export class EventResponseBuilder {
 				return `Updating ${event.tableName}#${event.rowId.join(';')}`
 			case EventType.delete:
 				return `Deleting ${event.tableName}#${event.rowId.join(';')}`
+			case EventType.truncate:
+				return 'Truncating content'
 			default:
 				return assertNever(event)
 		}

--- a/packages/engine-system-api/src/model/events/types.ts
+++ b/packages/engine-system-api/src/model/events/types.ts
@@ -2,9 +2,10 @@ export enum EventType {
 	delete = 'delete',
 	update = 'update',
 	create = 'create',
+	truncate = 'truncate',
 }
 
-export type ContentEvent = UpdateEvent | CreateEvent | DeleteEvent
+export type ContentEvent = UpdateEvent | CreateEvent | DeleteEvent | TruncateEvent
 
 export interface Event {
 	readonly type: EventType
@@ -57,6 +58,19 @@ export class DeleteEvent implements Event {
 		public readonly transactionId: string,
 		public readonly rowId: string[],
 		public readonly tableName: string,
+	) {
+	}
+}
+
+export class TruncateEvent implements Event {
+	public readonly type = EventType.truncate
+
+	constructor(
+		public readonly id: string,
+		public readonly createdAt: Date,
+		public readonly appliedAt: Date,
+		public readonly identityId: string,
+		public readonly transactionId: string,
 	) {
 	}
 }

--- a/packages/engine-system-api/src/model/queries/events/EventQueryHelpers.ts
+++ b/packages/engine-system-api/src/model/queries/events/EventQueryHelpers.ts
@@ -1,12 +1,12 @@
-import { ContentEvent, CreateEvent, DeleteEvent, EventType, UpdateEvent } from '../../events/index.js'
+import { ContentEvent, CreateEvent, DeleteEvent, EventType, TruncateEvent, UpdateEvent } from '../../events/index.js'
 import { assertNever } from '../../../utils/index.js'
 
 export type EventRow = {
 	id: string
 	type: EventType
-	table_name: string
-	row_ids: string[]
-	values: Record<string, any>
+	table_name: string | null
+	row_ids: string[] | null
+	values: Record<string, any> | null
 	created_at: Date
 	applied_at: Date
 	identity_id: string
@@ -23,9 +23,9 @@ export const createEventsFromRows = (rows: EventRow[]): ContentEvent[] => {
 					event.applied_at,
 					event.identity_id,
 					event.transaction_id,
-					event.row_ids,
-					event.table_name,
-					event.values,
+					event.row_ids ?? [],
+					event.table_name ?? '',
+					event.values ?? {},
 				)
 			case EventType.update:
 				return new UpdateEvent(
@@ -34,9 +34,9 @@ export const createEventsFromRows = (rows: EventRow[]): ContentEvent[] => {
 					event.applied_at,
 					event.identity_id,
 					event.transaction_id,
-					event.row_ids,
-					event.table_name,
-					event.values,
+					event.row_ids ?? [],
+					event.table_name ?? '',
+					event.values ?? {},
 				)
 			case EventType.delete:
 				return new DeleteEvent(
@@ -45,8 +45,16 @@ export const createEventsFromRows = (rows: EventRow[]): ContentEvent[] => {
 					event.applied_at,
 					event.identity_id,
 					event.transaction_id,
-					event.row_ids,
-					event.table_name,
+					event.row_ids ?? [],
+					event.table_name ?? '',
+				)
+			case EventType.truncate:
+				return new TruncateEvent(
+					event.id,
+					event.created_at,
+					event.applied_at,
+					event.identity_id,
+					event.transaction_id,
 				)
 			default:
 				assertNever(event.type)

--- a/packages/engine-system-api/src/resolvers/ResolverFactory.ts
+++ b/packages/engine-system-api/src/resolvers/ResolverFactory.ts
@@ -34,6 +34,8 @@ export class ResolverFactory {
 							return 'UpdateEvent'
 						case EventType.Delete:
 							return 'DeleteEvent'
+						case EventType.Truncate:
+							return 'TruncateEvent'
 						case null:
 						case undefined:
 							return null

--- a/packages/engine-system-api/src/resolvers/mutation/TruncateMutationResolver.ts
+++ b/packages/engine-system-api/src/resolvers/mutation/TruncateMutationResolver.ts
@@ -12,7 +12,7 @@ export class TruncateMutationResolver implements MutationResolver<'truncate'> {
 		context: SystemResolverContext,
 		info: GraphQLResolveInfo,
 	): Promise<TruncateResponse> {
-		await this.projectTruncateExecutor.truncateProject(context.db, context.project, await context.getSchema())
+		await this.projectTruncateExecutor.truncateProject(context.db, context.project, await context.getSchema(), context.identity.id)
 		return {
 			ok: true,
 		}

--- a/packages/engine-system-api/src/schema/system.graphql.ts
+++ b/packages/engine-system-api/src/schema/system.graphql.ts
@@ -91,14 +91,15 @@ const schema: DocumentNode = gql`
 		createdAt: DateTime!
 		appliedAt: DateTime!
 		type: EventType!
-		tableName: String!
-		primaryKey: [PrimaryKey!]!
+		tableName: String
+		primaryKey: [PrimaryKey!]
 	}
 
 	enum EventType {
 		UPDATE
 		DELETE
 		CREATE
+		TRUNCATE
 	}
 
 	type UpdateEvent implements Event {
@@ -142,6 +143,19 @@ const schema: DocumentNode = gql`
 		tableName: String!
 		primaryKey: [PrimaryKey!]!
 		newValues: Json!
+	}
+
+	type TruncateEvent implements Event {
+		id: String!
+		transactionId: String!
+		identityId: String!
+		identityDescription: String!
+		description: String!
+		createdAt: DateTime!
+		appliedAt: DateTime!
+		type: EventType!
+		tableName: String
+		primaryKey: [PrimaryKey!]
 	}
 
 	# === executedMigrations ===

--- a/packages/engine-system-api/src/schema/types.ts
+++ b/packages/engine-system-api/src/schema/types.ts
@@ -61,8 +61,8 @@ export type Event = {
 	readonly id: Scalars['String']['output']
 	readonly identityDescription: Scalars['String']['output']
 	readonly identityId: Scalars['String']['output']
-	readonly primaryKey: ReadonlyArray<Scalars['PrimaryKey']['output']>
-	readonly tableName: Scalars['String']['output']
+	readonly primaryKey?: Maybe<ReadonlyArray<Scalars['PrimaryKey']['output']>>
+	readonly tableName?: Maybe<Scalars['String']['output']>
 	readonly transactionId: Scalars['String']['output']
 	readonly type: EventType
 }
@@ -75,6 +75,7 @@ export type EventFilterRow = {
 export enum EventType {
 	Create = 'CREATE',
 	Delete = 'DELETE',
+	Truncate = 'TRUNCATE',
 	Update = 'UPDATE',
 }
 
@@ -298,6 +299,20 @@ export type Stage = {
 	readonly slug: Scalars['String']['output']
 }
 
+export type TruncateEvent = Event & {
+	readonly __typename?: 'TruncateEvent'
+	readonly appliedAt: Scalars['DateTime']['output']
+	readonly createdAt: Scalars['DateTime']['output']
+	readonly description: Scalars['String']['output']
+	readonly id: Scalars['String']['output']
+	readonly identityDescription: Scalars['String']['output']
+	readonly identityId: Scalars['String']['output']
+	readonly primaryKey?: Maybe<ReadonlyArray<Scalars['PrimaryKey']['output']>>
+	readonly tableName?: Maybe<Scalars['String']['output']>
+	readonly transactionId: Scalars['String']['output']
+	readonly type: EventType
+}
+
 export type TruncateResponse = {
 	readonly __typename?: 'TruncateResponse'
 	readonly ok: Scalars['Boolean']['output']
@@ -405,6 +420,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
 	Event:
 		| (CreateEvent)
 		| (DeleteEvent)
+		| (TruncateEvent)
 		| (UpdateEvent)
 }
 
@@ -448,6 +464,7 @@ export type ResolversTypes = {
 	SnapshotInput: SnapshotInput
 	Stage: ResolverTypeWrapper<Stage>
 	String: ResolverTypeWrapper<Scalars['String']['output']>
+	TruncateEvent: ResolverTypeWrapper<TruncateEvent>
 	TruncateResponse: ResolverTypeWrapper<TruncateResponse>
 	UpdateEvent: ResolverTypeWrapper<UpdateEvent>
 }
@@ -486,6 +503,7 @@ export type ResolversParentTypes = {
 	SnapshotInput: SnapshotInput
 	Stage: Stage
 	String: Scalars['String']['output']
+	TruncateEvent: TruncateEvent
 	TruncateResponse: TruncateResponse
 	UpdateEvent: UpdateEvent
 }
@@ -525,7 +543,7 @@ export type DeleteEventResolvers<ContextType = any, ParentType extends Resolvers
 }
 
 export type EventResolvers<ContextType = any, ParentType extends ResolversParentTypes['Event'] = ResolversParentTypes['Event']> = {
-	__resolveType: TypeResolveFn<'CreateEvent' | 'DeleteEvent' | 'UpdateEvent', ParentType, ContextType>
+	__resolveType: TypeResolveFn<'CreateEvent' | 'DeleteEvent' | 'TruncateEvent' | 'UpdateEvent', ParentType, ContextType>
 }
 
 export type ExecutedMigrationResolvers<
@@ -645,6 +663,23 @@ export type StageResolvers<ContextType = any, ParentType extends ResolversParent
 	slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 }
 
+export type TruncateEventResolvers<
+	ContextType = any,
+	ParentType extends ResolversParentTypes['TruncateEvent'] = ResolversParentTypes['TruncateEvent'],
+> = {
+	appliedAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>
+	createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>
+	description?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	id?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	identityDescription?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	identityId?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	primaryKey?: Resolver<Maybe<ReadonlyArray<ResolversTypes['PrimaryKey']>>, ParentType, ContextType>
+	tableName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+	transactionId?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	type?: Resolver<ResolversTypes['EventType'], ParentType, ContextType>
+	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
+}
+
 export type TruncateResponseResolvers<
 	ContextType = any,
 	ParentType extends ResolversParentTypes['TruncateResponse'] = ResolversParentTypes['TruncateResponse'],
@@ -687,6 +722,7 @@ export type Resolvers<ContextType = any> = {
 	Query?: QueryResolvers<ContextType>
 	Schema?: GraphQLScalarType
 	Stage?: StageResolvers<ContextType>
+	TruncateEvent?: TruncateEventResolvers<ContextType>
 	TruncateResponse?: TruncateResponseResolvers<ContextType>
 	UpdateEvent?: UpdateEventResolvers<ContextType>
 }

--- a/packages/engine-system-api/tests/cases/unit/truncateEventsCommand.test.ts
+++ b/packages/engine-system-api/tests/cases/unit/truncateEventsCommand.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'bun:test'
+import { TruncateEventsCommand } from '../../../src/model/index.js'
+import { testUuid } from '../../src/uuid.js'
+
+const createMockDb = () => {
+	const queries: { sql: string; params: any[] }[] = []
+	return {
+		queries,
+		db: {
+			schema: 'public',
+			query: async (sql: string, params: any[] = []) => {
+				queries.push({ sql, params })
+				return { rows: [], rowCount: 0 }
+			},
+		} as any,
+	}
+}
+
+test('truncate events command clears the event log and records a truncate event', async () => {
+	const { db, queries } = createMockDb()
+	let uuidCounter = 100
+	const providers = { uuid: () => testUuid(uuidCounter++) }
+
+	const command = new TruncateEventsCommand(testUuid(1), [testUuid(2), testUuid(3)])
+	await command.execute({ db, providers, bus: {} as any })
+
+	// 1x delete + 1x insert into event_data + 2x insert into stage_transaction
+	expect(queries.length).toBe(4)
+
+	const [del, insertEvent, stage1, stage2] = queries
+
+	expect(del.sql).toContain('delete from')
+	expect(del.sql).toContain('"event_data"')
+
+	expect(insertEvent.sql).toContain('insert into')
+	expect(insertEvent.sql).toContain('"event_data"')
+	expect(insertEvent.sql).toContain('clock_timestamp()')
+	expect(insertEvent.sql).toContain('MAX("id")')
+	expect(insertEvent.sql).toContain('"schema_migration"')
+	// type 'truncate' and identity id are passed as bound params
+	expect(insertEvent.params).toContain('truncate')
+	expect(insertEvent.params).toContain(testUuid(1))
+
+	for (const stageInsert of [stage1, stage2]) {
+		expect(stageInsert.sql).toContain('insert into')
+		expect(stageInsert.sql).toContain('"stage_transaction"')
+		expect(stageInsert.sql).toContain('on conflict')
+		expect(stageInsert.sql).toContain('do nothing')
+	}
+	// both stages linked to the same (single) truncate transaction
+	const stageIds = [...stage1.params, ...stage2.params]
+	expect(stageIds).toContain(testUuid(2))
+	expect(stageIds).toContain(testUuid(3))
+})


### PR DESCRIPTION
## What & why

The system-API `truncate` mutation wipes the content event log (`event_data`) as part of clearing the project's data, but it never recorded the truncate itself — leaving a gap in the audit trail. After a truncate, the event log was simply empty, with no trace of who triggered the destructive operation or when.

This change makes truncate produce an appropriate event-log entry, consistent with how create/update/delete content mutations are logged.

Closes #38

## Design notes

A truncate is a project-wide operation, not tied to a specific table/row, so the existing `create`/`update`/`delete` event shapes don't fit. I added a dedicated **`truncate` event type** end-to-end:

- **Migration** (`2026-06-01-120000-event-truncate.ts`): relaxes the `event_data_type` domain constraint to allow `'truncate'`, and drops `NOT NULL` on `event_data.table_name` / `event_data.row_ids` (a truncate event references no specific table/row). The `snapshot.ts` is updated to the same final state so the snapshot-bootstrap == full-replay invariant holds.
- **`TruncateEventsCommand`**: still clears `event_data`, then inserts a single `truncate` event (fresh id + transaction id, `schema_id` = latest `schema_migration`, acting identity). It also inserts a `stage_transaction` row for every stage, so the truncate event shows up in each stage's event stream (the events query joins `event_data` to `stage_transaction`).
- **Identity**: the acting identity id is threaded from the resolver context through `ProjectTruncateExecutor` into the command, so the event is attributed correctly.
- **Model + GraphQL**: added `EventType.truncate`, a `TruncateEvent` model class, a `TruncateEvent` GraphQL type implementing the `Event` interface, query/response mapping, and the `__resolveType` branch. The `Event` interface's `tableName`/`primaryKey` fields are made nullable to accommodate truncate (concrete `CreateEvent`/`UpdateEvent`/`DeleteEvent` types keep them non-null).

### Scope

This covers the system-API truncate mutation. The data-transfer **import** flow (`engine-http/src/transfer/ImportExecutor.ts`) also issues raw `TRUNCATE`s; that path is intentionally out of scope for this issue.

## Tests

Added `truncateEventsCommand.test.ts` (mock-db unit test, no Postgres) asserting the command clears the log, records exactly one `truncate` event, and links every stage to the single truncate transaction. Existing `eventsQuery` test still passes (its SQL is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)