### PR TITLE
perf(schema-migrations): update views in-place via CREATE OR REPLACE

### DIFF
--- a/e2e/cases/content/view-update.test.ts
+++ b/e2e/cases/content/view-update.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from 'bun:test'
+import { createTester, gql } from '../../src/tester.js'
+import { c, createSchema, SchemaDefinition as def } from '@contember/schema-definition'
+import { ModificationHandlerFactory, SchemaDiffer, SchemaMigrator } from '@contember/schema-migrations'
+import { Schema } from '@contember/schema'
+
+const diffSchemas = (original: Schema, updated: Schema) => {
+	const differ = new SchemaDiffer(new SchemaMigrator(new ModificationHandlerFactory(ModificationHandlerFactory.defaultFactoryMap)))
+	return differ.diffSchemas(original, updated)
+}
+
+// Chain of dependent views: ViewC -> ViewB -> ViewA -> source table.
+namespace ViewChainV1 {
+	export class Source {
+		value = c.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM source')
+	export class ViewA {
+		value = def.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM view_a', { dependencies: [ViewA] })
+	export class ViewB {
+		value = def.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM view_b', { dependencies: [ViewB] })
+	export class ViewC {
+		value = def.intColumn()
+	}
+}
+
+// Only the SQL body of ViewA changes (value * 10); its output columns stay the same.
+namespace ViewChainV2InPlace {
+	export class Source {
+		value = c.intColumn()
+	}
+
+	@c.View('SELECT id, value * 10 AS value FROM source')
+	export class ViewA {
+		value = def.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM view_a', { dependencies: [ViewA] })
+	export class ViewB {
+		value = def.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM view_b', { dependencies: [ViewB] })
+	export class ViewC {
+		value = def.intColumn()
+	}
+}
+
+// ViewA gains a new output column -> structural change, requires drop & recreate cascade.
+namespace ViewChainV2Structural {
+	export class Source {
+		value = c.intColumn()
+	}
+
+	@c.View('SELECT id, value, value * 100 AS big FROM source')
+	export class ViewA {
+		value = def.intColumn()
+		big = def.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM view_a', { dependencies: [ViewA] })
+	export class ViewB {
+		value = def.intColumn()
+	}
+
+	@c.View('SELECT id, value FROM view_b', { dependencies: [ViewB] })
+	export class ViewC {
+		value = def.intColumn()
+	}
+}
+
+test('Content API: in-place view update (CREATE OR REPLACE) propagates through dependent views', async () => {
+	const tester = await createTester(createSchema(ViewChainV1))
+
+	await tester(gql`mutation { createSource(data: { value: 5 }) { ok } }`)
+		.expect({ data: { createSource: { ok: true } } })
+		.expect(200)
+
+	// before: 5 flows unchanged through the whole chain
+	await tester(gql`query { listViewC { value } }`)
+		.expect({ data: { listViewC: [{ value: 5 }] } })
+		.expect(200)
+
+	// the optimization: an sql-only change must compile to a single updateView, no dependant cascade
+	const diff = diffSchemas(createSchema(ViewChainV1), createSchema(ViewChainV2InPlace))
+	expect(diff).toHaveLength(1)
+	expect(diff[0].modification).toBe('updateView')
+	expect((diff[0] as any).entityName).toBe('ViewA')
+
+	await tester.migrate(diff, '2024-07-01-130000-update-view-a')
+
+	// after: ViewA now multiplies by 10; ViewB and ViewC were never recreated yet reflect the new value
+	await tester(gql`query { listViewC { value } }`)
+		.expect({ data: { listViewC: [{ value: 50 }] } })
+		.expect(200)
+})
+
+test('Content API: structural view change still cascades drop & recreate', async () => {
+	const tester = await createTester(createSchema(ViewChainV1))
+
+	await tester(gql`mutation { createSource(data: { value: 5 }) { ok } }`)
+		.expect({ data: { createSource: { ok: true } } })
+		.expect(200)
+
+	// adding a column to ViewA is not replaceable -> full cascade
+	const diff = diffSchemas(createSchema(ViewChainV1), createSchema(ViewChainV2Structural))
+	expect(diff.some(it => it.modification === 'updateView')).toBe(false)
+	expect(diff.filter(it => it.modification === 'removeEntity').map(it => (it as any).entityName))
+		.toEqual(['ViewC', 'ViewB', 'ViewA'])
+	expect(diff.some(it => it.modification === 'createView')).toBe(true)
+
+	await tester.migrate(diff, '2024-07-01-130000-add-view-a-column')
+
+	// the cascade rebuilt the whole chain; ViewC (which does not select the new column) is unaffected
+	await tester(gql`query { listViewC { value } }`)
+		.expect({ data: { listViewC: [{ value: 5 }] } })
+		.expect(200)
+
+	// the new column is available on the recreated ViewA
+	await tester(gql`query { listViewA { value big } }`)
+		.expect({ data: { listViewA: [{ value: 5, big: 500 }] } })
+		.expect(200)
+})

--- a/packages/cli/src/commands/migrations/MigrationDiffCommand.ts
+++ b/packages/cli/src/commands/migrations/MigrationDiffCommand.ts
@@ -15,6 +15,7 @@ type Options = {
 	execute?: true
 	yes?: true
 	'skip-initial-schema-validation'?: true
+	'recreate-views'?: true
 }
 
 export class MigrationDiffCommand extends Command<Args, Options> {
@@ -40,6 +41,12 @@ export class MigrationDiffCommand extends Command<Args, Options> {
 			.description('Do not ask for confirmation.')
 
 		configuration.option('skip-initial-schema-validation')
+		configuration //
+			.option('recreate-views')
+			.valueNone()
+			.description(
+				'Drop & recreate changed views instead of updating them in-place (CREATE OR REPLACE VIEW). Use when an in-place view update fails with SQLSTATE 42P16.',
+			)
 	}
 
 	protected async execute(input: Input<Args, Options>): Promise<void> {
@@ -47,6 +54,7 @@ export class MigrationDiffCommand extends Command<Args, Options> {
 		let shouldExecute = input.getOption('execute')
 		const yes = input.getOption('yes')
 		const skipInitialSchemaValidation = input.getOption('skip-initial-schema-validation') === true
+		const recreateViews = input.getOption('recreate-views') === true
 
 		const schema = await this.schemaLoader.loadSchema()
 		let stateMode = await this.schemaStateManager.isStateMode()
@@ -64,6 +72,7 @@ export class MigrationDiffCommand extends Command<Args, Options> {
 			const result = await this.migrationCreator.prepareMigration(initialSchema, schema, migrationName, {
 				skipInitialSchemaValidation: skipInitialSchemaValidation,
 				skipNonModelDiffers: stateMode,
+				recreateViews,
 			})
 
 			const schemaState = stateMode ? SchemaStateManager.schemaStateFromSchema(schema) : undefined

--- a/packages/cli/src/lib/migrations/MigrationExecutionFacade.ts
+++ b/packages/cli/src/lib/migrations/MigrationExecutionFacade.ts
@@ -115,19 +115,31 @@ export class MigrationExecutionFacade {
 			} while (true)
 		}
 
-		await this.migrationExecutor.executeMigrations({
-			client: this.systemClientProvider.get(),
-			migrations,
-			schemaState,
-			contentMigrationFactoryArgs: {
-				apiToken: project.token,
-				apiBaseUrl: project.endpoint,
-				projectName: project.name,
-				schemaVersionBuilder: this.schemaVersionBuilder,
-			},
-			log: message => console.log(message),
-			force,
-		})
+		try {
+			await this.migrationExecutor.executeMigrations({
+				client: this.systemClientProvider.get(),
+				migrations,
+				schemaState,
+				contentMigrationFactoryArgs: {
+					apiToken: project.token,
+					apiBaseUrl: project.endpoint,
+					projectName: project.name,
+					schemaVersionBuilder: this.schemaVersionBuilder,
+				},
+				log: message => console.log(message),
+				force,
+			})
+		} catch (e) {
+			if (isViewReplaceFailure(e)) {
+				console.error(
+					"\nAn in-place view update (CREATE OR REPLACE VIEW) failed — Postgres rejects it (SQLSTATE 42P16) when a view's"
+						+ ' output columns changed (e.g. reordered or retyped) even though its fields did not.\n'
+						+ 'Re-generate the migration with `migrations:diff <name> --recreate-views` to drop & recreate the affected'
+						+ ' views (and their dependants) instead.\n',
+				)
+			}
+			throw e
+		}
 		return true
 	}
 
@@ -166,3 +178,15 @@ export class MigrationExecutionFacade {
 
 const isProjectNotEmptyError = (e: unknown): boolean =>
 	Array.isArray(e) && e.some(it => it !== null && typeof it === 'object' && (it as { code?: unknown }).code === MigrateErrorCode.ProjectNotEmpty)
+
+// A failed `updateView` modification surfaces as MIGRATION_FAILED whose developerMessage embeds the failing
+// statement (`CREATE OR REPLACE VIEW …`). Since each modification's SQL is executed in isolation, that string
+// is a precise signal that an in-place view update — and not some other statement — is what Postgres rejected.
+const isViewReplaceFailure = (e: unknown): boolean =>
+	Array.isArray(e) && e.some(it =>
+		it !== null
+		&& typeof it === 'object'
+		&& (it as { code?: unknown }).code === MigrateErrorCode.MigrationFailed
+		&& typeof (it as { message?: unknown }).message === 'string'
+		&& (it as { message: string }).message.includes('CREATE OR REPLACE VIEW')
+	)

--- a/packages/migrations-client/src/MigrationCreator.ts
+++ b/packages/migrations-client/src/MigrationCreator.ts
@@ -25,11 +25,15 @@ export class MigrationCreator {
 		initialSchema: Schema,
 		newSchema: Schema,
 		migrationName: string,
-		{ skipInitialSchemaValidation = false, skipNonModelDiffers = false }: { skipInitialSchemaValidation?: boolean; skipNonModelDiffers?: boolean } = {},
+		{ skipInitialSchemaValidation = false, skipNonModelDiffers = false, recreateViews = false }: {
+			skipInitialSchemaValidation?: boolean
+			skipNonModelDiffers?: boolean
+			recreateViews?: boolean
+		} = {},
 	): Promise<{ migration: Migration; initialSchema: Schema } | null> {
 		await this.migrationFilesManager.createDirIfNotExist()
 
-		const modifications = this.schemaDiffer.diffSchemas(initialSchema, newSchema, { skipInitialSchemaValidation, skipNonModelDiffers })
+		const modifications = this.schemaDiffer.diffSchemas(initialSchema, newSchema, { skipInitialSchemaValidation, skipNonModelDiffers, recreateViews })
 		if (modifications.length === 0) {
 			return null
 		}

--- a/packages/schema-migrations/src/SchemaDiffer.ts
+++ b/packages/schema-migrations/src/SchemaDiffer.ts
@@ -43,7 +43,7 @@ import {
 	UpdateValidationSchemaDiffer,
 	VERSION_LATEST,
 } from './modifications/index.js'
-import { RemoveChangedFieldDiffer, RemoveViewDiffer } from './modifications/differs/index.js'
+import { RemoveChangedFieldDiffer, RemoveViewDiffer, UpdateViewDiffer } from './modifications/differs/index.js'
 import { CreateIndexDiffer, RemoveIndexDiffer } from './modifications/indexes/index.js'
 import { CreateTriggerDiffer, RemoveTriggerDiffer, UpdateTriggerDiffer } from './modifications/actions/index.js'
 import { UpdateTargetDiffer } from './modifications/actions/UpdateTargetModification.js'
@@ -109,6 +109,7 @@ export class SchemaDiffer {
 			new CreateColumnDiffer(),
 			new CreateRelationDiffer(),
 			new CreateViewDiffer(),
+			new UpdateViewDiffer(),
 			new CreateRelationInverseSideDiffer(),
 			new CreateUniqueConstraintDiffer(),
 			new CreateIndexDiffer(),

--- a/packages/schema-migrations/src/SchemaDiffer.ts
+++ b/packages/schema-migrations/src/SchemaDiffer.ts
@@ -53,7 +53,18 @@ import { UpdateSettingsDiffer } from './modifications/settings/index.js'
 import { RemoveIndexNamesDiffer } from './modifications/upgrade/RemoveIndexNamesModification.js'
 import { ConvertOneHasManyToOneHasOneRelationDiffer } from './modifications/relations/ConvertOneHasManyToOneHasOneRelationModification.js'
 
-export type DiffOptions = { skipRecreateValidation?: boolean; skipInitialSchemaValidation?: boolean; skipNonModelDiffers?: boolean }
+export type DiffOptions = {
+	skipRecreateValidation?: boolean
+	skipInitialSchemaValidation?: boolean
+	skipNonModelDiffers?: boolean
+	/**
+	 * Disable the in-place `CREATE OR REPLACE VIEW` optimization and drop & recreate every
+	 * changed view (with its dependant cascade) instead. Escape hatch for views whose real
+	 * output columns drifted without a matching field change (which would otherwise fail at
+	 * execute time with `SQLSTATE 42P16`).
+	 */
+	recreateViews?: boolean
+}
 
 export class SchemaDiffer {
 	constructor(
@@ -67,6 +78,7 @@ export class SchemaDiffer {
 		skipInitialSchemaValidation = false,
 		skipRecreateValidation = false,
 		skipNonModelDiffers = false,
+		recreateViews = false,
 	}: DiffOptions = {}): Migration.Modification[] {
 		if (!skipInitialSchemaValidation) {
 			const originalErrors = SchemaValidator.validate(originalSchema)
@@ -87,7 +99,7 @@ export class SchemaDiffer {
 			new ConvertOneHasManyToOneHasOneRelationDiffer(),
 			new RemoveUniqueConstraintDiffer(),
 			new RemoveIndexDiffer(),
-			new RemoveViewDiffer(),
+			new RemoveViewDiffer(recreateViews),
 			new RemoveEntityDiffer(),
 			new RemoveFieldDiffer(),
 			new CreateEnumDiffer(),
@@ -109,7 +121,7 @@ export class SchemaDiffer {
 			new CreateColumnDiffer(),
 			new CreateRelationDiffer(),
 			new CreateViewDiffer(),
-			new UpdateViewDiffer(),
+			...recreateViews ? [] : [new UpdateViewDiffer()],
 			new CreateRelationInverseSideDiffer(),
 			new CreateUniqueConstraintDiffer(),
 			new CreateIndexDiffer(),

--- a/packages/schema-migrations/src/modifications/differs/RemoveViewDiffer.ts
+++ b/packages/schema-migrations/src/modifications/differs/RemoveViewDiffer.ts
@@ -10,8 +10,15 @@ import { UpdateColumnDefinitionDiffer } from '../columns/index.js'
  * View changes that can be applied in-place via `CREATE OR REPLACE VIEW` (see
  * {@link isReplaceableViewChange}) are intentionally skipped here so they don't trigger
  * the drop cascade onto dependant views – those are handled by `UpdateViewDiffer`.
+ *
+ * When `recreateAllViews` is set, the in-place optimization is disabled and every changed
+ * view drops & recreates (with its dependant cascade) as before. This is the escape hatch
+ * for the rare case where a view's actual output columns drifted without a matching field
+ * change, which `CREATE OR REPLACE VIEW` would reject at execute time (`SQLSTATE 42P16`).
  */
 export class RemoveViewDiffer implements Differ {
+	constructor(private readonly recreateAllViews: boolean = false) {}
+
 	createDiff(originalSchema: Schema, updatedSchema: Schema) {
 		const changedOrRemovedViews = Object.values(originalSchema.model.entities)
 			.filter(it => {
@@ -35,7 +42,7 @@ export class RemoveViewDiffer implements Differ {
 
 				if (!deepEqual(updatedEntity.view, it.view)) {
 					// view changed – cascade only when it cannot be replaced in-place
-					return !isReplaceableViewChange(it, updatedEntity)
+					return this.recreateAllViews || !isReplaceableViewChange(it, updatedEntity)
 				}
 
 				return false

--- a/packages/schema-migrations/src/modifications/differs/RemoveViewDiffer.ts
+++ b/packages/schema-migrations/src/modifications/differs/RemoveViewDiffer.ts
@@ -1,11 +1,15 @@
 import { Differ } from '../ModificationHandler.js'
 import { Schema } from '@contember/schema'
 import deepEqual from 'fast-deep-equal'
-import { cascadeRemoveDependantViews } from '../utils/viewDependencies.js'
+import { cascadeRemoveDependantViews, isReplaceableViewChange } from '../utils/viewDependencies.js'
 import { UpdateColumnDefinitionDiffer } from '../columns/index.js'
 
 /**
- * Remove changed or removed view.
+ * Remove views that were removed or changed in a way that requires a drop & recreate.
+ *
+ * View changes that can be applied in-place via `CREATE OR REPLACE VIEW` (see
+ * {@link isReplaceableViewChange}) are intentionally skipped here so they don't trigger
+ * the drop cascade onto dependant views – those are handled by `UpdateViewDiffer`.
  */
 export class RemoveViewDiffer implements Differ {
 	createDiff(originalSchema: Schema, updatedSchema: Schema) {
@@ -30,7 +34,8 @@ export class RemoveViewDiffer implements Differ {
 				}
 
 				if (!deepEqual(updatedEntity.view, it.view)) {
-					return true // view is different
+					// view changed – cascade only when it cannot be replaced in-place
+					return !isReplaceableViewChange(it, updatedEntity)
 				}
 
 				return false

--- a/packages/schema-migrations/src/modifications/differs/UpdateViewDiffer.ts
+++ b/packages/schema-migrations/src/modifications/differs/UpdateViewDiffer.ts
@@ -1,0 +1,58 @@
+import { Differ } from '../ModificationHandler.js'
+import { Model, Schema } from '@contember/schema'
+import deepEqual from 'fast-deep-equal'
+import { Migration } from '../../Migration.js'
+import { isReplaceableViewChange } from '../utils/viewDependencies.js'
+import { updateViewModification } from '../entities/UpdateViewModification.js'
+
+/**
+ * Update a view in-place via `CREATE OR REPLACE VIEW` when only its definition
+ * (sql/dependencies/idSource) changed and its output columns stayed the same.
+ *
+ * This avoids dropping & recreating the whole dependant-view cascade (and the
+ * associated ACL / inverse-relation churn) that {@link RemoveViewDiffer} would
+ * otherwise produce. Views that had to be recreated structurally are already
+ * up to date in the running schema by the time this differ runs, so they are
+ * naturally skipped here.
+ */
+export class UpdateViewDiffer implements Differ {
+	createDiff(originalSchema: Schema, updatedSchema: Schema) {
+		const candidates = Object.values(updatedSchema.model.entities).filter(updated => {
+			const original = originalSchema.model.entities[updated.name]
+			if (!original?.view || !updated.view) {
+				return false
+			}
+			if (deepEqual(original.view, updated.view)) {
+				return false // view unchanged
+			}
+			return isReplaceableViewChange(original, updated)
+		})
+
+		// emit dependencies before dependants so a (future) appended column is available to dependants
+		const candidateNames = new Set(candidates.map(it => it.name))
+		const visited = new Set<string>()
+		const ordered: Model.Entity[] = []
+		const visit = (entity: Model.Entity) => {
+			if (visited.has(entity.name)) {
+				return
+			}
+			visited.add(entity.name)
+			for (const dependency of entity.view?.dependencies ?? []) {
+				if (candidateNames.has(dependency)) {
+					visit(updatedSchema.model.entities[dependency])
+				}
+			}
+			ordered.push(entity)
+		}
+		for (const candidate of candidates) {
+			visit(candidate)
+		}
+
+		return ordered.map((entity): Migration.Modification =>
+			updateViewModification.createModification({
+				entityName: entity.name,
+				view: entity.view!,
+			})
+		)
+	}
+}

--- a/packages/schema-migrations/src/modifications/differs/index.ts
+++ b/packages/schema-migrations/src/modifications/differs/index.ts
@@ -1,2 +1,3 @@
 export * from './RemoveChangedFieldDiffer.js'
 export * from './RemoveViewDiffer.js'
+export * from './UpdateViewDiffer.js'

--- a/packages/schema-migrations/src/modifications/utils/viewDependencies.ts
+++ b/packages/schema-migrations/src/modifications/utils/viewDependencies.ts
@@ -1,6 +1,30 @@
 import { Model } from '@contember/schema'
+import deepEqual from 'fast-deep-equal'
 import { Migration } from '../../Migration.js'
 import { removeEntityModification } from '../entities/index.js'
+
+/**
+ * Determines whether a view change can be applied in-place via `CREATE OR REPLACE VIEW`,
+ * i.e. without dropping & recreating the view (and cascading to its dependants).
+ *
+ * Postgres allows `CREATE OR REPLACE VIEW` only when the output columns stay the same
+ * (it may append new columns at the end). We conservatively allow it only when the
+ * entity is structurally identical and just the view metadata (`sql`/`dependencies`/`idSource`)
+ * differs. Materialized views are never replaceable (no `CREATE OR REPLACE MATERIALIZED VIEW`).
+ */
+export const isReplaceableViewChange = (original: Model.Entity, updated: Model.Entity): boolean => {
+	if (!original.view || !updated.view) {
+		return false
+	}
+	if (original.view.materialized || updated.view.materialized) {
+		return false
+	}
+	const stripView = (entity: Model.Entity): Omit<Model.Entity, 'view'> => {
+		const { view, ...rest } = entity
+		return rest
+	}
+	return deepEqual(stripView(original), stripView(updated))
+}
 
 type EntityDependantViews = Map<string, Set<Model.Entity>>
 export const getEntityDependantViews = (model: Model.Schema): EntityDependantViews => {

--- a/packages/schema-migrations/tests/cases/integration/updateView.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/updateView.test.ts
@@ -364,3 +364,119 @@ DROP VIEW "author";
 CREATE VIEW "author" AS SELECT null as id, 'John' AS name, 0 AS age;
 CREATE VIEW "author2" AS SELECT * FROM author;`,
 	}))
+
+namespace RecreateViewsOriginalSchema {
+	@def.View("SELECT null as id, 'John' AS name")
+	export class Author {
+		name = def.stringColumn()
+	}
+
+	@def.View('SELECT * FROM author', { dependencies: [Author] })
+	export class Author2 {
+		name = def.stringColumn()
+	}
+}
+
+namespace RecreateViewsUpdatedSchema {
+	@def.View("SELECT null as id, 'Jack' AS name")
+	export class Author {
+		name = def.stringColumn()
+	}
+
+	@def.View('SELECT * FROM author', { dependencies: [Author] })
+	export class Author2 {
+		name = def.stringColumn()
+	}
+}
+
+// escape hatch: with `recreateViews`, even an SQL-only change (which is replaceable in-place)
+// drops & recreates the whole dependant cascade instead of emitting a single updateView
+describe('recreate views opt-out - SQL-only change drops & recreates instead of CREATE OR REPLACE', () =>
+	testMigrations({
+		diffOptions: { recreateViews: true },
+		original: createSchema(RecreateViewsOriginalSchema),
+		updated: createSchema(RecreateViewsUpdatedSchema),
+		diff: [
+			{
+				modification: 'removeEntity',
+				entityName: 'Author2',
+			},
+			{
+				modification: 'removeEntity',
+				entityName: 'Author',
+			},
+			{
+				modification: 'createView',
+				entity: {
+					name: 'Author',
+					primary: 'id',
+					primaryColumn: 'id',
+					unique: [],
+					indexes: [],
+					fields: {
+						id: {
+							name: 'id',
+							columnName: 'id',
+							nullable: false,
+							type: 'Uuid',
+							columnType: 'uuid',
+						},
+						name: {
+							name: 'name',
+							columnName: 'name',
+							nullable: true,
+							type: 'String',
+							columnType: 'text',
+						},
+					},
+					tableName: 'author',
+					eventLog: {
+						enabled: true,
+					},
+					view: {
+						sql: "SELECT null as id, 'Jack' AS name",
+					},
+				},
+			},
+			{
+				modification: 'createView',
+				entity: {
+					name: 'Author2',
+					primary: 'id',
+					primaryColumn: 'id',
+					unique: [],
+					indexes: [],
+					fields: {
+						id: {
+							name: 'id',
+							columnName: 'id',
+							nullable: false,
+							type: 'Uuid',
+							columnType: 'uuid',
+						},
+						name: {
+							name: 'name',
+							columnName: 'name',
+							nullable: true,
+							type: 'String',
+							columnType: 'text',
+						},
+					},
+					tableName: 'author2',
+					eventLog: {
+						enabled: true,
+					},
+					view: {
+						sql: 'SELECT * FROM author',
+						dependencies: [
+							'Author',
+						],
+					},
+				},
+			},
+		],
+		sql: SQL`DROP VIEW "author2";
+DROP VIEW "author";
+CREATE VIEW "author" AS SELECT null as id, 'Jack' AS name;
+CREATE VIEW "author2" AS SELECT * FROM author;`,
+	}))

--- a/packages/schema-migrations/tests/cases/integration/updateView.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/updateView.test.ts
@@ -37,135 +37,20 @@ namespace ViewEntityUpdatedSchema1 {
 	}
 }
 
-describe('update a view 1', () =>
+describe('update a view 1 - replace sql in-place, no dependant cascade', () =>
 	testMigrations({
 		original: createSchema(ViewEntityOriginalSchema),
 		updated: createSchema(ViewEntityUpdatedSchema1),
 		diff: [
 			{
-				modification: 'removeEntity',
-				entityName: 'Author3',
-			},
-			{
-				modification: 'removeEntity',
-				entityName: 'Author2',
-			},
-			{
-				modification: 'removeEntity',
+				modification: 'updateView',
 				entityName: 'Author',
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author',
-					view: {
-						sql: "SELECT null as id, 'Jack' AS name",
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
-				},
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author2',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author2',
-					view: {
-						sql: 'SELECT * FROM author',
-						dependencies: [
-							'Author',
-						],
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
-				},
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author3',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author3',
-					view: {
-						sql: 'SELECT * FROM author2',
-						dependencies: [
-							'Author2',
-						],
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
+				view: {
+					sql: "SELECT null as id, 'Jack' AS name",
 				},
 			},
 		],
-		sql: SQL`DROP VIEW "author3";
-DROP VIEW "author2";
-DROP VIEW "author";
-CREATE VIEW "author" AS SELECT null as id, 'Jack' AS name;
-CREATE VIEW "author2" AS SELECT * FROM author;
-CREATE VIEW "author3" AS SELECT * FROM author2;`,
+		sql: SQL`CREATE OR REPLACE VIEW "author" AS SELECT null as id, 'Jack' AS name;`,
 	}))
 
 namespace ViewEntityUpdatedSchema2 {
@@ -185,97 +70,23 @@ namespace ViewEntityUpdatedSchema2 {
 	}
 }
 
-describe('update a view 2', () =>
+describe('update a view 2 - replace dependency in-place', () =>
 	testMigrations({
 		original: createSchema(ViewEntityOriginalSchema),
 		updated: createSchema(ViewEntityUpdatedSchema2),
 		diff: [
 			{
-				modification: 'removeEntity',
-				entityName: 'Author3',
-			},
-			{
-				modification: 'removeEntity',
+				modification: 'updateView',
 				entityName: 'Author2',
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author2',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author2',
-					view: {
-						sql: 'SELECT id, name FROM author',
-						dependencies: [
-							'Author',
-						],
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
-				},
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author3',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author3',
-					view: {
-						sql: 'SELECT * FROM author2',
-						dependencies: [
-							'Author2',
-						],
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
+				view: {
+					sql: 'SELECT id, name FROM author',
+					dependencies: [
+						'Author',
+					],
 				},
 			},
 		],
-		sql: SQL`DROP VIEW "author3";
-DROP VIEW "author2";
-CREATE VIEW "author2" AS SELECT id, name FROM author;
-CREATE VIEW "author3" AS SELECT * FROM author2;
-`,
+		sql: SQL`CREATE OR REPLACE VIEW "author2" AS SELECT id, name FROM author;`,
 	}))
 
 namespace ViewEntityUpdatedSchema3 {
@@ -295,54 +106,23 @@ namespace ViewEntityUpdatedSchema3 {
 	}
 }
 
-describe('update a view 3', () =>
+describe('update a view 3 - replace leaf view in-place', () =>
 	testMigrations({
 		original: createSchema(ViewEntityOriginalSchema),
 		updated: createSchema(ViewEntityUpdatedSchema3),
 		diff: [
 			{
-				modification: 'removeEntity',
+				modification: 'updateView',
 				entityName: 'Author3',
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author3',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author3',
-					view: {
-						sql: 'SELECT id, name FROM author2',
-						dependencies: [
-							'Author2',
-						],
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
+				view: {
+					sql: 'SELECT id, name FROM author2',
+					dependencies: [
+						'Author2',
+					],
 				},
 			},
 		],
-		sql: SQL`DROP VIEW "author3";
-CREATE VIEW "author3" AS SELECT id, name FROM author2;`,
+		sql: SQL`CREATE OR REPLACE VIEW "author3" AS SELECT id, name FROM author2;`,
 	}))
 
 namespace ViewEntityUpdatedSchema4 {
@@ -362,30 +142,76 @@ namespace ViewEntityUpdatedSchema4 {
 	}
 }
 
-describe('update a view 4', () =>
+describe('update a view 4 - replace whole chain in dependency order', () =>
 	testMigrations({
 		original: createSchema(ViewEntityOriginalSchema),
 		updated: createSchema(ViewEntityUpdatedSchema4),
 		diff: [
 			{
-				modification: 'removeEntity',
-				entityName: 'Author3',
-			},
-			{
-				modification: 'removeEntity',
-				entityName: 'Author2',
-			},
-			{
-				modification: 'removeEntity',
+				modification: 'updateView',
 				entityName: 'Author',
+				view: {
+					sql: "SELECT null as id, 'Jack' AS name",
+				},
+			},
+			{
+				modification: 'updateView',
+				entityName: 'Author2',
+				view: {
+					sql: 'SELECT id, name FROM author',
+					dependencies: [
+						'Author',
+					],
+				},
+			},
+			{
+				modification: 'updateView',
+				entityName: 'Author3',
+				view: {
+					sql: 'SELECT id, name FROM author2',
+					dependencies: [
+						'Author2',
+					],
+				},
+			},
+		],
+		sql: SQL`CREATE OR REPLACE VIEW "author" AS SELECT null as id, 'Jack' AS name;
+CREATE OR REPLACE VIEW "author2" AS SELECT id, name FROM author;
+CREATE OR REPLACE VIEW "author3" AS SELECT id, name FROM author2;`,
+	}))
+
+namespace MaterializedViewOriginalSchema {
+	@def.View("SELECT null as id, 'John' AS name", { materialized: true })
+	export class MatAuthor {
+		name = def.stringColumn()
+	}
+}
+
+namespace MaterializedViewUpdatedSchema {
+	@def.View("SELECT null as id, 'Jack' AS name", { materialized: true })
+	export class MatAuthor {
+		name = def.stringColumn()
+	}
+}
+
+// materialized views cannot be replaced in-place (no CREATE OR REPLACE MATERIALIZED VIEW) -> drop & recreate
+describe('update a materialized view - still drops & recreates', () =>
+	testMigrations({
+		original: createSchema(MaterializedViewOriginalSchema),
+		updated: createSchema(MaterializedViewUpdatedSchema),
+		diff: [
+			{
+				modification: 'removeEntity',
+				entityName: 'MatAuthor',
 			},
 			{
 				modification: 'createView',
 				entity: {
-					name: 'Author',
+					name: 'MatAuthor',
 					primary: 'id',
 					primaryColumn: 'id',
 					unique: [],
+					indexes: [],
 					fields: {
 						id: {
 							name: 'id',
@@ -402,14 +228,98 @@ describe('update a view 4', () =>
 							columnType: 'text',
 						},
 					},
-					tableName: 'author',
-					view: {
-						sql: "SELECT null as id, 'Jack' AS name",
-					},
+					tableName: 'mat_author',
 					eventLog: {
 						enabled: true,
 					},
+					view: {
+						sql: "SELECT null as id, 'Jack' AS name",
+						materialized: true,
+					},
+				},
+			},
+		],
+		sql: SQL`DROP MATERIALIZED VIEW "mat_author";
+CREATE MATERIALIZED VIEW "mat_author" AS SELECT null as id, 'Jack' AS name WITH DATA;`,
+	}))
+
+namespace AddViewColumnOriginalSchema {
+	@def.View("SELECT null as id, 'John' AS name")
+	export class Author {
+		name = def.stringColumn()
+	}
+
+	@def.View('SELECT * FROM author', { dependencies: [Author] })
+	export class Author2 {
+		name = def.stringColumn()
+	}
+}
+
+namespace AddViewColumnUpdatedSchema {
+	@def.View("SELECT null as id, 'John' AS name, 0 AS age")
+	export class Author {
+		name = def.stringColumn()
+		age = def.intColumn()
+	}
+
+	@def.View('SELECT * FROM author', { dependencies: [Author] })
+	export class Author2 {
+		name = def.stringColumn()
+	}
+}
+
+// changing the output columns of a view requires a drop & recreate of it and its dependants
+describe('add a column to a view - still cascades drop & recreate', () =>
+	testMigrations({
+		original: createSchema(AddViewColumnOriginalSchema),
+		updated: createSchema(AddViewColumnUpdatedSchema),
+		diff: [
+			{
+				modification: 'removeEntity',
+				entityName: 'Author2',
+			},
+			{
+				modification: 'removeEntity',
+				entityName: 'Author',
+			},
+			{
+				modification: 'createView',
+				entity: {
+					name: 'Author',
+					primary: 'id',
+					primaryColumn: 'id',
+					unique: [],
 					indexes: [],
+					fields: {
+						id: {
+							name: 'id',
+							columnName: 'id',
+							nullable: false,
+							type: 'Uuid',
+							columnType: 'uuid',
+						},
+						name: {
+							name: 'name',
+							columnName: 'name',
+							nullable: true,
+							type: 'String',
+							columnType: 'text',
+						},
+						age: {
+							name: 'age',
+							columnName: 'age',
+							nullable: true,
+							type: 'Integer',
+							columnType: 'integer',
+						},
+					},
+					tableName: 'author',
+					eventLog: {
+						enabled: true,
+					},
+					view: {
+						sql: "SELECT null as id, 'John' AS name, 0 AS age",
+					},
 				},
 			},
 			{
@@ -419,6 +329,7 @@ describe('update a view 4', () =>
 					primary: 'id',
 					primaryColumn: 'id',
 					unique: [],
+					indexes: [],
 					fields: {
 						id: {
 							name: 'id',
@@ -436,59 +347,20 @@ describe('update a view 4', () =>
 						},
 					},
 					tableName: 'author2',
+					eventLog: {
+						enabled: true,
+					},
 					view: {
-						sql: 'SELECT id, name FROM author',
+						sql: 'SELECT * FROM author',
 						dependencies: [
 							'Author',
 						],
 					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
-				},
-			},
-			{
-				modification: 'createView',
-				entity: {
-					name: 'Author3',
-					primary: 'id',
-					primaryColumn: 'id',
-					unique: [],
-					fields: {
-						id: {
-							name: 'id',
-							columnName: 'id',
-							nullable: false,
-							type: 'Uuid',
-							columnType: 'uuid',
-						},
-						name: {
-							name: 'name',
-							columnName: 'name',
-							nullable: true,
-							type: 'String',
-							columnType: 'text',
-						},
-					},
-					tableName: 'author3',
-					view: {
-						sql: 'SELECT id, name FROM author2',
-						dependencies: [
-							'Author2',
-						],
-					},
-					eventLog: {
-						enabled: true,
-					},
-					indexes: [],
 				},
 			},
 		],
-		sql: SQL`DROP VIEW "author3";
-DROP VIEW "author2";
+		sql: SQL`DROP VIEW "author2";
 DROP VIEW "author";
-CREATE VIEW "author" AS SELECT null as id, 'Jack' AS name;
-CREATE VIEW "author2" AS SELECT id, name FROM author;
-CREATE VIEW "author3" AS SELECT id, name FROM author2;`,
+CREATE VIEW "author" AS SELECT null as id, 'John' AS name, 0 AS age;
+CREATE VIEW "author2" AS SELECT * FROM author;`,
 	}))

--- a/packages/schema-migrations/tests/src/tests.ts
+++ b/packages/schema-migrations/tests/src/tests.ts
@@ -1,4 +1,4 @@
-import { Migration, ModificationHandlerFactory, SchemaDiffer, SchemaMigrator, VERSION_LATEST } from '../../src/index.js'
+import { DiffOptions, Migration, ModificationHandlerFactory, SchemaDiffer, SchemaMigrator, VERSION_LATEST } from '../../src/index.js'
 import { Schema } from '@contember/schema'
 import { createMigrationBuilder } from '@contember/database-migrations'
 import { describe, expect, it, test } from 'bun:test'
@@ -16,17 +16,19 @@ export interface TestContext {
 	sql: string
 	noDiff?: boolean
 	databaseMetadata?: DatabaseMetadata
+	diffOptions?: DiffOptions
 }
 
 export function testDiffSchemas(
 	original: Partial<Schema>,
 	updated: Partial<Schema>,
 	expectedDiff: Migration.Modification[],
+	diffOptions: DiffOptions = {},
 ) {
 	const actualDiff = schemaDiffer.diffSchemas(
 		{ ...emptySchema, ...original },
 		{ ...emptySchema, ...updated },
-		{ skipRecreateValidation: true },
+		{ skipRecreateValidation: true, ...diffOptions },
 	)
 	try {
 		expect(actualDiff).toStrictEqual(expectedDiff)
@@ -85,12 +87,12 @@ export function testGenerateSql(
 	expect(actual).toEqual(expectedSql)
 }
 
-export function testMigrations({ original, updated, diff, noDiff, sql, databaseMetadata }: TestContext) {
+export function testMigrations({ original, updated, diff, noDiff, sql, databaseMetadata, diffOptions }: TestContext) {
 	test('diff schemas', () => {
 		if (noDiff) {
 			return
 		}
-		testDiffSchemas(original, updated, diff)
+		testDiffSchemas(original, updated, diff, diffOptions)
 	})
 	test('apply diff', () => {
 		testApplyDiff(original, updated, diff)


### PR DESCRIPTION
## Problem

Any change to a view definition currently drops & recreates the **entire dependant-view cascade**. Because `removeEntity` also strips the entity's ACL (which `UpdateAclSchemaDiffer` then re-adds) and each `createView` re-emits the full entity definition, a single view-SQL change can produce a migration of tens to hundreds of KB.

Real-world example (a "pushdown" optimization that changed **one** view's SQL body, columns unchanged):

| | now | after |
|---|---|---|
| modifications | 3× `removeEntity` + 3× `createView` + 3× `createRelationInverseSide` + 1× `patchAclSchema` (89 ACL ops) | **1× `updateView`** |
| size | ~53 KB | ~2 KB |

Across one batch of view migrations, **0** of the recreated views actually had a column change — every recreation was either a genuinely-new view, an SQL-only change, or a pure cascade victim.

## Change

The `updateView` modification (`CREATE OR REPLACE VIEW`) already existed but was never produced by any differ. This wires it in:

- **`isReplaceableViewChange()`** — a view change is replaceable iff the entity is structurally identical (only `view.sql`/`dependencies`/`idSource` differ) and it is **not** materialized.
- **`UpdateViewDiffer`** — emits `updateView` for replaceable changes, topologically ordered by dependencies.
- **`RemoveViewDiffer`** — now cascades **only** on non-replaceable (structural) changes; SQL-only changes no longer trigger the drop cascade, the ACL re-patch, or inverse-relation churn.
- The iterative diff-apply naturally avoids a duplicate `updateView` for a view that was already recreated by a structural cascade (it already matches the target by the time `UpdateViewDiffer` runs).

Materialized views and any column/structure change still drop & recreate as before.

## Tests

`tests/cases/integration/updateView.test.ts` rewritten:
- SQL-only changes (leaf, dependency, full chain) → single/ordered `updateView` + `CREATE OR REPLACE VIEW`
- **boundary tests** asserting materialized views and adding a view column **still** drop & recreate

`bun test packages/schema-migrations` → 301 pass. `tsc --build`, dprint, biome all green.

## Known limitation (caveat)

The field-equality guard is **necessary but not sufficient**: a view's real column order/types come from the SQL body, not the field metadata. So an SQL-only **column reorder**, or an **output-type drift** without a matching field-type change, will fail at **execute** time with a transactional `SQLSTATE 42P16` (loud, before any data change — never silent corruption). Both cases are rare (they imply an SQL/schema inconsistency the old drop+recreate merely masked). A follow-up "schema-stable recreate" (drop CASCADE + recreate while keeping the migration small) would eliminate even these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)