### PR TITLE
feat(schema): numericColumn type for exact decimals

### DIFF
--- a/docs/src/content/docs/reference/engine/schema/columns.mdx
+++ b/docs/src/content/docs/reference/engine/schema/columns.mdx
@@ -17,13 +17,14 @@ In this example, the Post entity has two columns: title and publishedAt. The tit
 
 ## Supported data types
 
-Contember supports several different data types for columns, including string, int, double, bool, dateTime, date, json, and uuid. You can use the following methods to define columns of different types:
+Contember supports several different data types for columns, including string, int, double, numeric, bool, dateTime, date, json, and uuid. You can use the following methods to define columns of different types:
 
 | Contember Type | Definition method | PostgreSQL type  | Description
 | -------------- | ------------------| ---------------- | -----------
 | String         | stringColumn      | text             | Generic text field with arbitrary length.
 | Int            | intColumn         | integer          | Stores whole signed numbers (32b default)
 | Double         | doubleColumn      | double precision | Floating point numbers according to IEEE 64-bit float.
+| Numeric        | numericColumn     | numeric(p, s)    | Exact decimal numbers with a fixed precision and scale (e.g. money). Transferred as a string. [See more in a section below.](#numeric-exact-decimals)
 | Bool           | boolColumn        | boolean          | Binary true/false value.
 | DateTime       | dateTimeColumn    | timestamptz      | For storing date and time, converted to UTC by default and transferred in ISO 8601 format (e.g. `2032-01-18T13:36:45Z`).
 | Date           | dateColumn        | date             | Date field without a time part. It's transferred in `YYYY-MM-DD` format (e.g. `2032-01-18`).
@@ -39,6 +40,58 @@ export class Post {
 	config = c.jsonColumn().columnType('json')
 }
 ```
+:::
+
+
+## Numeric (exact decimals)
+
+The `numericColumn` method defines an exact decimal column backed by the PostgreSQL `numeric(precision, scale)` type. Unlike `doubleColumn`, which uses IEEE 64-bit floating point and is subject to rounding errors, `numeric` stores the value exactly. Use it whenever you need precise arithmetic — most importantly for money, but also for quantities, rates, measurements, and any value where a rounding error is unacceptable.
+
+`numericColumn` takes two required arguments:
+
+- `precision` — the total number of significant digits.
+- `scale` — the number of digits after the decimal point.
+
+#### Example how to define a price column:
+
+```typescript
+export class Product {
+	price = c.numericColumn(20, 9).notNull()
+}
+```
+
+This maps to a `numeric(20, 9)` column in PostgreSQL, allowing up to 20 significant digits with 9 of them after the decimal point.
+
+### Transferred as a string
+
+Numeric values are transported over GraphQL as **strings** rather than numbers. This is intentional: JavaScript numbers are IEEE 64-bit floats and cannot represent every decimal value exactly (for example, `0.1 + 0.2 !== 0.3`), so passing them through a GraphQL `Float` would silently corrupt the very precision a `numeric` column exists to protect. The column is therefore exposed through a custom `Decimal` GraphQL scalar, and the generated TypeScript SDK types it as `string`.
+
+**On input**, the `Decimal` scalar accepts either a string (e.g. `"123.45"`, including scientific notation like `"1.5e10"`) or a plain JSON number, which is normalized to a string. Values that are not valid decimals — as well as `NaN` and `Infinity` — are rejected.
+
+**On output**, the API returns the exact PostgreSQL `numeric` text representation. This preserves trailing zeros up to the column scale, so a value of `123.45` stored in a `numeric(20, 9)` column is returned as `"123.450000000"`.
+
+```graphql
+mutation {
+  createProduct(data: { price: "123.45" }) {
+    node {
+      price # => "123.450000000"
+    }
+  }
+}
+```
+
+Filtering and ordering work the same way as for other numeric types — operators such as `eq`, `gt`, `lt`, `in`, and `notIn` are available, and comparison happens in the database as exact `numeric` arithmetic. Filter values are also passed as strings:
+
+```graphql
+query {
+  listProduct(filter: { price: { gt: "100.5" } }, orderBy: [{ price: asc }]) {
+    price
+  }
+}
+```
+
+:::tip
+If you don't need exact precision and prefer working with plain JavaScript numbers, use `doubleColumn` instead.
 :::
 
 

--- a/packages/client-content-generator/src/EntityTypeSchemaGenerator.ts
+++ b/packages/client-content-generator/src/EntityTypeSchemaGenerator.ts
@@ -149,6 +149,8 @@ const columnToTsType = (column: Model.AnyColumn): string => {
 				return 'number'
 			case Model.ColumnType.Double:
 				return 'number'
+			case Model.ColumnType.Numeric:
+				return 'string'
 			case Model.ColumnType.Bool:
 				return 'boolean'
 			case Model.ColumnType.DateTime:

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
@@ -28,6 +28,10 @@ export class FieldsVisitor implements Model.RelationByTypeVisitor<void>, Model.C
 		const columnAlias = columnPath.alias
 
 		let selectFrom = wrapIdentifier(tableAlias) + '.' + wrapIdentifier(column.columnName)
+		if (column.type === Model.ColumnType.Numeric) {
+			// Numeric is transported as a string to avoid JS float precision loss.
+			selectFrom += column.list ? '::text[]' : '::text'
+		}
 		if (column.type === Model.ColumnType.Date && this.settings.shortDateResponse) {
 			selectFrom += '::text'
 		}

--- a/packages/engine-content-api/src/schema/ColumnTypeResolver.ts
+++ b/packages/engine-content-api/src/schema/ColumnTypeResolver.ts
@@ -82,6 +82,8 @@ export class ColumnTypeResolver {
 				return this.customTypeProvider.uuidType
 			case Model.ColumnType.Double:
 				return GraphQLFloat
+			case Model.ColumnType.Numeric:
+				return this.customTypeProvider.decimalType
 			case Model.ColumnType.Bool:
 				return GraphQLBoolean
 			case Model.ColumnType.DateTime:

--- a/packages/engine-content-api/src/schema/CustomTypesProvider.ts
+++ b/packages/engine-content-api/src/schema/CustomTypesProvider.ts
@@ -3,6 +3,26 @@ import { JSONType, UuidType } from '@contember/graphql-utils'
 
 const TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)(?::([0-5]\d)(?:\.(\d+))?)?$/
 
+const DECIMAL_REGEX = /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/
+
+function validateDecimal(value: unknown): string {
+	// Numeric values are transported as strings to avoid JS float precision loss.
+	// Plain numbers are accepted for convenience but normalized to a string.
+	if (typeof value === 'number') {
+		if (!Number.isFinite(value)) {
+			throw new TypeError(`Decimal value must be a finite number, got: ${value}`)
+		}
+		return String(value)
+	}
+	if (typeof value !== 'string') {
+		throw new TypeError(`Decimal value must be a string, got: ${typeof value}`)
+	}
+	if (!DECIMAL_REGEX.test(value.trim())) {
+		throw new TypeError(`Value is not a valid decimal: ${value}`)
+	}
+	return value.trim()
+}
+
 function validateTime(value: unknown): string {
 	if (typeof value !== 'string') {
 		throw new TypeError(`Time value must be a string, got: ${typeof value}`)
@@ -59,4 +79,21 @@ export class CustomTypesProvider {
 		},
 	})
 	public readonly jsonType: GraphQLScalarType = JSONType
+
+	public readonly decimalType: GraphQLScalarType = new GraphQLScalarType({
+		name: 'Decimal',
+		description: 'Arbitrary precision decimal number, transported as a string to avoid floating-point precision loss.',
+		serialize(value) {
+			return validateDecimal(value)
+		},
+		parseValue(value) {
+			return validateDecimal(value)
+		},
+		parseLiteral(ast) {
+			if (ast.kind === Kind.STRING || ast.kind === Kind.INT || ast.kind === Kind.FLOAT) {
+				return validateDecimal(ast.value)
+			}
+			throw new TypeError(`Decimal scalar can only parse string or numeric values, got: ${ast.kind}`)
+		},
+	})
 }

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/numericColumn.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/numericColumn.test.ts
@@ -1,8 +1,8 @@
 import { test } from 'bun:test'
-import { execute, sqlTransaction } from '../../../../src/test'
+import { execute, sqlTransaction } from '../../../../src/test.js'
 import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
-import { GQL, SQL } from '../../../../src/tags'
-import { testUuid } from '../../../../src/testUuid'
+import { GQL, SQL } from '../../../../src/tags.js'
+import { testUuid } from '../../../../src/testUuid.js'
 
 namespace NumericModel {
 	export class Product {

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/numericColumn.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/numericColumn.test.ts
@@ -1,0 +1,110 @@
+import { test } from 'bun:test'
+import { execute, sqlTransaction } from '../../../../src/test'
+import { SchemaDefinition as def, createSchema } from '@contember/schema-definition'
+import { GQL, SQL } from '../../../../src/tags'
+import { testUuid } from '../../../../src/testUuid'
+
+namespace NumericModel {
+	export class Product {
+		price = def.numericColumn(20, 9)
+	}
+}
+
+const schema = createSchema(NumericModel).model
+
+test('insert product with numeric price (cast to numeric(p, s))', async () => {
+	await execute({
+		schema,
+		query: GQL`
+        mutation {
+          createProduct(data: {price: "123.45"}) {
+            node {
+              id
+              price
+            }
+          }
+        }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as
+						(select ? :: uuid as "id", ? :: numeric(20, 9) as "price")
+						insert into "public"."product" ("id", "price")
+						select "root_"."id", "root_"."price"
+            from "root_"
+						returning "id"`,
+					parameters: [testUuid(1), '123.45'],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" as "root_id", "root_"."price"::text as "root_price"
+                     from "public"."product" as "root_"
+                     where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ root_id: testUuid(1), root_price: '123.450000000' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createProduct: {
+					node: {
+						id: testUuid(1),
+						price: '123.450000000',
+					},
+				},
+			},
+		},
+	})
+})
+
+test('update product numeric price (cast to numeric(p, s))', async () => {
+	await execute({
+		schema,
+		query: GQL`
+        mutation {
+          updateProduct(by: {id: "${testUuid(1)}"}, data: {price: "999.99"}) {
+            node {
+              id
+              price
+            }
+          }
+        }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."product" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`with "newData_" as
+						(select ? :: numeric(20, 9) as "price", "root_"."price" as "price_old__", "root_"."id"
+						from "public"."product" as "root_"  where "root_"."id" = ?)
+						update "public"."product"
+						set "price" = "newData_"."price"  from "newData_"
+						where "product"."id" = "newData_"."id"  returning "price_old__"`,
+					parameters: ['999.99', testUuid(1)],
+					response: { rows: [{ price_old__: '1.000000000' }] },
+				},
+				{
+					sql: SQL`select "root_"."id" as "root_id", "root_"."price"::text as "root_price"
+                     from "public"."product" as "root_"
+                     where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ root_id: testUuid(1), root_price: '999.990000000' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateProduct: {
+					node: {
+						id: testUuid(1),
+						price: '999.990000000',
+					},
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/numericColumn.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/numericColumn.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'bun:test'
 import { execute, sqlTransaction } from '../../../../src/test'
-import { SchemaDefinition as def, createSchema } from '@contember/schema-definition'
+import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
 import { GQL, SQL } from '../../../../src/tags'
 import { testUuid } from '../../../../src/testUuid'
 

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/filter/numericFilter.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/filter/numericFilter.test.ts
@@ -1,8 +1,8 @@
 import { test } from 'bun:test'
-import { execute } from '../../../../../src/test'
+import { execute } from '../../../../../src/test.js'
 import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
-import { GQL, SQL } from '../../../../../src/tags'
-import { testUuid } from '../../../../../src/testUuid'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
 
 namespace NumericFilterModel {
 	export class Product {

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/filter/numericFilter.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/filter/numericFilter.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'bun:test'
 import { execute } from '../../../../../src/test'
-import { SchemaDefinition as def, createSchema } from '@contember/schema-definition'
+import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
 import { GQL, SQL } from '../../../../../src/tags'
 import { testUuid } from '../../../../../src/testUuid'
 

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/filter/numericFilter.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/filter/numericFilter.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'bun:test'
+import { execute } from '../../../../../src/test'
+import { SchemaDefinition as def, createSchema } from '@contember/schema-definition'
+import { GQL, SQL } from '../../../../../src/tags'
+import { testUuid } from '../../../../../src/testUuid'
+
+namespace NumericFilterModel {
+	export class Product {
+		price = def.numericColumn(20, 9)
+	}
+}
+
+const schema = createSchema(NumericFilterModel).model
+
+test('Numeric column "in" filter renders an IN list', async () => {
+	await execute({
+		schema,
+		query: GQL`
+        query {
+          listProduct(filter: {price: {in: ["100.5", "200.25"]}}) {
+            price
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."price"::text as "root_price", "root_"."id" as "root_id"
+                     from "public"."product" as "root_"
+                     where "root_"."price" in (?, ?)`,
+				parameters: ['100.5', '200.25'],
+				response: { rows: [{ root_id: testUuid(1), root_price: '100.500000000' }] },
+			},
+		],
+		return: {
+			data: {
+				listProduct: [{ price: '100.500000000' }],
+			},
+		},
+	})
+})
+
+test('Numeric column "notIn" filter renders a negated IN list', async () => {
+	await execute({
+		schema,
+		query: GQL`
+        query {
+          listProduct(filter: {price: {notIn: ["100.5", "200.25"]}}) {
+            price
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."price"::text as "root_price", "root_"."id" as "root_id"
+                     from "public"."product" as "root_"
+                     where not("root_"."price" in (?, ?))`,
+				parameters: ['100.5', '200.25'],
+				response: { rows: [{ root_id: testUuid(1), root_price: '1.000000000' }] },
+			},
+		],
+		return: {
+			data: {
+				listProduct: [{ price: '1.000000000' }],
+			},
+		},
+	})
+})
+
+test('Numeric column "in" filter with >100 values uses the any(?::numeric(p,s)[]) fast path', async () => {
+	const values = Array.from({ length: 101 }, (_, i) => String(i))
+	await execute({
+		schema,
+		query: GQL`
+        query {
+          listProduct(filter: {price: {in: ${JSON.stringify(values)}}}) {
+            price
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."price"::text as "root_price", "root_"."id" as "root_id"
+                     from "public"."product" as "root_"
+                     where "root_"."price" = any(?::numeric(20, 9)[])`,
+				parameters: [values],
+				response: { rows: [{ root_id: testUuid(1), root_price: '1.000000000' }] },
+			},
+		],
+		return: {
+			data: {
+				listProduct: [{ price: '1.000000000' }],
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericFormat.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericFormat.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'bun:test'
+import { execute } from '../../../../../src/test'
+import { SchemaBuilder } from '@contember/schema-definition'
+import { Model } from '@contember/schema'
+import { GQL, SQL } from '../../../../../src/tags'
+import { testUuid } from '../../../../../src/testUuid'
+
+test('Numeric column is selected as text (string transport)', async () => {
+	await execute({
+		schema: new SchemaBuilder()
+			.entity('Product', entity => entity.column('price', column => column.type(Model.ColumnType.Numeric)))
+			.buildSchema(),
+		query: GQL`
+        query {
+          getProduct(by: {id: "${testUuid(1)}"}) {
+            price
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."price"::text as "root_price", "root_"."id" as "root_id"
+                     from "public"."product" as "root_"
+                     where "root_"."id" = ?`,
+				response: { rows: [{ root_id: testUuid(1), root_price: '123.450000000' }] },
+				parameters: [testUuid(1)],
+			},
+		],
+		return: {
+			data: {
+				getProduct: {
+					price: '123.450000000',
+				},
+			},
+		},
+	})
+})
+
+test('Numeric column can be filtered as a number', async () => {
+	await execute({
+		schema: new SchemaBuilder()
+			.entity('Product', entity => entity.column('price', column => column.type(Model.ColumnType.Numeric)))
+			.buildSchema(),
+		query: GQL`
+        query {
+          listProduct(filter: {price: {gt: "100.5"}}) {
+            price
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."price"::text as "root_price", "root_"."id" as "root_id"
+                     from "public"."product" as "root_"
+                     where "root_"."price" > ?`,
+				response: { rows: [{ root_id: testUuid(1), root_price: '123.450000000' }] },
+				parameters: ['100.5'],
+			},
+		],
+		return: {
+			data: {
+				listProduct: [
+					{
+						price: '123.450000000',
+					},
+				],
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericFormat.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericFormat.test.ts
@@ -1,9 +1,9 @@
 import { test } from 'bun:test'
-import { execute } from '../../../../../src/test'
+import { execute } from '../../../../../src/test.js'
 import { SchemaBuilder } from '@contember/schema-definition'
 import { Model } from '@contember/schema'
-import { GQL, SQL } from '../../../../../src/tags'
-import { testUuid } from '../../../../../src/testUuid'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
 
 test('Numeric column is selected as text (string transport)', async () => {
 	await execute({

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericList.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericList.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'bun:test'
 import { execute } from '../../../../../src/test'
-import { SchemaDefinition as def, createSchema } from '@contember/schema-definition'
+import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
 import { GQL, SQL } from '../../../../../src/tags'
 import { testUuid } from '../../../../../src/testUuid'
 

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericList.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericList.test.ts
@@ -1,8 +1,8 @@
 import { test } from 'bun:test'
-import { execute } from '../../../../../src/test'
+import { execute } from '../../../../../src/test.js'
 import { createSchema, SchemaDefinition as def } from '@contember/schema-definition'
-import { GQL, SQL } from '../../../../../src/tags'
-import { testUuid } from '../../../../../src/testUuid'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
 
 namespace NumericListModel {
 	export class Product {

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericList.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/formatting/numericList.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'bun:test'
+import { execute } from '../../../../../src/test'
+import { SchemaDefinition as def, createSchema } from '@contember/schema-definition'
+import { GQL, SQL } from '../../../../../src/tags'
+import { testUuid } from '../../../../../src/testUuid'
+
+namespace NumericListModel {
+	export class Product {
+		prices = def.numericColumn(20, 9).list()
+	}
+}
+
+const schema = createSchema(NumericListModel).model
+
+test('Numeric list column is selected as text[] (string array transport)', async () => {
+	await execute({
+		schema,
+		query: GQL`
+        query {
+          getProduct(by: {id: "${testUuid(1)}"}) {
+            prices
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."prices"::text[] as "root_prices", "root_"."id" as "root_id"
+                     from "public"."product" as "root_"
+                     where "root_"."id" = ?`,
+				response: { rows: [{ root_id: testUuid(1), root_prices: ['1.500000000', '2.250000000'] }] },
+				parameters: [testUuid(1)],
+			},
+		],
+		return: {
+			data: {
+				getProduct: {
+					prices: ['1.500000000', '2.250000000'],
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/unit/decimalType.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/decimalType.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test'
+import { Kind } from 'graphql'
+import { CustomTypesProvider } from '../../../src'
+
+describe('decimal graphql type', () => {
+	const decimalType = new CustomTypesProvider().decimalType
+
+	it('accepts a plain decimal string and trims it', () => {
+		expect(decimalType.parseValue('123.45')).toEqual('123.45')
+		expect(decimalType.parseValue('  -0.001  ')).toEqual('-0.001')
+		expect(decimalType.parseValue('+42')).toEqual('+42')
+		expect(decimalType.parseValue('.5')).toEqual('.5')
+		expect(decimalType.parseValue('5.')).toEqual('5.')
+	})
+
+	it('accepts scientific notation', () => {
+		expect(decimalType.parseValue('1.5e10')).toEqual('1.5e10')
+		expect(decimalType.parseValue('1.5E-10')).toEqual('1.5E-10')
+		expect(decimalType.parseValue('-2e+3')).toEqual('-2e+3')
+	})
+
+	it('normalizes a JSON number input to a string', () => {
+		expect(decimalType.parseValue(123.45)).toEqual('123.45')
+		expect(decimalType.parseValue(0)).toEqual('0')
+		expect(decimalType.parseValue(-7)).toEqual('-7')
+	})
+
+	it('rejects an invalid decimal string', () => {
+		expect(() => decimalType.parseValue('abc')).toThrow()
+		expect(() => decimalType.parseValue('1.2.3')).toThrow()
+		expect(() => decimalType.parseValue('')).toThrow()
+		expect(() => decimalType.parseValue('1,000')).toThrow()
+		expect(() => decimalType.parseValue('0x10')).toThrow()
+	})
+
+	it('rejects non-finite numbers', () => {
+		expect(() => decimalType.parseValue(NaN)).toThrow()
+		expect(() => decimalType.parseValue(Infinity)).toThrow()
+		expect(() => decimalType.parseValue(-Infinity)).toThrow()
+	})
+
+	it('rejects non-string, non-number values', () => {
+		expect(() => decimalType.parseValue(true)).toThrow()
+		expect(() => decimalType.parseValue(null)).toThrow()
+		expect(() => decimalType.parseValue({})).toThrow()
+	})
+
+	it('serializes preserving exact text (incl. trailing zeros)', () => {
+		// The DB returns the full-scale numeric text representation; it must pass through untouched.
+		expect(decimalType.serialize('123.450000000')).toEqual('123.450000000')
+		expect(decimalType.serialize('0.000000000')).toEqual('0.000000000')
+		expect(decimalType.serialize('-123456789123.456')).toEqual('-123456789123.456')
+	})
+
+	it('parses string, int and float literals', () => {
+		expect(decimalType.parseLiteral({ kind: Kind.STRING, value: '123.45' } as any, undefined)).toEqual('123.45')
+		expect(decimalType.parseLiteral({ kind: Kind.INT, value: '42' } as any, undefined)).toEqual('42')
+		expect(decimalType.parseLiteral({ kind: Kind.FLOAT, value: '1.5' } as any, undefined)).toEqual('1.5')
+	})
+
+	it('rejects non-numeric literals', () => {
+		expect(() => decimalType.parseLiteral({ kind: Kind.BOOLEAN, value: true } as any, undefined)).toThrow()
+		expect(() => decimalType.parseLiteral({ kind: Kind.NULL } as any, undefined)).toThrow()
+	})
+})

--- a/packages/engine-content-api/tests/cases/unit/decimalType.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/decimalType.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { Kind } from 'graphql'
-import { CustomTypesProvider } from '../../../src'
+import { CustomTypesProvider } from '../../../src/index.js'
 
 describe('decimal graphql type', () => {
 	const decimalType = new CustomTypesProvider().decimalType

--- a/packages/engine-http/src/transfer/ExportExecutor.ts
+++ b/packages/engine-http/src/transfer/ExportExecutor.ts
@@ -123,9 +123,14 @@ export class ExportExecutor {
 					|| column.type === Model.ColumnType.DateTime)
 			) {
 				builder = builder.select(expr => expr.raw(`${wrapIdentifier(column.name)}::text[]`))
+			} else if (column.list && column.type === Model.ColumnType.Numeric) {
+				builder = builder.select(expr => expr.raw(`${wrapIdentifier(column.name)}::text[]`))
 			} else if (column.list) {
 				builder = builder.select(column.name)
-			} else if (column.type === Model.ColumnType.Json || column.type === Model.ColumnType.Date || column.type === Model.ColumnType.DateTime) {
+			} else if (
+				column.type === Model.ColumnType.Json || column.type === Model.ColumnType.Date || column.type === Model.ColumnType.DateTime
+				|| column.type === Model.ColumnType.Numeric
+			) {
 				builder = builder.select(expr => expr.raw(`${wrapIdentifier(column.name)}::text`))
 			} else {
 				builder = builder.select(column.name)

--- a/packages/engine-http/src/transfer/ImportExecutor.ts
+++ b/packages/engine-http/src/transfer/ImportExecutor.ts
@@ -433,6 +433,8 @@ export class ImportExecutor {
 			case Model.ColumnType.Time:
 			case Model.ColumnType.Date:
 			case Model.ColumnType.Json:
+			// Numeric is transferred as a string to avoid JS float precision loss.
+			case Model.ColumnType.Numeric:
 				return column.list ? listType(Typesafe.array(Typesafe.string)) : Typesafe.string
 			case Model.ColumnType.Int:
 			case Model.ColumnType.Double:

--- a/packages/schema-definition/src/index.ts
+++ b/packages/schema-definition/src/index.ts
@@ -62,6 +62,7 @@ export const c = {
 	boolColumn: SchemaDefinition.boolColumn,
 	intColumn: SchemaDefinition.intColumn,
 	doubleColumn: SchemaDefinition.doubleColumn,
+	numericColumn: SchemaDefinition.numericColumn,
 	dateColumn: SchemaDefinition.dateColumn,
 	timeColumn: SchemaDefinition.timeColumn,
 	dateTimeColumn: SchemaDefinition.dateTimeColumn,

--- a/packages/schema-definition/src/model/definition/fieldDefinitions/ColumnDefinition.ts
+++ b/packages/schema-definition/src/model/definition/fieldDefinitions/ColumnDefinition.ts
@@ -131,6 +131,21 @@ export function doubleColumn(): ColumnDefinition {
 	return column(Model.ColumnType.Double)
 }
 
+/**
+ * Creates a `numeric(precision, scale)` (a.k.a. `decimal`) column.
+ *
+ * Values are transported over GraphQL as strings (e.g. `'-123456789123.456'`) to avoid
+ * JavaScript floating-point precision loss. The value returned by the API is the exact
+ * Postgres `numeric` text representation, which includes trailing zeros up to the column
+ * scale (e.g. `123.450000000` for `numeric(20, 9)`).
+ *
+ * @param precision total number of significant digits
+ * @param scale number of digits after the decimal point
+ */
+export function numericColumn(precision: number, scale: number): ColumnDefinition {
+	return column(Model.ColumnType.Numeric).columnType(`${resolveDefaultColumnType(Model.ColumnType.Numeric)}(${precision}, ${scale})`)
+}
+
 export function dateColumn(): ColumnDefinition {
 	return column(Model.ColumnType.Date)
 }

--- a/packages/schema-definition/tests/cases/unit/numericColumn.test.ts
+++ b/packages/schema-definition/tests/cases/unit/numericColumn.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { c, createSchema } from '../../../src'
+import { c, createSchema } from '../../../src/index.js'
 import { Model } from '@contember/schema'
 
 namespace NumericModel {

--- a/packages/schema-definition/tests/cases/unit/numericColumn.test.ts
+++ b/packages/schema-definition/tests/cases/unit/numericColumn.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from 'bun:test'
+import { c, createSchema } from '../../../src'
+import { Model } from '@contember/schema'
+
+namespace NumericModel {
+	export class Product {
+		price = c.numericColumn(20, 9).notNull()
+		discount = c.numericColumn(5, 2)
+	}
+}
+
+test('numericColumn produces numeric(precision, scale)', () => {
+	const schema = createSchema(NumericModel)
+	const fields = schema.model.entities.Product.fields
+
+	expect(fields.price).toMatchObject({
+		name: 'price',
+		columnName: 'price',
+		type: Model.ColumnType.Numeric,
+		columnType: 'numeric(20, 9)',
+		nullable: false,
+	})
+
+	expect(fields.discount).toMatchObject({
+		name: 'discount',
+		columnName: 'discount',
+		type: Model.ColumnType.Numeric,
+		columnType: 'numeric(5, 2)',
+		nullable: true,
+	})
+})

--- a/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
@@ -202,3 +202,30 @@ describe('create list column', () =>
 		],
 		sql: SQL`ALTER TABLE "author" ADD "emails" text[];`,
 	}))
+
+describe('create numeric column', () =>
+	testMigrations({
+		original: createSchema({
+			Author: class Author {
+			},
+		}),
+		updated: createSchema({
+			Author: class Author {
+				balance = def.numericColumn(20, 9)
+			},
+		}),
+		diff: [
+			{
+				modification: 'createColumn',
+				entityName: 'Author',
+				field: {
+					columnName: 'balance',
+					name: 'balance',
+					nullable: true,
+					type: Model.ColumnType.Numeric,
+					columnType: 'numeric(20, 9)',
+				},
+			},
+		],
+		sql: SQL`ALTER TABLE "author" ADD "balance" numeric(20, 9);`,
+	}))

--- a/packages/schema-utils/src/dataUtils.ts
+++ b/packages/schema-utils/src/dataUtils.ts
@@ -17,6 +17,7 @@ export const resolveDefaultValue = (column: Model.AnyColumn, providers: Pick<Pro
 		case Model.ColumnType.Int:
 		case Model.ColumnType.Enum:
 		case Model.ColumnType.Double:
+		case Model.ColumnType.Numeric:
 		case Model.ColumnType.Bool:
 		case Model.ColumnType.Json:
 			if (typeof column.default !== 'undefined') {

--- a/packages/schema-utils/src/definition-generator/DefinitionCodeGenerator.ts
+++ b/packages/schema-utils/src/definition-generator/DefinitionCodeGenerator.ts
@@ -190,6 +190,17 @@ ${Object.values(entity.fields).map(field => this.generateField({ field, entity, 
 		let parts: string[] = []
 		if (column.type === Model.ColumnType.Enum) {
 			parts.push(`enumColumn(${column.columnType})`)
+		} else if (column.type === Model.ColumnType.Numeric) {
+			// numericColumn requires precision and scale, parsed from e.g. "numeric(10, 2)"
+			const match = /numeric\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)/i.exec(column.columnType)
+			if (match) {
+				parts.push(`numericColumn(${match[1]}, ${match[2]})`)
+			} else {
+				parts.push('numericColumn(30, 10)')
+				if (resolveDefaultColumnType(column.type) !== column.columnType) {
+					parts.push(`columnType(${printJsValue(column.columnType)})`)
+				}
+			}
 		} else {
 			parts.push(`${ColumnToMethodMapping[column.type]}()`)
 			const defaultColumnType = resolveDefaultColumnType(column.type)
@@ -231,6 +242,7 @@ const ColumnToMethodMapping: {
 	[Model.ColumnType.Time]: 'timeColumn',
 	[Model.ColumnType.Json]: 'jsonColumn',
 	[Model.ColumnType.Double]: 'doubleColumn',
+	[Model.ColumnType.Numeric]: 'numericColumn',
 	[Model.ColumnType.Uuid]: 'uuidColumn',
 	[Model.ColumnType.Int]: 'intColumn',
 	[Model.ColumnType.String]: 'stringColumn',

--- a/packages/schema-utils/src/model/resolveDefaultColumnType.ts
+++ b/packages/schema-utils/src/model/resolveDefaultColumnType.ts
@@ -7,6 +7,8 @@ export const resolveDefaultColumnType = (type: Exclude<Model.ColumnType, Model.C
 			return 'integer'
 		case Model.ColumnType.Double:
 			return 'double precision'
+		case Model.ColumnType.Numeric:
+			return 'numeric'
 		case Model.ColumnType.String:
 			return 'text'
 		case Model.ColumnType.Uuid:

--- a/packages/schema-utils/src/type-schema/condition.ts
+++ b/packages/schema-utils/src/type-schema/condition.ts
@@ -79,6 +79,9 @@ const resolveColumnTypeSchema = (type: Model.ColumnType) => {
 		case Model.ColumnType.Enum:
 		case Model.ColumnType.String:
 			return Typesafe.string
+		// Numeric is transported as a string to avoid JS float precision loss.
+		case Model.ColumnType.Numeric:
+			return Typesafe.string
 		case Model.ColumnType.Double:
 			return Typesafe.number
 		case Model.ColumnType.Int:

--- a/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
@@ -1,7 +1,7 @@
 import { c, createSchema } from '@contember/schema-definition'
 import { expect, test } from 'bun:test'
 import { Model, Schema } from '@contember/schema'
-import { DefinitionCodeGenerator } from '../../../src/definition-generator/DefinitionCodeGenerator'
+import { DefinitionCodeGenerator } from '../../../src/definition-generator/DefinitionCodeGenerator.js'
 
 namespace NumericModel {
 	export class Product {

--- a/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
@@ -1,5 +1,4 @@
-import { createSchema } from '@contember/schema-definition'
-import { c } from '@contember/schema-definition'
+import { c, createSchema } from '@contember/schema-definition'
 import { expect, test } from 'bun:test'
 import { Model } from '@contember/schema'
 import { DefinitionCodeGenerator } from '../../../src/definition-generator/DefinitionCodeGenerator'

--- a/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
@@ -1,12 +1,35 @@
 import { c, createSchema } from '@contember/schema-definition'
 import { expect, test } from 'bun:test'
-import { Model } from '@contember/schema'
+import { Model, Schema } from '@contember/schema'
 import { DefinitionCodeGenerator } from '../../../src/definition-generator/DefinitionCodeGenerator'
 
 namespace NumericModel {
 	export class Product {
 		price = c.numericColumn(20, 9).notNull()
 		discount = c.numericColumn(5, 2)
+	}
+}
+
+// Immutably overrides the stored columnType of a single Product column, so we can
+// exercise the regex / fallback branches without writing to the readonly fields map.
+const withColumnType = (schema: Schema, field: string, columnType: string): Schema => {
+	const entity = schema.model.entities.Product
+	const column = entity.fields[field] as Model.AnyColumn
+	return {
+		...schema,
+		model: {
+			...schema.model,
+			entities: {
+				...schema.model.entities,
+				Product: {
+					...entity,
+					fields: {
+						...entity.fields,
+						[field]: { ...column, columnType },
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -19,38 +42,26 @@ test('reverse codegen round-trips numericColumn(precision, scale)', () => {
 })
 
 test('reverse codegen parses arbitrary whitespace/casing in numeric(p, s)', () => {
-	const schema = createSchema(NumericModel)
-	// Mutate the stored columnType to an equivalent-but-unusual form to exercise the regex.
-	schema.model.entities.Product.fields.price = {
-		...(schema.model.entities.Product.fields.price as Model.AnyColumn),
-		columnType: 'NUMERIC ( 30 ,  10 )',
-	}
+	// An equivalent-but-unusual form must still be parsed by the regex.
+	const schema = withColumnType(createSchema(NumericModel), 'price', 'NUMERIC ( 30 ,  10 )')
 
 	const generated = new DefinitionCodeGenerator().generate(schema)
 	expect(generated).toContain('price = c.numericColumn(30, 10).notNull()')
 })
 
 test('reverse codegen falls back when columnType is not parseable', () => {
-	const schema = createSchema(NumericModel)
-	// An unparseable columnType (e.g. a bare "numeric" without precision/scale, or a domain type)
-	// must fall back to a default numericColumn(...) plus an explicit columnType(...).
-	schema.model.entities.Product.fields.price = {
-		...(schema.model.entities.Product.fields.price as Model.AnyColumn),
-		columnType: 'my_money_domain',
-	}
+	// An unparseable columnType (e.g. a domain type) must fall back to a default
+	// numericColumn(...) plus an explicit columnType(...).
+	const schema = withColumnType(createSchema(NumericModel), 'price', 'my_money_domain')
 
 	const generated = new DefinitionCodeGenerator().generate(schema)
 	expect(generated).toContain("price = c.numericColumn(30, 10).columnType('my_money_domain').notNull()")
 })
 
 test('reverse codegen fallback omits columnType when it equals the default', () => {
-	const schema = createSchema(NumericModel)
 	// A bare "numeric" is not matched by the precision/scale regex, but equals the default
 	// column type, so no redundant columnType(...) should be emitted.
-	schema.model.entities.Product.fields.discount = {
-		...(schema.model.entities.Product.fields.discount as Model.AnyColumn),
-		columnType: 'numeric',
-	}
+	const schema = withColumnType(createSchema(NumericModel), 'discount', 'numeric')
 
 	const generated = new DefinitionCodeGenerator().generate(schema)
 	expect(generated).toContain('discount = c.numericColumn(30, 10)')

--- a/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/numericColumnCodeGenerator.test.ts
@@ -1,0 +1,59 @@
+import { createSchema } from '@contember/schema-definition'
+import { c } from '@contember/schema-definition'
+import { expect, test } from 'bun:test'
+import { Model } from '@contember/schema'
+import { DefinitionCodeGenerator } from '../../../src/definition-generator/DefinitionCodeGenerator'
+
+namespace NumericModel {
+	export class Product {
+		price = c.numericColumn(20, 9).notNull()
+		discount = c.numericColumn(5, 2)
+	}
+}
+
+test('reverse codegen round-trips numericColumn(precision, scale)', () => {
+	const schema = createSchema(NumericModel)
+	const generated = new DefinitionCodeGenerator().generate(schema)
+
+	expect(generated).toContain('price = c.numericColumn(20, 9).notNull()')
+	expect(generated).toContain('discount = c.numericColumn(5, 2)')
+})
+
+test('reverse codegen parses arbitrary whitespace/casing in numeric(p, s)', () => {
+	const schema = createSchema(NumericModel)
+	// Mutate the stored columnType to an equivalent-but-unusual form to exercise the regex.
+	schema.model.entities.Product.fields.price = {
+		...(schema.model.entities.Product.fields.price as Model.AnyColumn),
+		columnType: 'NUMERIC ( 30 ,  10 )',
+	}
+
+	const generated = new DefinitionCodeGenerator().generate(schema)
+	expect(generated).toContain('price = c.numericColumn(30, 10).notNull()')
+})
+
+test('reverse codegen falls back when columnType is not parseable', () => {
+	const schema = createSchema(NumericModel)
+	// An unparseable columnType (e.g. a bare "numeric" without precision/scale, or a domain type)
+	// must fall back to a default numericColumn(...) plus an explicit columnType(...).
+	schema.model.entities.Product.fields.price = {
+		...(schema.model.entities.Product.fields.price as Model.AnyColumn),
+		columnType: 'my_money_domain',
+	}
+
+	const generated = new DefinitionCodeGenerator().generate(schema)
+	expect(generated).toContain("price = c.numericColumn(30, 10).columnType('my_money_domain').notNull()")
+})
+
+test('reverse codegen fallback omits columnType when it equals the default', () => {
+	const schema = createSchema(NumericModel)
+	// A bare "numeric" is not matched by the precision/scale regex, but equals the default
+	// column type, so no redundant columnType(...) should be emitted.
+	schema.model.entities.Product.fields.discount = {
+		...(schema.model.entities.Product.fields.discount as Model.AnyColumn),
+		columnType: 'numeric',
+	}
+
+	const generated = new DefinitionCodeGenerator().generate(schema)
+	expect(generated).toContain('discount = c.numericColumn(30, 10)')
+	expect(generated).not.toContain("columnType('numeric')")
+})

--- a/packages/schema/src/schema/model.ts
+++ b/packages/schema/src/schema/model.ts
@@ -39,6 +39,7 @@ export namespace Model {
 		String = 'String',
 		Int = 'Integer',
 		Double = 'Double',
+		Numeric = 'Numeric',
 		Bool = 'Bool',
 		Enum = 'Enum',
 		DateTime = 'DateTime',


### PR DESCRIPTION
## What & why

Adds a `numeric(precision, scale)` column type, addressing the absence of an exact decimal type (only `intColumn`/`doubleColumn` existed, both lossy for money-like values).

```ts
class Product {
  price = def.numericColumn(20, 9).notNull()
}
```

This emits a Postgres `numeric(20, 9)` column. Filtering (`gt`/`lt`/`eq`/`in`/...) and ordering work like other numeric types — they reuse the existing operator infra, since the GraphQL condition/order types are derived generically from the column's scalar.

Closes #730

## Design notes

**Transport as string.** `numeric` values can exceed JS `number` precision, so they are transported as strings (never JS floats):
- A new GraphQL `Decimal` scalar (in `CustomTypesProvider`) serializes/parses values as validated decimal strings. Plain JSON numbers are also accepted on input and normalized to a string.
- On read, the column is cast to `::text` in `FieldsVisitor` (and in import/export executors) so the API always returns a string.
- The condition value schema (`type-schema/condition.ts`) types `Numeric` as a string, so `gt: "100.5"` is accepted; string-only operators (`contains`, etc.) are *not* offered.

**Precision form.** The returned string is the exact Postgres `numeric` text representation, which includes trailing zeros up to the column scale (e.g. `numeric(20, 9)` returns `123.450000000`). This is lossless and stable. A trimmed/canonical form (`123.45`) would have required `trim_scale()`, which is **PostgreSQL 13+** only — and the CI DB matrix still includes PG 12 — so the full-scale form is the documented default. This is noted in the `numericColumn` JSDoc.

**Wiring.** New `Model.ColumnType.Numeric` member; `resolveDefaultColumnType` → `numeric`; reverse codegen (`DefinitionCodeGenerator`) parses precision/scale back into `numericColumn(p, s)`; SDK type generator maps it to `string`.

## Tests

- `schema-definition`: `numericColumn(p, s)` produces `numeric(p, s)`.
- `schema-migrations`: `createColumn` emits `numeric(20, 9)`.
- `engine-content-api`: string transport via `::text` cast + numeric `gt` filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)