### PR TITLE
docs(schema): view dependencies cover tables, not just other views

### DIFF
--- a/docs/src/content/docs/reference/engine/schema/views.mdx
+++ b/docs/src/content/docs/reference/engine/schema/views.mdx
@@ -69,7 +69,7 @@ export class PendingActionEvents {
   state = c.stringColumn().notNull()
   visibleAt = c.dateTimeColumn().notNull()
 }
-````
+```
 
 This view surfaces pending action events queued in the system.
 
@@ -152,13 +152,25 @@ query {
 
 ### Handling Dependencies in View Entities
 
-If a view depends on other views, declare them using the `dependencies` option to ensure the correct migration order.
+Declare **every project entity the view's SQL reads from** — regular tables *and* other views — using the `dependencies` option:
 
 ```ts
-@c.View(`SELECT ...`, {
-  dependencies: () => [OtherViewEntity],
+@c.View(`SELECT * FROM author JOIN survey_answer_stats ...`, {
+  dependencies: () => [Author, SurveyAnswerStats],
 })
+export class AuthorReport {}
 ```
+
+Contember uses these declarations to:
+
+- **Order migrations correctly** — a view is always created after the entities (tables or views) it reads from.
+- **Recreate the view when a referenced column changes type** — PostgreSQL forbids altering the type of a column that is used by a view, so Contember has to `DROP` the dependent view, run the `ALTER`, and re-`CREATE` it. It can only do this for entities you list in `dependencies`.
+
+:::caution
+Declaring dependencies only on other **views** is a common mistake. If your view reads from a regular **table** and you omit it here, a later migration that changes a column's type on that table will **fail** with `cannot alter type of a column used by a view`. Always list the tables your view reads from, too.
+:::
+
+Use the arrow-function form (`() => [...]`) to avoid problems with circular imports between entity definitions.
 
 ---
 


### PR DESCRIPTION
## What

Rewrites the *Handling Dependencies in View Entities* section of the views docs.

## Why

The section said dependencies are for when *"a view depends on **other views**"* and only showed a view-on-view example. This is misleading: `dependencies` accepts **any** project entity, and the engine already drops & recreates a view when a column type changes on a **table** listed in its `dependencies` (see `RemoveViewDiffer` → `cascadeRemoveDependantViews`, and the existing test `recreate view dependent on entity after changing column type` which uses `dependencies: [Author]` on a plain table).

Because users followed the docs and only declared view-on-view deps, a view reading from a regular table didn't trigger the drop/recreate, so a later column-type change failed with `cannot alter type of a column used by a view` — this is the root cause of #828.

## Changes

- Document that `dependencies` must list **every project entity the view reads from — tables and views**.
- Explain the two reasons (migration ordering + column-type recreate) and add a `:::caution` about the table case.
- Fix a stray 4-backtick code fence in Example 1.

Refs #828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)