### PR TITLE
feat(tenant): unpersisted root tokens

### DIFF
--- a/docs/src/content/docs/reference/engine/tenant/overview.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/overview.mdx
@@ -18,6 +18,19 @@ The default tokens for the `login` and `super_admin` roles are configured via th
 
 The login token authorizes the public auth flows: `signIn`, `signInIDP`, `signInPasswordless`, `createResetPasswordRequest`, `resetPassword`, `signUp`.
 
+### Unpersisted root tokens
+
+`CONTEMBER_ROOT_TOKEN` is seeded into the tenant database during setup — its hash is stored in the `api_key` table. As an alternative (or in addition), you can configure **unpersisted** root tokens that are verified at runtime and resolve to a `super_admin` identity **without being stored in the database**:
+
+- `CONTEMBER_ROOT_TOKENS` — a comma- or whitespace-separated list of plain root tokens.
+- `CONTEMBER_ROOT_TOKEN_HASHES` — a comma- or whitespace-separated list of sha256 hashes (lower- or upper-case hex) of root tokens, so the plain secret never has to be handed to the engine.
+
+In the JSON/YAML config these map to `tenant.credentials.rootTokens` and `tenant.credentials.rootTokenHashes`, which may also be supplied as arrays.
+
+Because these tokens are never written to the database, rotation is trivial — just change the environment variable (or config) and restart; no migration or database write is involved, and revoking a token is as simple as removing it from the list. Incoming tokens are matched against the configured hashes using a constant-time comparison.
+
+A request authenticated by an unpersisted root token is granted the `super_admin` role (full access) and is attributed to a fixed virtual identity id that has no row in the `identity` table.
+
 ## Choosing the right token
 
 Picking the correct token for a given operation can be confusing. The canonical example — generating a permanent API key so an application can read from the Content API:

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -91,6 +91,9 @@ export const tenantConfigSchema = Typesafe.intersection(
 			rootPassword: Typesafe.string,
 			rootEmail: Typesafe.string,
 			loginToken: Typesafe.string,
+			// Either a JSON array of tokens, or a comma-separated string (for env-based config).
+			rootTokens: Typesafe.union(Typesafe.array(Typesafe.string), Typesafe.string),
+			rootTokenHashes: Typesafe.union(Typesafe.array(Typesafe.string), Typesafe.string),
 		}),
 	}),
 	Typesafe.object({

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -54,6 +54,8 @@ export const configTemplate: any = {
 			rootTokenHash: '%?env.CONTEMBER_ROOT_TOKEN_HASH%',
 			rootPassword: '%?env.CONTEMBER_ROOT_PASSWORD%',
 			loginToken: '%?env.CONTEMBER_LOGIN_TOKEN%',
+			rootTokens: '%?env.CONTEMBER_ROOT_TOKENS%',
+			rootTokenHashes: '%?env.CONTEMBER_ROOT_TOKEN_HASHES%',
 		},
 		secrets: {
 			encryptionKey: '%?env.CONTEMBER_ENCRYPTION_KEY%',

--- a/packages/engine-http/src/projectGroup/ProjectGroupContainer.ts
+++ b/packages/engine-http/src/projectGroup/ProjectGroupContainer.ts
@@ -26,6 +26,21 @@ import { ProjectMembershipFetcher, ProjectMembershipResolver } from '../content/
 import { Providers } from '../providers.js'
 import { CryptoWrapper } from '../utils/CryptoWrapper.js'
 
+/**
+ * Normalizes a token list that may be provided either as an array (JSON config)
+ * or as a comma/whitespace-separated string (env-based config) into an array of
+ * non-empty tokens.
+ */
+const normalizeTokenList = (value: string | readonly string[] | undefined): readonly string[] | undefined => {
+	if (value === undefined) {
+		return undefined
+	}
+	const items = (Array.isArray(value) ? value : (value as string).split(/[\s,]+/))
+		.map(it => it.trim())
+		.filter(it => it.length > 0)
+	return items.length > 0 ? items : undefined
+}
+
 export interface ProjectGroupContainer {
 	slug: string | undefined
 
@@ -98,7 +113,11 @@ export class ProjectGroupContainerFactory {
 					readConnection: tenantReadConnection,
 					dbCredentials: tenantDbCredentials,
 					mailOptions: config.mailer,
-					tenantCredentials: config.credentials,
+					tenantCredentials: {
+						...config.credentials,
+						rootTokens: normalizeTokenList(config.credentials.rootTokens),
+						rootTokenHashes: normalizeTokenList(config.credentials.rootTokenHashes),
+					},
 					projectInitializer,
 					projectSchemaResolver,
 					cryptoProviders: {

--- a/packages/engine-tenant-api/CLAUDE.md
+++ b/packages/engine-tenant-api/CLAUDE.md
@@ -26,7 +26,8 @@ CQRS pattern with Command/Query separation via `CommandBus` and `DatabaseQuery`.
 
 ## Key Services
 
-- `ApiKeyManager` — token creation, verification, prolongation
+- `ApiKeyManager` — token creation, verification, prolongation. `verifyAndProlong` first consults `UnpersistedApiKeyManager` (configured root tokens, constant-time hash match, no DB row) and only then falls back to the `api_key` table lookup.
+- `UnpersistedApiKeyManager` — verifies configured root tokens that are NOT stored in the DB (enables zero-write rotation); built from `tenantCredentials.rootTokens` / `rootTokenHashes`, resolves to a fixed virtual `super_admin` identity (`UNPERSISTED_ROOT_IDENTITY_ID`).
 - `OtpManager` — TOTP 2FA setup/confirm/disable
 - `SecretsManager` — encrypted project secrets
 - `ConfigurationManager` — tenant-wide config (password policies, login settings, passwordless)

--- a/packages/engine-tenant-api/src/TenantContainer.ts
+++ b/packages/engine-tenant-api/src/TenantContainer.ts
@@ -48,6 +48,7 @@ import {
 	SignInManager,
 	SignUpManager,
 	TurnstileProvider,
+	UnpersistedApiKeyManager,
 	UserMailer,
 } from './model/index.js'
 import { HibpChecker, HttpHibpChecker, NoopHibpChecker } from './model/service/HibpChecker.js'
@@ -182,10 +183,15 @@ export class TenantContainerFactory {
 				return idpRegistry
 			})
 			.addService('idpSessionRevalidator', ({ idpRegistry }) => new IdpSessionRevalidator(idpRegistry))
+			.addService('unpersistedApiKeyManager', () =>
+				UnpersistedApiKeyManager.createForRootTokens({
+					tokens: args.tenantCredentials.rootTokens,
+					tokenHashes: args.tenantCredentials.rootTokenHashes,
+				}))
 			.addService(
 				'apiKeyManager',
-				({ apiKeyService, authPolicyResolver, authLogService, idpSessionRevalidator }) =>
-					new ApiKeyManager(apiKeyService, authPolicyResolver, authLogService, idpSessionRevalidator),
+				({ apiKeyService, authPolicyResolver, authLogService, unpersistedApiKeyManager, idpSessionRevalidator }) =>
+					new ApiKeyManager(apiKeyService, authPolicyResolver, authLogService, unpersistedApiKeyManager, idpSessionRevalidator),
 			)
 			.addService('emailValidator', () => new EmailValidator())
 			.addService('hibpChecker', (): HibpChecker => new HttpHibpChecker())

--- a/packages/engine-tenant-api/src/migrations/runner.ts
+++ b/packages/engine-tenant-api/src/migrations/runner.ts
@@ -69,6 +69,17 @@ export interface TenantCredentials {
 	rootToken?: string
 	rootTokenHash?: string
 	rootPassword?: string
+	/**
+	 * Unpersisted root tokens (plain values). When set, these tokens are
+	 * verified at runtime and resolve to a super-admin identity without being
+	 * stored in the database. Useful for easy rotation.
+	 */
+	rootTokens?: readonly string[]
+	/**
+	 * Unpersisted root token hashes (sha256 hex). Same as {@link rootTokens} but
+	 * the plain token never needs to be passed to the engine.
+	 */
+	rootTokenHashes?: readonly string[]
 }
 
 const migrations = {

--- a/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts
+++ b/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts
@@ -21,12 +21,14 @@ import { intervalToPostgres, intervalToSeconds } from '../../utils/interval.js'
 import { AuthPolicyResolver } from '../AuthPolicyResolver.js'
 import { AuthLogService } from '../AuthLogService.js'
 import { IdpSessionRevalidator } from '../idp/IdpSessionRevalidator.js'
+import { UnpersistedApiKeyManager } from './UnpersistedApiKeyManager.js'
 
 export class ApiKeyManager {
 	constructor(
 		private readonly apiKeyService: ApiKeyService,
 		private readonly authPolicyResolver: AuthPolicyResolver,
 		private readonly authLogService: AuthLogService,
+		private readonly unpersistedApiKeyManager: UnpersistedApiKeyManager = new UnpersistedApiKeyManager(),
 		private readonly idpSessionRevalidator?: IdpSessionRevalidator,
 	) {}
 
@@ -37,6 +39,12 @@ export class ApiKeyManager {
 		requestInfo?: ApiKeyRequestInfo,
 		forwardedInfo?: ApiKeyRequestInfo,
 	): Promise<VerifyResponse> {
+		const unpersistedResult = this.unpersistedApiKeyManager.verify(token)
+		if (unpersistedResult !== null) {
+			// Configured (unpersisted) root token: no DB row to prolong/track.
+			return new ResponseOk(unpersistedResult)
+		}
+
 		const apiKeyRow = await readDbContext.queryHandler.fetch(new ApiKeyByTokenQuery(token))
 		if (apiKeyRow === null) {
 			return new ResponseError(VerifyErrorCode.NOT_FOUND, 'API key was not found')

--- a/packages/engine-tenant-api/src/model/service/apiKey/UnpersistedApiKeyManager.ts
+++ b/packages/engine-tenant-api/src/model/service/apiKey/UnpersistedApiKeyManager.ts
@@ -1,0 +1,99 @@
+import { computeTokenHash, isTokenHash, timingSafeCompareHash, TokenHash } from '../../utils/index.js'
+import { TenantRole } from '../../authorization/index.js'
+import { VerifyResult } from './ApiKeyManager.js'
+
+/**
+ * Well-known identity id used for super-admin identities authenticated via an
+ * unpersisted (configured) root token. The id is stable so that audit logs and
+ * created entities consistently reference the same virtual identity, even
+ * though no row exists in the `identity` table.
+ */
+export const UNPERSISTED_ROOT_IDENTITY_ID = 'f3b2c4d6-0000-4000-8000-000000000001'
+
+export interface UnpersistedApiKey {
+	readonly tokenHash: TokenHash
+	readonly identityId: string
+	readonly roles: readonly string[]
+}
+
+/**
+ * Verifies incoming tokens against a fixed set of root tokens configured out of
+ * band (env/config) instead of being stored in the database. This enables token
+ * rotation without database writes and avoids persisting the token hash.
+ *
+ * Token hashes are compared in constant time to avoid leaking information about
+ * the configured secret.
+ */
+export class UnpersistedApiKeyManager {
+	private readonly apiKeys: readonly UnpersistedApiKey[]
+
+	constructor(apiKeys: readonly UnpersistedApiKey[] = []) {
+		this.apiKeys = apiKeys
+	}
+
+	get isEmpty(): boolean {
+		return this.apiKeys.length === 0
+	}
+
+	verify(token: string): VerifyResult | null {
+		if (this.apiKeys.length === 0) {
+			return null
+		}
+		const tokenHash = computeTokenHash(token)
+		// Iterate over all configured keys (no early return) so that matching
+		// remains independent of the position of the matching key.
+		let matched: UnpersistedApiKey | null = null
+		for (const apiKey of this.apiKeys) {
+			if (timingSafeCompareHash(tokenHash, apiKey.tokenHash)) {
+				matched = apiKey
+			}
+		}
+		if (matched === null) {
+			return null
+		}
+		return new VerifyResult(
+			matched.identityId,
+			// There is no persisted api_key row, so there is no api key id.
+			matched.identityId,
+			[...matched.roles],
+			null,
+			false,
+		)
+	}
+
+	static createRootApiKey(tokenHash: TokenHash): UnpersistedApiKey {
+		return {
+			tokenHash,
+			identityId: UNPERSISTED_ROOT_IDENTITY_ID,
+			roles: [TenantRole.SUPER_ADMIN],
+		}
+	}
+
+	/**
+	 * Builds a manager for unpersisted super-admin root tokens from configured
+	 * plain tokens and/or pre-computed token hashes.
+	 */
+	static createForRootTokens(input: {
+		tokens?: readonly string[]
+		tokenHashes?: readonly string[]
+	}): UnpersistedApiKeyManager {
+		const hashes: TokenHash[] = []
+		for (const token of input.tokens ?? []) {
+			if (token.length === 0) {
+				continue
+			}
+			hashes.push(computeTokenHash(token))
+		}
+		for (const hash of input.tokenHashes ?? []) {
+			if (hash.length === 0) {
+				continue
+			}
+			const normalized = hash.toLowerCase()
+			if (!isTokenHash(normalized)) {
+				throw new Error(`Invalid unpersisted root token hash: expected a 64-character sha256 hex string.`)
+			}
+			hashes.push(normalized)
+		}
+		return new UnpersistedApiKeyManager(hashes.map(it => UnpersistedApiKeyManager.createRootApiKey(it)))
+	}
+}

--- a/packages/engine-tenant-api/src/model/service/apiKey/index.ts
+++ b/packages/engine-tenant-api/src/model/service/apiKey/index.ts
@@ -1,2 +1,3 @@
 export * from './ApiKeyManager.js'
 export * from './ApiKeyService.js'
+export * from './UnpersistedApiKeyManager.js'

--- a/packages/engine-tenant-api/src/model/utils/token.ts
+++ b/packages/engine-tenant-api/src/model/utils/token.ts
@@ -23,6 +23,20 @@ export const isTokenHash = (token: string): token is TokenHash => isFixedLengthH
 
 export const MAX_OTP_ATTEMPTS = 3
 
+/**
+ * Constant-time comparison of two token hashes. Both inputs are expected to be
+ * 64-character hex strings (sha256). Returns false on any length mismatch
+ * without leaking timing information about the matching prefix.
+ */
+export const timingSafeCompareHash = (a: TokenHash, b: TokenHash): boolean => {
+	const bufferA = Buffer.from(a, 'hex')
+	const bufferB = Buffer.from(b, 'hex')
+	if (bufferA.length !== bufferB.length) {
+		return false
+	}
+	return crypto.timingSafeEqual(bufferA, bufferB)
+}
+
 export const validateToken = ({ entry, validationType, token, now }: {
 	entry: PersonToken.Row | null
 	validationType: PersonToken.ValidationType

--- a/packages/engine-tenant-api/tests/cases/unit/apiKey/unpersistedApiKeyManager.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/apiKey/unpersistedApiKeyManager.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from 'bun:test'
+import {
+	ApiKeyManager,
+	ApiKeyService,
+	AuthLogService,
+	AuthPolicyResolver,
+	computeTokenHash,
+	DatabaseContext,
+	Providers,
+	TenantRole,
+	UNPERSISTED_ROOT_IDENTITY_ID,
+	UnpersistedApiKeyManager,
+} from '../../../../src/index.js'
+import { createConnectionMock, ExpectedQuery } from '@contember/database-tester'
+
+const baseProviders: Providers = {
+	bcrypt: () => Promise.resolve('x'),
+	bcryptCompare: () => Promise.resolve(true),
+	now: () => new Date('2026-05-12T12:00:00Z'),
+	randomBytes: () => Promise.resolve(Buffer.alloc(0)),
+	uuid: () => '00000000-0000-0000-0000-000000000000',
+	encryptionEnabled: false,
+	decrypt: () => {
+		throw new Error('not supported')
+	},
+	encrypt: () => {
+		throw new Error('not supported')
+	},
+	hash: () => Buffer.alloc(0),
+}
+
+test('verify returns null when no root tokens are configured', () => {
+	const manager = new UnpersistedApiKeyManager()
+	expect(manager.isEmpty).toBe(true)
+	expect(manager.verify('anything')).toBeNull()
+})
+
+test('verify resolves a configured plain root token to super-admin', () => {
+	const manager = UnpersistedApiKeyManager.createForRootTokens({ tokens: ['my-secret-root-token'] })
+	expect(manager.isEmpty).toBe(false)
+
+	const result = manager.verify('my-secret-root-token')
+	expect(result).not.toBeNull()
+	expect(result!.identityId).toBe(UNPERSISTED_ROOT_IDENTITY_ID)
+	expect(result!.roles).toEqual([TenantRole.SUPER_ADMIN])
+	expect(result!.personId).toBeNull()
+})
+
+test('verify resolves a configured root token hash to super-admin', () => {
+	const tokenHash = computeTokenHash('hashed-root-token')
+	const manager = UnpersistedApiKeyManager.createForRootTokens({ tokenHashes: [tokenHash] })
+
+	const result = manager.verify('hashed-root-token')
+	expect(result).not.toBeNull()
+	expect(result!.identityId).toBe(UNPERSISTED_ROOT_IDENTITY_ID)
+	expect(result!.roles).toEqual([TenantRole.SUPER_ADMIN])
+})
+
+test('verify accepts upper-case token hashes', () => {
+	const tokenHash = computeTokenHash('case-insensitive').toUpperCase()
+	const manager = UnpersistedApiKeyManager.createForRootTokens({ tokenHashes: [tokenHash] })
+	expect(manager.verify('case-insensitive')).not.toBeNull()
+})
+
+test('verify returns null for a non-matching token', () => {
+	const manager = UnpersistedApiKeyManager.createForRootTokens({ tokens: ['correct'] })
+	expect(manager.verify('wrong')).toBeNull()
+})
+
+test('createForRootTokens rejects malformed token hashes', () => {
+	expect(() => UnpersistedApiKeyManager.createForRootTokens({ tokenHashes: ['not-a-valid-hash'] })).toThrow()
+})
+
+test('createForRootTokens ignores empty entries', () => {
+	const manager = UnpersistedApiKeyManager.createForRootTokens({ tokens: ['', 'real'], tokenHashes: [''] })
+	expect(manager.verify('real')).not.toBeNull()
+	expect(manager.verify('')).toBeNull()
+})
+
+const createDbContext = (expectedQueries: ExpectedQuery[]) => {
+	const connection = createConnectionMock(expectedQueries)
+	const client = connection.createClient('tenant', { module: 'tenant' })
+	return new DatabaseContext(client, baseProviders)
+}
+
+test('verifyAndProlong short-circuits an unpersisted root token without touching the database', async () => {
+	const unpersisted = UnpersistedApiKeyManager.createForRootTokens({ tokens: ['unpersisted-root'] })
+	const manager = new ApiKeyManager(new ApiKeyService(), new AuthPolicyResolver(), new AuthLogService(), unpersisted)
+
+	// No expected queries: any DB access would throw.
+	const dbContext = createDbContext([])
+	const readDbContext = createDbContext([])
+
+	const response = await manager.verifyAndProlong(dbContext, readDbContext, 'unpersisted-root')
+	expect(response.ok).toBe(true)
+	if (response.ok) {
+		expect(response.result.identityId).toBe(UNPERSISTED_ROOT_IDENTITY_ID)
+		expect(response.result.roles).toEqual([TenantRole.SUPER_ADMIN])
+	}
+})
+
+test('verifyAndProlong falls through to the database for a non-matching token', async () => {
+	const unpersisted = UnpersistedApiKeyManager.createForRootTokens({ tokens: ['unpersisted-root'] })
+	const manager = new ApiKeyManager(new ApiKeyService(), new AuthPolicyResolver(), new AuthLogService(), unpersisted)
+
+	const tokenHash = computeTokenHash('some-db-token')
+	const readDbContext = createDbContext([
+		{
+			sql:
+				'select "api_key"."id", "api_key"."type", "api_key"."identity_id", "api_key"."disabled_at", "api_key"."expires_at", "identity"."roles", "api_key"."expiration", "person"."id" as "person_id", "api_key"."last_ip", "api_key"."last_user_agent", "api_key"."last_used_at", "api_key"."trust_forwarded_info", "api_key"."issued_at", "api_key"."idle_timeout", "api_key"."max_expires_at" from "tenant"."api_key" inner join "tenant"."identity" as "identity" on "api_key"."identity_id" = "identity"."id" left join "tenant"."person" as "person" on "person"."identity_id" = "identity"."id" where "token_hash" = ?',
+			parameters: [tokenHash],
+			response: { rows: [] },
+		},
+	])
+	const dbContext = createDbContext([])
+
+	const response = await manager.verifyAndProlong(dbContext, readDbContext, 'some-db-token')
+	expect(response.ok).toBe(false)
+})

--- a/packages/engine-tenant-api/tests/cases/unit/apiKey/unpersistedApiKeyManager.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/apiKey/unpersistedApiKeyManager.test.ts
@@ -67,6 +67,24 @@ test('verify returns null for a non-matching token', () => {
 	expect(manager.verify('wrong')).toBeNull()
 })
 
+test('verify resolves every configured token, regardless of position', () => {
+	// Mix of plain tokens and a pre-computed hash; every one must resolve.
+	// This also guards the constant-time loop, which intentionally does not
+	// early-return on the first match.
+	const manager = UnpersistedApiKeyManager.createForRootTokens({
+		tokens: ['first-token', 'second-token'],
+		tokenHashes: [computeTokenHash('third-token')],
+	})
+
+	for (const token of ['first-token', 'second-token', 'third-token']) {
+		const result = manager.verify(token)
+		expect(result).not.toBeNull()
+		expect(result!.identityId).toBe(UNPERSISTED_ROOT_IDENTITY_ID)
+		expect(result!.roles).toEqual([TenantRole.SUPER_ADMIN])
+	}
+	expect(manager.verify('unknown-token')).toBeNull()
+})
+
 test('createForRootTokens rejects malformed token hashes', () => {
 	expect(() => UnpersistedApiKeyManager.createForRootTokens({ tokenHashes: ['not-a-valid-hash'] })).toThrow()
 })


### PR DESCRIPTION
## What & why

Currently the root (super-admin) token is seeded into the tenant database during setup — its sha256 hash is stored in the \`api_key\` table. Rotating it requires a DB write, and the hash lives in the database.

This PR adds **unpersisted root tokens**: a configured set of root tokens that are verified at runtime and resolve to a \`super_admin\` identity **without any \`api_key\` row**. This enables trivial, zero-write rotation (change config + restart) and avoids storing the token or its hash in the DB.

Closes #389

## Design

- New \`UnpersistedApiKeyManager\` (engine-tenant-api) holds a set of configured root-token sha256 hashes and resolves a matching token to a fixed virtual \`super_admin\` identity (\`UNPERSISTED_ROOT_IDENTITY_ID\`) with no DB row.
- \`ApiKeyManager.verifyAndProlong\` consults the unpersisted manager **first** and only falls back to the existing \`ApiKeyByTokenQuery\` DB lookup on no match. The persisted-token flow is unchanged and fully backward compatible (the second constructor arg is optional and defaults to an empty manager).
- Configuration (engine-http): \`CONTEMBER_ROOT_TOKENS\` (plain tokens) and \`CONTEMBER_ROOT_TOKEN_HASHES\` (sha256 hex), or the config keys \`tenant.credentials.rootTokens\` / \`rootTokenHashes\`. Each accepts a JSON array or a comma/whitespace-separated string; values are normalized before building the manager. Pre-computed hashes mean the plain secret never needs to be handed to the engine.
- These tokens are **not** seeded by the migration runner — the new \`TenantCredentials\` fields are consumed only by the runtime verifier.

## Security notes

- Incoming token hashes are matched against configured hashes using \`crypto.timingSafeEqual\` (\`timingSafeCompareHash\`), with a length guard. Matching iterates all configured keys without early return so it doesn't leak which/where a key matched.
- A matched request is granted \`super_admin\` (the same privilege the seeded root token grants — full ALL/ALL access) and is attributed to a fixed virtual identity id that has no row in the \`identity\` table. Downstream auth relies on the role wildcard, not on identity-row lookups.
- **Rotation:** add/remove entries in the env/config list and restart; no migration or DB write, and revoking is just removing the entry. Documented in \`docs/.../tenant/overview.mdx\`.

## Tests

Unit tests in \`tests/cases/unit/apiKey/unpersistedApiKeyManager.test.ts\`: match by plain token and by hash, case-insensitive hashes, malformed-hash rejection, empty-entry handling, \`verifyAndProlong\` short-circuiting with **zero** DB queries on match, and falling through to the DB lookup otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)