### PR TITLE
feat(tenant-api): make OIDC/IdP integration ready for external CAS-style providers

### DIFF
--- a/docs/src/content/docs/reference/engine/tenant/email-verification.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/email-verification.mdx
@@ -127,7 +127,7 @@ mutation {
 }
 ```
 
-Auto-linking by e-mail is takeover-grade: a provider returning an unverified (or attacker-controlled) address could otherwise hijack a local account. With this option on, an unverified claim fails to link / sign in. Defaults to `false`. Only relevant for non-`exclusive` providers (exclusive providers never link by e-mail). See [IdP](/reference/engine/tenant/idp#configuration).
+Auto-linking by e-mail is takeover-grade: a provider returning an unverified (or attacker-controlled) address could otherwise hijack a local account. With this option on, an unverified claim fails to link / sign in. A blocked attempt surfaces to the client as the generic `PERSON_NOT_FOUND` — so it does not leak that the account exists — and is recorded in the [audit log](/reference/engine/tenant/audit-log) with reason `idp_email_unverified`. Defaults to `false`. Only relevant for non-`exclusive` providers (exclusive providers never link by e-mail). See [IdP](/reference/engine/tenant/idp#configuration).
 
 The gate is satisfied when the provider asserts the address is verified **or** when the IdP is configured with `assumeEmailVerified: true`. Some trusted providers vouch for their accounts but never emit an `email_verified` claim, which would otherwise always fail the gate; `assumeEmailVerified` treats such a provider's e-mails as verified even without the claim, so `requireVerifiedEmail` can stay on. It **waives** the gate for that provider, so the protection is then only as strong as that provider — use it only for an IdP you fully trust to assert addresses. Defaults to `false`. See [IdP options](/reference/engine/tenant/idp#configuration).
 

--- a/docs/src/content/docs/reference/engine/tenant/email-verification.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/email-verification.mdx
@@ -127,7 +127,9 @@ mutation {
 }
 ```
 
-Auto-linking by e-mail is takeover-grade: a provider returning an unverified (or attacker-controlled) address could otherwise hijack a local account. With this option on, an unverified claim simply fails to link / sign in. Defaults to `false`. Only relevant for non-`exclusive` providers (exclusive providers never link by e-mail). See [IdP](/reference/engine/tenant/idp#configuration).
+Auto-linking by e-mail is takeover-grade: a provider returning an unverified (or attacker-controlled) address could otherwise hijack a local account. With this option on, an unverified claim fails to link / sign in. Defaults to `false`. Only relevant for non-`exclusive` providers (exclusive providers never link by e-mail). See [IdP](/reference/engine/tenant/idp#configuration).
+
+The gate is satisfied when the provider asserts the address is verified **or** when the IdP is configured with `assumeEmailVerified: true`. Some trusted providers vouch for their accounts but never emit an `email_verified` claim, which would otherwise always fail the gate; `assumeEmailVerified` treats such a provider's e-mails as verified even without the claim, so `requireVerifiedEmail` can stay on. It **waives** the gate for that provider, so the protection is then only as strong as that provider — use it only for an IdP you fully trust to assert addresses. Defaults to `false`. See [IdP options](/reference/engine/tenant/idp#configuration).
 
 ## Configuration
 

--- a/docs/src/content/docs/reference/engine/tenant/idp.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/idp.mdx
@@ -9,6 +9,18 @@ Once the user has authenticated with the identity provider, they will be redirec
 
 ## IdP configuration
 
+### Provider types
+
+Contember ships three IdP types, selected by the `type` argument of `addIDP`:
+
+| `type` | Provider | Configuration |
+|---|---|---|
+| `oidc` | Any OpenID Connect–compliant provider (Keycloak, Microsoft Entra, Auth0, Apereo CAS, …) | [OIDC configuration](#oidc-configuration) |
+| `facebook` | Facebook Login | [Facebook configuration](#facebook-configuration) |
+| `apple` | Sign in with Apple | [Apple configuration](#apple-configuration) |
+
+All three are built on the same OIDC machinery and share the [OIDC option set](#oidc-configuration) (`scope`, `claimMapping`, `revalidation`, …); they differ only in the credential fields and how the issuer is discovered. The walkthroughs below use `oidc`.
+
 ### Adding new IdP
 
 To add a new identity provider (IdP) in Contember, you will need to use the `addIDP` mutation provided by the [tenant API](/reference/engine/tenant/overview). This mutation allows you to specify the details of the identity provider you want to add, including its type, configuration, and options.
@@ -154,6 +166,42 @@ mutation {
 }
 ```
 
+### Facebook configuration
+
+`type: "facebook"` uses Contember's built-in Facebook endpoints; you supply the credentials from your Facebook app. The configuration shares the [OIDC options](#oidc-configuration) (`scope`, `claimMapping`, `revalidation`, …).
+
+| Field | Default | Notes |
+|---|---|---|
+| `clientId` | — | **Required.** Facebook app ID. |
+| `clientSecret` | — | **Required.** Facebook app secret. Redacted in the [audit log](#audit) and never returned by [`identityProviders`](#listing-configured-idps). |
+| `url` | — | **Required by the shared schema** — but the Facebook issuer is built in, so the value is not used for discovery. Set it to `https://www.facebook.com/.well-known/openid-configuration/`. |
+
+Besides the standard redirect/callback flow, `signInIDP` also accepts a **Facebook JS SDK** response in `data` instead of a callback `url`:
+
+```graphql
+data: {
+  authResponse: {
+    accessToken: "…",      # from FB.login()
+    signedRequest: "…"
+  }
+}
+```
+
+Contember verifies the `signedRequest` HMAC with the app secret and then fetches `id,email,name` from the Graph API.
+
+### Apple configuration
+
+`type: "apple"` uses Apple's fixed discovery endpoint and builds the client secret as a short-lived JWT signed with your Apple private key — so there is **no** `clientSecret` or `url` field. Shares the [OIDC options](#oidc-configuration).
+
+| Field | Default | Notes |
+|---|---|---|
+| `clientId` | — | **Required.** Your Apple **Services ID** (the OAuth client identifier). |
+| `teamId` | — | **Required.** Apple Developer Team ID — becomes the client-secret JWT issuer. |
+| `keyId` | — | **Required.** Key ID of the Apple sign-in key — becomes the JWT `kid`. |
+| `privateKey` | — | **Required.** The `.p8` private key (PKCS#8 PEM). Redacted in the [audit log](#audit) and never returned by [`identityProviders`](#listing-configured-idps). |
+
+Contember signs an ES256 client-secret JWT (`aud: appleid.apple.com`, 10-minute lifetime) per request, so no static client secret is stored.
+
 ### Updating existing IdP
 
 To update an existing identity provider (IdP) in Contember, you will need to use the updateIDP mutation. This mutation allows you to specify the updated details of the identity provider you want to update, including its configuration and options.
@@ -193,6 +241,10 @@ The options field allows you to specify updated options for the identity provide
 
 If the "ok" in response is `false`, you will find details in `error`, possible error codes are following: `NOT_FOUND`, `INVALID_CONFIGURATION`
 
+:::caution[`configuration` is replaced wholesale by default]
+By default `updateIDP` **replaces** the entire `configuration` object — any field you don't pass is dropped. To change a single field while keeping the rest, pass `mergeConfiguration: true`: each key you provide is merged into the stored configuration, and a key set to `null` is **removed**. Omitting `configuration` entirely leaves it untouched (handy when you only want to change `options`). The merge is **shallow** — a nested object such as `claimMapping` or `revalidation` is replaced as a whole, not deep-merged.
+:::
+
 ### Temporarily disabling and enabling an IdP
 
 In Contember, you can enable or disable an identity provider (IdP) using the `enableIDP` and `disableIDP` mutations. These mutations allow you to control whether an identity provider is available.
@@ -231,6 +283,30 @@ The enableIDP mutation works in a similar way to the disableIDP mutation, with t
 
 When you execute the disableIDP mutation, it will return a response indicating whether the operation was successful. If the operation was not successful, the ok field will be set to false and the error field will contain details about the error that occurred. Possible error code is `NOT_FOUND`.
 
+### Listing configured IdPs
+
+The `identityProviders` query returns every configured provider — enabled or disabled. It requires the `idp:list` permission (granted to `PROJECT_ADMIN` and `SUPER_ADMIN` by default), so it is meant for administrative tooling, not the public login screen.
+
+```graphql
+query {
+  identityProviders {
+    slug
+    type
+    disabledAt
+    configuration
+    options {
+      autoSignUp
+      exclusive
+      initReturnsConfig
+      requireVerifiedEmail
+      assumeEmailVerified
+    }
+  }
+}
+```
+
+`disabledAt` is `null` for an active provider and carries the timestamp of the last `disableIDP` otherwise. The returned `configuration` has its **secrets stripped** — OIDC/Facebook `clientSecret` and Apple `privateKey` are never exposed — so it is safe to surface in an admin UI.
+
 ## IdP authentication
 
 A two-step exchange: `initSignInIDP` produces the redirect URL and any state your client must remember, the user authenticates at the provider, and `signInIDP` consumes the callback URL to mint a session.
@@ -256,7 +332,7 @@ mutation {
 }
 ```
 
-The `identityProvider` field is the slug used when the IdP was added. `data.redirectUrl` is where the provider should send the user after authentication. The exact `data` shape is provider-specific — for OIDC the supported key is `redirectUrl`.
+The `identityProvider` field is the slug used when the IdP was added. `data.redirectUrl` is where the provider should send the user after authentication. The exact `data` shape is provider-specific — for `oidc`, `facebook` and `apple` the keys are `redirectUrl` (required) and an optional `responseMode` (the OAuth `response_mode`, e.g. `query` or `form_post`).
 
 The response carries:
 

--- a/docs/src/content/docs/reference/engine/tenant/idp.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/idp.mdx
@@ -59,6 +59,7 @@ The options field allows you to specify additional options for the identity prov
 | `exclusive` | `false` | Only this IdP may authenticate the matched accounts; disables linking by e-mail. |
 | `initReturnsConfig` | `false` | `initSignInIDP` returns the raw provider config to the client. |
 | `requireVerifiedEmail` | `false` | *(since 2.2)* For a non-`exclusive` provider, only auto-link to / sign in an existing local account by e-mail when the provider asserts the e-mail is **verified**. Guards against account takeover via an unverified provider claim. See [e-mail verification](/reference/engine/tenant/email-verification#idp-verified-email-gate). |
+| `assumeEmailVerified` | `false` | *(since 2.2)* Treat this provider's e-mails as **verified** even when it sends no `email_verified` claim, so `requireVerifiedEmail` can stay on for a trusted IdP that never emits the claim. **Waives** the verified-email gate — use **only** for a provider you fully trust to vouch for its accounts. See [e-mail verification](/reference/engine/tenant/email-verification#idp-verified-email-gate). |
 
 If the "ok" in response is `false`, you will find details in `error`, possible error codes are following: `ALREADY_EXISTS`, `UNKNOWN_TYPE`, `INVALID_CONFIGURATION`
 

--- a/docs/src/content/docs/reference/engine/tenant/idp.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/idp.mdx
@@ -19,7 +19,7 @@ Contember ships three IdP types, selected by the `type` argument of `addIDP`:
 | `facebook` | Facebook Login | [Facebook configuration](#facebook-configuration) |
 | `apple` | Sign in with Apple | [Apple configuration](#apple-configuration) |
 
-All three are built on the same OIDC machinery and share the [OIDC option set](#oidc-configuration) (`scope`, `claimMapping`, `revalidation`, …); they differ only in the credential fields and how the issuer is discovered. The walkthroughs below use `oidc`.
+All three are built on the same OIDC machinery and accept a common subset of the [OIDC configuration](#oidc-configuration) — `scope` (`claims`), `responseType`, and `additionalAuthorizedParties` — differing mainly in the credential fields and how the issuer is discovered. The richer OIDC options (`claimMapping`, `fetchUserInfo`, `returnOIDCResult`, `tokenEndpointAuthMethod`, and `revalidation`) are honored **only** by `type: "oidc"` — Facebook and Apple silently ignore them. The walkthroughs below use `oidc`.
 
 ### Adding new IdP
 
@@ -168,7 +168,7 @@ mutation {
 
 ### Facebook configuration
 
-`type: "facebook"` uses Contember's built-in Facebook endpoints; you supply the credentials from your Facebook app. The configuration shares the [OIDC options](#oidc-configuration) (`scope`, `claimMapping`, `revalidation`, …).
+`type: "facebook"` uses Contember's built-in Facebook endpoints; you supply the credentials from your Facebook app. It honors the common [OIDC options](#oidc-configuration) (`scope`, `responseType`, `additionalAuthorizedParties`) but **not** the `oidc`-only ones (`claimMapping`, `fetchUserInfo`, `returnOIDCResult`, `tokenEndpointAuthMethod`, `revalidation`).
 
 | Field | Default | Notes |
 |---|---|---|
@@ -191,7 +191,7 @@ Contember verifies the `signedRequest` HMAC with the app secret and then fetches
 
 ### Apple configuration
 
-`type: "apple"` uses Apple's fixed discovery endpoint and builds the client secret as a short-lived JWT signed with your Apple private key — so there is **no** `clientSecret` or `url` field. Shares the [OIDC options](#oidc-configuration).
+`type: "apple"` uses Apple's fixed discovery endpoint and builds the client secret as a short-lived JWT signed with your Apple private key — so there is **no** `clientSecret` or `url` field. Like Facebook, it honors the common [OIDC options](#oidc-configuration) (`scope`, `responseType`, `additionalAuthorizedParties`) but **not** the `oidc`-only ones (`claimMapping`, `fetchUserInfo`, `returnOIDCResult`, `tokenEndpointAuthMethod`, `revalidation`).
 
 | Field | Default | Notes |
 |---|---|---|

--- a/docs/src/content/docs/reference/engine/tenant/idp.mdx
+++ b/docs/src/content/docs/reference/engine/tenant/idp.mdx
@@ -63,6 +63,97 @@ The options field allows you to specify additional options for the identity prov
 
 If the "ok" in response is `false`, you will find details in `error`, possible error codes are following: `ALREADY_EXISTS`, `UNKNOWN_TYPE`, `INVALID_CONFIGURATION`
 
+### OIDC configuration
+
+The `configuration` object passed to `addIDP` / `updateIDP` is provider-specific. For `type: "oidc"` the following fields are supported — only `url` is strictly required, the rest fall back to the defaults below:
+
+| Field | Default | Notes |
+|---|---|---|
+| `url` | — | **Required.** The provider's OpenID Connect discovery URL (`…/.well-known/openid-configuration`), used for issuer discovery. |
+| `clientId` | — | OAuth client ID issued by the provider. |
+| `clientSecret` | — | OAuth client secret. Never returned by the API and redacted in the [audit log](#audit). |
+| `scope` | `openid email` | Space-separated scopes requested at authorization. When [re-validation](#session-re-validation) uses `refresh`, `offline_access` is appended automatically. |
+| `claims` | — | *Deprecated* alias for `scope` — despite the name these are OIDC scopes, not claims. Prefer `scope`. |
+| `responseType` | `code` | OIDC `response_type`. One of `code`, `code id_token`, `code id_token token`, `code token`, `id_token`, `id_token token`, `none`. |
+| `idTokenSignedResponseAlg` | `RS256` | Expected signing algorithm of the ID token. |
+| `tokenEndpointAuthMethod` | `client_secret_basic` | *(since 2.2)* How the client authenticates to the token endpoint. See [Token endpoint authentication](#token-endpoint-authentication). |
+| `fetchUserInfo` | `false` | After the token exchange, also call the userinfo endpoint and merge its claims (userinfo wins over the ID token). Needed when the provider only returns some claims from userinfo. |
+| `returnOIDCResult` | `false` | Expose the provider's raw token-exchange response in `signInIDP`'s `result.idpResponse` (access token, raw claims, …). |
+| `additionalAuthorizedParties` | `[]` | Extra `azp` values accepted in the ID token besides the configured `clientId`. |
+| `timeout` | `5000` | HTTP timeout (ms) for calls to the provider. |
+| `claimMapping` | — | *(since 2.2)* Remap provider claims onto Contember's identity fields. See [Claim mapping](#claim-mapping). |
+| `revalidation` | — | *(since 2.3)* Continuous session re-validation. See [Session re-validation](#session-re-validation). |
+
+#### Token endpoint authentication
+
+:::note[Available since 2.2]
+:::
+
+`tokenEndpointAuthMethod` controls how the client proves its identity when exchanging the authorization code for tokens. The default is `client_secret_basic` (the secret in an HTTP Basic header). Some providers — notably certain **Apereo CAS** registrations — only accept the secret in the request body, which requires `client_secret_post`:
+
+```graphql
+mutation {
+  updateIDP(
+    identityProvider: "cas-provider",
+    mergeConfiguration: true,
+    configuration: { tokenEndpointAuthMethod: "client_secret_post" }
+  ) { ok error { code developerMessage } }
+}
+```
+
+Supported values: `client_secret_basic`, `client_secret_post`, `client_secret_jwt`, `private_key_jwt`, `tls_client_auth`, `self_signed_tls_client_auth`, `none`.
+
+#### Claim mapping
+
+:::note[Available since 2.2]
+:::
+
+By default Contember derives the identity from the standard OIDC claims: `sub` for the stable external identifier, `email` for the e-mail, `name` for the display name. A provider whose claims don't follow these defaults can be remapped via `claimMapping` — without a per-provider code change.
+
+| Field | Default | Notes |
+|---|---|---|
+| `externalIdentifier` | `sub` | Claim used as the **stable federation key** persisted per identity and matched on every subsequent sign-in. Must resolve to a scalar (string/number); a non-scalar or empty value is rejected at sign-in (see the caution below). |
+| `email` | `email` | Claim used as the e-mail address. A non-string value is ignored (treated as absent). |
+| `name` | `name` | Claim used as the display name. A non-string value is ignored. |
+| `attributesKey` | — | Key of a nested object whose properties are lifted to the top level before mapping. For providers that nest their claims — notably **Apereo CAS** userinfo, which returns them under `attributes`. |
+
+Each mapping value is a claim name, with **dot-paths** into nested objects supported (e.g. `user.id`, `address.region`).
+
+:::caution[Mapping the external identifier safely]
+`externalIdentifier` is the key that ties an IdP account to a Contember identity on every sign-in, so it must be stable and unique per user.
+
+- It must resolve to a **scalar**. A claim that resolves to an object/array, or to an empty string, is **rejected** at sign-in (`IDP_VALIDATION_FAILED`) — mapping such a value through would otherwise collapse multiple users onto a single key (account takeover). When the mapped claim is simply absent, Contember falls back to the signed `sub`.
+- Claims lifted via `attributesKey` (or fetched from userinfo) are **not** covered by the ID-token signature. A signed ID-token claim always wins over an `attributes`-level claim of the same name, but if you map `externalIdentifier` to a claim that *only* exists in userinfo / `attributes`, the federation key is no longer anchored to the signed subject. Prefer a signed claim where possible.
+:::
+
+##### Example: Apereo CAS
+
+Apereo CAS exposes user attributes nested under `attributes` in its userinfo response and, in many deployments, expects the client secret in the request body. The two new options combine to consume it without any code change — fetch userinfo, unwrap `attributes`, map the stable `oid` to the external identifier, and post the secret:
+
+```graphql
+mutation {
+  addIDP(
+    identityProvider: "cas-provider",
+    type: "oidc",
+    configuration: {
+      url: "https://cas.example.edu/cas/oidc/.well-known/openid-configuration",
+      clientId: "YOUR_CLIENT_ID",
+      clientSecret: "YOUR_CLIENT_SECRET",
+      scope: "openid email profile",
+      tokenEndpointAuthMethod: "client_secret_post",
+      fetchUserInfo: true,
+      claimMapping: {
+        attributesKey: "attributes",
+        externalIdentifier: "oid",
+        email: "email",
+        name: "name"
+      }
+    },
+    options: { autoSignUp: true }
+  ) { ok error { code developerMessage } }
+}
+```
+
 ### Updating existing IdP
 
 To update an existing identity provider (IdP) in Contember, you will need to use the updateIDP mutation. This mutation allows you to specify the updated details of the identity provider you want to update, including its configuration and options.

--- a/packages/engine-tenant-api/src/migrations/2026-06-08-100000-idp-assume-email-verified.ts
+++ b/packages/engine-tenant-api/src/migrations/2026-06-08-100000-idp-assume-email-verified.ts
@@ -1,0 +1,15 @@
+import { MigrationBuilder } from '@contember/database-migrations'
+
+const sql = `
+-- When TRUE, e-mail addresses asserted by this identity provider are treated as
+-- verified even if the provider does not send an "email_verified" claim. Use only
+-- for trusted providers (e.g. an enterprise IdP that vouches for its accounts) so
+-- that "require_verified_email" can stay on without the IdP emitting the claim.
+-- Defaults to FALSE to preserve existing behavior.
+ALTER TABLE "identity_provider"
+	ADD COLUMN "assume_email_verified" BOOLEAN NOT NULL DEFAULT FALSE;
+`
+
+export default async function(builder: MigrationBuilder) {
+	builder.sql(sql)
+}

--- a/packages/engine-tenant-api/src/migrations/runner.ts
+++ b/packages/engine-tenant-api/src/migrations/runner.ts
@@ -59,6 +59,7 @@ import _20260526130010idprequireverifiedemail from './2026-05-26-130010-idp-requ
 import _20260526130020emailverificationratelimit from './2026-05-26-130020-email-verification-rate-limit.js'
 import _20260526130030captchaprotectflows from './2026-05-26-130030-captcha-protect-flows.js'
 import _20260526140000idpsession from './2026-05-26-140000-idp-session.js'
+import _20260608100000idpassumeemailverified from './2026-06-08-100000-idp-assume-email-verified.js'
 import snapshot from './snapshot.js'
 import { computeTokenHash, Providers } from '../model/index.js'
 import { Logger } from '@contember/logger'
@@ -141,6 +142,7 @@ const migrations = {
 	'2026-05-26-130020-email-verification-rate-limit': _20260526130020emailverificationratelimit,
 	'2026-05-26-130030-captcha-protect-flows': _20260526130030captchaprotectflows,
 	'2026-05-26-140000-idp-session': _20260526140000idpsession,
+	'2026-06-08-100000-idp-assume-email-verified': _20260608100000idpassumeemailverified,
 }
 
 export class TenantMigrationsRunner {

--- a/packages/engine-tenant-api/src/migrations/snapshot-template-start.txt
+++ b/packages/engine-tenant-api/src/migrations/snapshot-template-start.txt
@@ -1,6 +1,6 @@
 import { MigrationBuilder } from '@contember/database-migrations'
-import { TenantMigrationArgs } from './types'
-import { createCredentials } from './tenantCredentials'
+import { TenantMigrationArgs } from './types.js'
+import { createCredentials } from './tenantCredentials.js'
 
 export default async function (builder: MigrationBuilder, args: TenantMigrationArgs) {
 	builder.sql(`

--- a/packages/engine-tenant-api/src/migrations/snapshot.ts
+++ b/packages/engine-tenant-api/src/migrations/snapshot.ts
@@ -190,7 +190,8 @@ CREATE TABLE "identity_provider" (
     "auto_sign_up" boolean DEFAULT false NOT NULL,
     "exclusive" boolean DEFAULT false,
     "init_returns_config" boolean DEFAULT false NOT NULL,
-    "require_verified_email" boolean DEFAULT false NOT NULL
+    "require_verified_email" boolean DEFAULT false NOT NULL,
+    "assume_email_verified" boolean DEFAULT false NOT NULL
 );
 CREATE TABLE "idp_session" (
     "id" "uuid" NOT NULL,

--- a/packages/engine-tenant-api/src/model/commands/idp/CreateIdpCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/idp/CreateIdpCommand.ts
@@ -9,7 +9,7 @@ export class CreateIdpCommand implements Command<void> {
 	}
 
 	async execute({ db, providers }: Command.Args): Promise<void> {
-		const { configuration, options: { autoSignUp, exclusive, initReturnsConfig, requireVerifiedEmail }, slug, type } = this.data
+		const { configuration, options: { autoSignUp, exclusive, initReturnsConfig, requireVerifiedEmail, assumeEmailVerified }, slug, type } = this.data
 		await InsertBuilder.create()
 			.into('identity_provider')
 			.values({
@@ -21,6 +21,7 @@ export class CreateIdpCommand implements Command<void> {
 				exclusive,
 				init_returns_config: initReturnsConfig,
 				require_verified_email: requireVerifiedEmail,
+				assume_email_verified: assumeEmailVerified,
 			})
 			.execute(db)
 	}

--- a/packages/engine-tenant-api/src/model/commands/idp/UpdateIdpCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/idp/UpdateIdpCommand.ts
@@ -10,7 +10,7 @@ export class UpdateIdpCommand implements Command<void> {
 	}
 
 	async execute({ db }: Command.Args): Promise<void> {
-		const { configuration, options: { autoSignUp, exclusive, initReturnsConfig, requireVerifiedEmail } = {} } = this.data
+		const { configuration, options: { autoSignUp, exclusive, initReturnsConfig, requireVerifiedEmail, assumeEmailVerified } = {} } = this.data
 		await UpdateBuilder.create()
 			.table('identity_provider')
 			.values({
@@ -19,6 +19,7 @@ export class UpdateIdpCommand implements Command<void> {
 				exclusive,
 				init_returns_config: initReturnsConfig,
 				require_verified_email: requireVerifiedEmail,
+				assume_email_verified: assumeEmailVerified,
 			})
 			.where({
 				id: this.id,

--- a/packages/engine-tenant-api/src/model/queries/idp/helpers.ts
+++ b/packages/engine-tenant-api/src/model/queries/idp/helpers.ts
@@ -12,13 +12,14 @@ export const createBaseIdpQuery = () =>
 		.select('exclusive')
 		.select('init_returns_config', 'initReturnsConfig')
 		.select('require_verified_email', 'requireVerifiedEmail')
+		.select('assume_email_verified', 'assumeEmailVerified')
 		.from('identity_provider')
 
 export const createIdpDto = (
-	{ exclusive, autoSignUp, initReturnsConfig, requireVerifiedEmail, ...row }: IdentityProviderRow,
+	{ exclusive, autoSignUp, initReturnsConfig, requireVerifiedEmail, assumeEmailVerified, ...row }: IdentityProviderRow,
 ): IdentityProviderDto => {
 	return {
 		...row,
-		options: { autoSignUp, exclusive, initReturnsConfig, requireVerifiedEmail },
+		options: { autoSignUp, exclusive, initReturnsConfig, requireVerifiedEmail, assumeEmailVerified },
 	}
 }

--- a/packages/engine-tenant-api/src/model/queries/idp/types.ts
+++ b/packages/engine-tenant-api/src/model/queries/idp/types.ts
@@ -10,6 +10,7 @@ export type IdentityProviderRow = {
 	exclusive: boolean
 	initReturnsConfig: boolean
 	requireVerifiedEmail: boolean
+	assumeEmailVerified: boolean
 }
 
 export type IdentityProviderDto =

--- a/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
+++ b/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
@@ -178,8 +178,10 @@ class IDPSignInManager {
 				// e-mail is takeover-grade: if the provider returns an unverified
 				// (or attacker-controlled) e-mail, it could hijack the account. When
 				// the provider requires a verified e-mail, refuse to link — and to
-				// sign in — unless the provider asserts the address is verified.
-				if (provider.requireVerifiedEmail && claim.emailVerified !== true) {
+				// sign in — unless the address is asserted verified. `assumeEmailVerified`
+				// lets a trusted IdP that never emits the claim still satisfy the gate.
+				const emailVerified = provider.assumeEmailVerified || claim.emailVerified === true
+				if (provider.requireVerifiedEmail && !emailVerified) {
 					return { person: null, blockedReason: 'idp_email_unverified', blockedPersonId: personByEmail.id }
 				}
 				await this.saveIdpIdentifier(db, provider, claim, personByEmail)

--- a/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
+++ b/packages/engine-tenant-api/src/model/service/IDPSignInManager.ts
@@ -172,7 +172,9 @@ class IDPSignInManager {
 		}
 
 		if (!provider.exclusive) {
-			const personByEmail = claim.email ? await db.queryHandler.fetch(PersonQuery.byEmail(claim.email)) : null
+			const personByEmail = typeof claim.email === 'string' && claim.email
+				? await db.queryHandler.fetch(PersonQuery.byEmail(claim.email))
+				: null
 			if (personByEmail) {
 				// Auto-linking an IdP identity to a pre-existing local account by
 				// e-mail is takeover-grade: if the provider returns an unverified

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
@@ -1,5 +1,5 @@
 import { Client, custom, errors, generators, TokenSet } from 'openid-client'
-import { OIDCResponseData } from './OIDCTypes.js'
+import { OIDCClaimMapping, OIDCResponseData } from './OIDCTypes.js'
 import { IDPValidationError } from '../IDPValidationError.js'
 import { IDPResponseError } from '../IDPResponseError.js'
 import { IDPResponse, IDPSessionState, InitIDPAuthResult, RevalidationResult } from '../IdentityProviderHandler.js'
@@ -48,12 +48,24 @@ export const initOIDCAuth = async (
 	}
 }
 
+export type HandleOIDCResponseOptions = {
+	fetchUserInfo?: boolean
+	returnOIDCResult?: boolean
+	captureSession?: boolean
+	claimMapping?: OIDCClaimMapping
+}
+
+/** Read a claim by name, supporting dot-paths into nested objects (`a.b.c`). */
+const getClaim = (source: Record<string, unknown>, path: string): unknown =>
+	path.split('.').reduce<unknown>(
+		(acc, key) => (acc != null && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined),
+		source,
+	)
+
 export const handleOIDCResponse = async (
 	client: Client,
 	{ sessionData, redirectUrl, ...otherData }: OIDCResponseData,
-	fetchUserInfo?: boolean,
-	returnOIDCResult?: boolean,
-	captureSession?: boolean,
+	{ fetchUserInfo, returnOIDCResult, captureSession, claimMapping }: HandleOIDCResponseOptions = {},
 ): Promise<IDPResponse> => {
 	const params = 'parameters' in otherData ? otherData.parameters : client.callbackParams(otherData.url)
 	if (params.state && !sessionData?.state) {
@@ -67,16 +79,34 @@ export const handleOIDCResponse = async (
 		const oidcResult = returnOIDCResult ? result : {}
 		const idpSession = captureSession ? tokenSetToSessionState(result, typeof claims.sid === 'string' ? claims.sid : undefined) : undefined
 
-		// The OIDC `email_verified` claim is a boolean per spec, but some providers
-		// send the string "true"; userInfo takes precedence over the ID token.
-		const rawEmailVerified = (userInfo as Record<string, unknown>).email_verified ?? claimsWithoutHashes.email_verified
+		// Merge ID-token claims with userInfo (userInfo wins, per spec). Then optionally lift a
+		// nested attributes object to the top level so providers that nest their claims (notably
+		// Apereo CAS userinfo, which returns them under `attributes`) map without a code change.
+		let source: Record<string, unknown> = { ...claimsWithoutHashes, ...userInfo }
+		const attributesKey = claimMapping?.attributesKey
+		if (attributesKey) {
+			const nested = source[attributesKey]
+			if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+				source = { ...source, ...(nested as Record<string, unknown>) }
+			}
+		}
+
+		// The OIDC `email_verified` claim is a boolean per spec, but some providers send the
+		// string "true". userInfo (and any unwrapped attributes) take precedence over the ID token.
+		const rawEmailVerified = source.email_verified
 		const emailVerified = rawEmailVerified === true || rawEmailVerified === 'true'
 
+		const mappedSubject = getClaim(source, claimMapping?.externalIdentifier ?? 'sub')
+		const externalIdentifier = mappedSubject !== undefined && mappedSubject !== null ? String(mappedSubject) : claims.sub
+		const email = getClaim(source, claimMapping?.email ?? 'email')
+		const name = getClaim(source, claimMapping?.name ?? 'name')
+
 		return {
-			externalIdentifier: claims.sub,
 			...oidcResult,
-			...claimsWithoutHashes,
-			...userInfo,
+			...source,
+			externalIdentifier,
+			...(typeof email === 'string' ? { email } : {}),
+			...(typeof name === 'string' ? { name } : {}),
 			emailVerified,
 			...(idpSession ? { idpSession } : {}),
 		}

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
@@ -82,12 +82,15 @@ export const handleOIDCResponse = async (
 		// Merge ID-token claims with userInfo (userInfo wins, per spec). Then optionally lift a
 		// nested attributes object to the top level so providers that nest their claims (notably
 		// Apereo CAS userinfo, which returns them under `attributes`) map without a code change.
+		// The nested attributes are UNSIGNED, so they must not override a claim already present in
+		// the (signature-verified) ID-token / userInfo merge — spread them UNDER `source`, not over
+		// it, so a signed `sub` / `email_verified` keeps precedence over an attributes-level value.
 		let source: Record<string, unknown> = { ...claimsWithoutHashes, ...userInfo }
 		const attributesKey = claimMapping?.attributesKey
 		if (attributesKey) {
 			const nested = source[attributesKey]
 			if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
-				source = { ...source, ...(nested as Record<string, unknown>) }
+				source = { ...(nested as Record<string, unknown>), ...source }
 			}
 		}
 
@@ -96,8 +99,28 @@ export const handleOIDCResponse = async (
 		const rawEmailVerified = source.email_verified
 		const emailVerified = rawEmailVerified === true || rawEmailVerified === 'true'
 
+		// `externalIdentifier` is the federation key persisted in `person_identity_provider` and
+		// matched on the next sign-in, so it must be a stable scalar. A `claimMapping` that pointed
+		// it at an object/array would otherwise be coerced by `String(...)` to `'[object Object]'` /
+		// a comma-join — collapsing every user of the provider onto one key (account takeover). Fail
+		// closed instead. The default `sub` path is safe (openid-client guarantees `sub` is a string).
 		const mappedSubject = getClaim(source, claimMapping?.externalIdentifier ?? 'sub')
-		const externalIdentifier = mappedSubject !== undefined && mappedSubject !== null ? String(mappedSubject) : claims.sub
+		let externalIdentifier: string
+		if (mappedSubject === undefined || mappedSubject === null) {
+			externalIdentifier = claims.sub
+		} else if (typeof mappedSubject === 'string' || typeof mappedSubject === 'number') {
+			externalIdentifier = String(mappedSubject)
+		} else {
+			throw new IDPValidationError(`The mapped externalIdentifier claim is not a scalar value`)
+		}
+		if (externalIdentifier === '') {
+			throw new IDPValidationError(`The mapped externalIdentifier claim resolved to an empty value`)
+		}
+
+		// `email` / `name` are typed `string | undefined` on IDPResponse and feed the by-e-mail
+		// account lookup (which crashes on a non-string). `...source` already placed the raw claim
+		// of whatever type, so OVERWRITE (don't conditionally add) with the mapped value when it is
+		// a string, otherwise `undefined` — a non-string claim must not leak through `...source`.
 		const email = getClaim(source, claimMapping?.email ?? 'email')
 		const name = getClaim(source, claimMapping?.name ?? 'name')
 
@@ -105,8 +128,8 @@ export const handleOIDCResponse = async (
 			...oidcResult,
 			...source,
 			externalIdentifier,
-			...(typeof email === 'string' ? { email } : {}),
-			...(typeof name === 'string' ? { name } : {}),
+			email: typeof email === 'string' ? email : undefined,
+			name: typeof name === 'string' ? name : undefined,
 			emailVerified,
 			...(idpSession ? { idpSession } : {}),
 		}

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCProvider.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCProvider.ts
@@ -29,9 +29,12 @@ export class OIDCProvider implements IdentityProviderHandler<OIDCConfiguration> 
 		return await handleOIDCResponse(
 			client,
 			responseData,
-			configuration.fetchUserInfo,
-			configuration.returnOIDCResult,
-			configuration.revalidation?.enabled === true,
+			{
+				fetchUserInfo: configuration.fetchUserInfo,
+				returnOIDCResult: configuration.returnOIDCResult,
+				captureSession: configuration.revalidation?.enabled === true,
+				claimMapping: configuration.claimMapping,
+			},
 		)
 	}
 

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCProvider.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCProvider.ts
@@ -67,6 +67,7 @@ export class OIDCProvider implements IdentityProviderHandler<OIDCConfiguration> 
 				client_secret: configuration.clientSecret,
 				response_types: [configuration.responseType || 'code'],
 				id_token_signed_response_alg: configuration.idTokenSignedResponseAlg ?? 'RS256',
+				...(configuration.tokenEndpointAuthMethod ? { token_endpoint_auth_method: configuration.tokenEndpointAuthMethod } : {}),
 			},
 			undefined,
 			{

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
@@ -24,7 +24,12 @@ export type OIDCRevalidationConfig = ReturnType<typeof OIDCRevalidationConfig>
  * the OIDC defaults still be consumed without a per-provider code change.
  */
 export const OIDCClaimMapping = Typesafe.partial({
-	/** Claim used as the stable external identifier (the IdP subject). Default `sub`. */
+	/**
+	 * Claim used as the stable external identifier (the IdP subject). Default `sub`.
+	 * Must resolve to a scalar (string/number) — a non-scalar claim is rejected at sign-in.
+	 * Mapping this to a claim that only appears in userInfo / `attributes` takes the federation
+	 * key off the signature-verified ID-token subject; prefer a signed claim where possible.
+	 */
 	externalIdentifier: Typesafe.string,
 	/** Claim used as the e-mail address. Default `email`. */
 	email: Typesafe.string,

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
@@ -1,5 +1,5 @@
 import * as Typesafe from '@contember/typesafe'
-import { ResponseType } from 'openid-client'
+import { ClientAuthMethod, ResponseType } from 'openid-client'
 import { IDPRevalidationConfig } from '../IDPRevalidation.js'
 
 export interface OIDCSessionData {
@@ -24,6 +24,20 @@ export const OIDCConfigurationOptions = Typesafe.partial({
 	scope: Typesafe.string,
 	additionalAuthorizedParties: Typesafe.array(Typesafe.string),
 	idTokenSignedResponseAlg: Typesafe.string,
+	/**
+	 * How the client authenticates to the token endpoint. `openid-client` defaults to
+	 * `client_secret_basic`; set `client_secret_post` for providers (e.g. some Apereo CAS
+	 * registrations) that only accept the secret in the request body.
+	 */
+	tokenEndpointAuthMethod: Typesafe.enumeration<ClientAuthMethod>(
+		'client_secret_basic',
+		'client_secret_post',
+		'client_secret_jwt',
+		'private_key_jwt',
+		'tls_client_auth',
+		'self_signed_tls_client_auth',
+		'none',
+	),
 	fetchUserInfo: Typesafe.boolean,
 	returnOIDCResult: Typesafe.boolean,
 	timeout: Typesafe.number,

--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts
@@ -18,6 +18,27 @@ export const OIDCRevalidationConfig = Typesafe.intersection(
 
 export type OIDCRevalidationConfig = ReturnType<typeof OIDCRevalidationConfig>
 
+/**
+ * Maps provider claims onto the normalized {@link IDPResponse} fields. Each value is a claim
+ * name, dot-path supported (e.g. `address.region`). Lets a provider whose claims don't follow
+ * the OIDC defaults still be consumed without a per-provider code change.
+ */
+export const OIDCClaimMapping = Typesafe.partial({
+	/** Claim used as the stable external identifier (the IdP subject). Default `sub`. */
+	externalIdentifier: Typesafe.string,
+	/** Claim used as the e-mail address. Default `email`. */
+	email: Typesafe.string,
+	/** Claim used as the display name. Default `name`. */
+	name: Typesafe.string,
+	/**
+	 * Key of a nested object whose properties are lifted to the top level before mapping.
+	 * Some providers (notably Apereo CAS userinfo) nest the actual claims under `attributes`.
+	 */
+	attributesKey: Typesafe.string,
+})
+
+export type OIDCClaimMapping = ReturnType<typeof OIDCClaimMapping>
+
 export const OIDCConfigurationOptions = Typesafe.partial({
 	responseType: Typesafe.enumeration<ResponseType>('code', 'code id_token', 'code id_token token', 'code token', 'id_token', 'id_token token', 'none'),
 	claims: Typesafe.string, // deprecated, use scope instead
@@ -42,6 +63,7 @@ export const OIDCConfigurationOptions = Typesafe.partial({
 	returnOIDCResult: Typesafe.boolean,
 	timeout: Typesafe.number,
 	revalidation: OIDCRevalidationConfig,
+	claimMapping: OIDCClaimMapping,
 })
 export const BaseOIDCConfiguration = Typesafe.intersection(
 	Typesafe.object({

--- a/packages/engine-tenant-api/src/model/type/IdentityProvider.ts
+++ b/packages/engine-tenant-api/src/model/type/IdentityProvider.ts
@@ -10,4 +10,5 @@ export interface IdentityProviderOptions {
 	exclusive: boolean
 	initReturnsConfig: boolean
 	requireVerifiedEmail: boolean
+	assumeEmailVerified: boolean
 }

--- a/packages/engine-tenant-api/src/resolvers/mutation/idp/AddIDPMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/idp/AddIDPMutationResolver.ts
@@ -25,6 +25,7 @@ export class AddIDPMutationResolver implements MutationResolvers {
 				exclusive: args.options?.exclusive ?? false,
 				initReturnsConfig: args.options?.initReturnsConfig ?? false,
 				requireVerifiedEmail: args.options?.requireVerifiedEmail ?? false,
+				assumeEmailVerified: args.options?.assumeEmailVerified ?? false,
 			},
 		})
 		if (!result.ok) {

--- a/packages/engine-tenant-api/src/resolvers/mutation/idp/UpdateIDPMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/idp/UpdateIDPMutationResolver.ts
@@ -25,6 +25,7 @@ export class UpdateIDPMutationResolver implements MutationResolvers {
 				exclusive: args.options?.exclusive ?? undefined,
 				initReturnsConfig: args.options?.initReturnsConfig ?? undefined,
 				requireVerifiedEmail: args.options?.requireVerifiedEmail ?? undefined,
+				assumeEmailVerified: args.options?.assumeEmailVerified ?? undefined,
 			},
 		}, args.mergeConfiguration ?? false)
 		if (!result.ok) {

--- a/packages/engine-tenant-api/src/resolvers/mutation/idp/audit.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/idp/audit.ts
@@ -13,6 +13,7 @@ export const idpRowToAuditSnapshot = (row: IdentityProviderRow | null): JSONValu
 		exclusive: row.exclusive,
 		initReturnsConfig: row.initReturnsConfig,
 		requireVerifiedEmail: row.requireVerifiedEmail,
+		assumeEmailVerified: row.assumeEmailVerified,
 		configurationKeys: Object.keys(row.configuration).sort(),
 	}
 }

--- a/packages/engine-tenant-api/src/schema/index.ts
+++ b/packages/engine-tenant-api/src/schema/index.ts
@@ -906,6 +906,7 @@ export type ForceSignOutPersonResponse = {
 }
 
 export type IdpOptions = {
+	readonly assumeEmailVerified?: InputMaybe<Scalars['Boolean']['input']>
 	readonly autoSignUp?: InputMaybe<Scalars['Boolean']['input']>
 	readonly exclusive?: InputMaybe<Scalars['Boolean']['input']>
 	readonly initReturnsConfig?: InputMaybe<Scalars['Boolean']['input']>
@@ -914,6 +915,12 @@ export type IdpOptions = {
 
 export type IdpOptionsOutput = {
 	readonly __typename?: 'IDPOptionsOutput'
+	/**
+	 * When true, e-mail addresses asserted by this provider are treated as verified
+	 * even without an "email_verified" claim. Use only for trusted providers.
+	 * Defaults to false.
+	 */
+	readonly assumeEmailVerified: Scalars['Boolean']['output']
 	readonly autoSignUp: Scalars['Boolean']['output']
 	readonly exclusive: Scalars['Boolean']['output']
 	readonly initReturnsConfig: Scalars['Boolean']['output']
@@ -3391,6 +3398,7 @@ export type IdpOptionsOutputResolvers<
 	ContextType = any,
 	ParentType extends ResolversParentTypes['IDPOptionsOutput'] = ResolversParentTypes['IDPOptionsOutput'],
 > = {
+	assumeEmailVerified?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	autoSignUp?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	exclusive?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>
 	initReturnsConfig?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>

--- a/packages/engine-tenant-api/src/schema/tenant.graphql.ts
+++ b/packages/engine-tenant-api/src/schema/tenant.graphql.ts
@@ -765,6 +765,12 @@ const schema: DocumentNode = gql`
 		Defaults to false.
 		"""
 		requireVerifiedEmail: Boolean!
+		"""
+		When true, e-mail addresses asserted by this provider are treated as verified
+		even without an "email_verified" claim. Use only for trusted providers.
+		Defaults to false.
+		"""
+		assumeEmailVerified: Boolean!
 	}
 
 	input IDPOptions {
@@ -772,6 +778,7 @@ const schema: DocumentNode = gql`
 		exclusive: Boolean
 		initReturnsConfig: Boolean
 		requireVerifiedEmail: Boolean
+		assumeEmailVerified: Boolean
 	}
 
 	# === passwordless sign in ===

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/signInIdpMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/signInIdpMutation.test.ts
@@ -48,6 +48,7 @@ test('signs in idp with existing identity', async () => {
 						disabledAt: null,
 						initReturnsConfig: false,
 						requireVerifiedEmail: false,
+						assumeEmailVerified: false,
 						slug: 'mock',
 						type: 'mock',
 					},
@@ -123,6 +124,7 @@ test('does NOT link by e-mail when provider requires a verified e-mail and the c
 						exclusive: false,
 						initReturnsConfig: false,
 						requireVerifiedEmail: true,
+						assumeEmailVerified: false,
 						configuration: {
 							externalIdentifier,
 							email,
@@ -201,10 +203,98 @@ test('links by e-mail when provider requires a verified e-mail and the claim is 
 						exclusive: false,
 						initReturnsConfig: false,
 						requireVerifiedEmail: true,
+						assumeEmailVerified: false,
 						configuration: {
 							externalIdentifier,
 							email,
 							emailVerified: true,
+						},
+						disabledAt: null,
+						slug: 'mock',
+						type: 'mock',
+					},
+				}),
+				getPersonByIdpSql({
+					externalIdentifier,
+					identityProviderId: idpId,
+					response: null,
+				}),
+				getPersonByEmailSql({
+					email,
+					response: { personId, identityId, password: '123', roles: [] },
+				}),
+				{
+					sql: `insert into  "tenant"."person_identity_provider" ("id", "identity_provider_id", "person_id", "external_identifier") values  (?, ?, ?, ?)`,
+					parameters: [testUuid(1), idpId, personId, externalIdentifier],
+					response: { rowCount: 1 },
+				},
+				getConfigSql(),
+				getIdentityByIdSql({ identityId }),
+				getAuthPoliciesSql(),
+				createSessionKeySql({
+					apiKeyId: testUuid(2),
+					identityId,
+				}),
+			),
+			getIdentityProjectsSql({ identityId, projectId }),
+			selectMembershipsSql({
+				identityId,
+				projectId,
+				membershipsResponse: [{ role: 'editor', variables: [{ name: 'locale', values: ['cs'] }] }],
+			}),
+		],
+		return: {
+			data: {
+				signInIDP: {
+					ok: true,
+					errors: [],
+					result: {
+						token: '0000000000000000000000000000000000000000',
+					},
+				},
+			},
+		},
+		expectedAuthLog: {
+			type: 'idp_login',
+			response: expect.objectContaining({
+				ok: true,
+			}),
+		},
+	})
+})
+
+test('links by e-mail when require + assumeEmailVerified are set, even though the claim is unverified', async () => {
+	const externalIdentifier = 'abcd'
+	const email = 'john@doe.com'
+	const identityId = testUuid(2)
+	const personId = testUuid(7)
+	const projectId = testUuid(10)
+	const idpId = testUuid(20)
+	await executeTenantTest({
+		query: signInIDP({
+			identityProvider: 'mock',
+			idpResponse: {
+				url: 'test',
+			},
+			redirectUrl: 'test',
+			sessionData: {},
+		}),
+		executes: [
+			...sqlTransaction(
+				getIdpBySlugSql({
+					slug: 'mock',
+					response: {
+						id: idpId,
+						autoSignUp: false,
+						exclusive: false,
+						initReturnsConfig: false,
+						requireVerifiedEmail: true,
+						// trusted IdP: e-mails are treated as verified even though the claim says false
+						assumeEmailVerified: true,
+						configuration: {
+							externalIdentifier,
+							email,
+							emailVerified: false,
 						},
 						disabledAt: null,
 						slug: 'mock',
@@ -287,6 +377,7 @@ test('signs in exclusive idp', async () => {
 						exclusive: true,
 						initReturnsConfig: false,
 						requireVerifiedEmail: false,
+						assumeEmailVerified: false,
 						configuration: {
 							externalIdentifier: externalIdentifier,
 							email,

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getIdpBySlugSql.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/sql/getIdpBySlugSql.ts
@@ -7,7 +7,7 @@ export const getIdpBySlugSql = (args: {
 	response: null | IdentityProviderRow
 }): ExpectedQuery => ({
 	sql:
-		SQL`select "id", "slug", "type", "configuration", "disabled_at" as "disabledAt", "auto_sign_up" as "autoSignUp", "exclusive", "init_returns_config" as "initReturnsConfig", "require_verified_email" as "requireVerifiedEmail"
+		SQL`select "id", "slug", "type", "configuration", "disabled_at" as "disabledAt", "auto_sign_up" as "autoSignUp", "exclusive", "init_returns_config" as "initReturnsConfig", "require_verified_email" as "requireVerifiedEmail", "assume_email_verified" as "assumeEmailVerified"
 		from "tenant"."identity_provider"
 		where "slug" = ?`,
 	parameters: [args.slug],

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcProvider.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcProvider.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { OIDCProvider } from '../../../../src/model/service/idp/providers/OIDCProvider.js'
+import { InvalidIDPConfigurationError } from '../../../../src/model/service/idp/InvalidIDPConfigurationError.js'
+
+const baseConfig = {
+	url: 'https://idp.example.com',
+	clientId: 'client',
+	clientSecret: 'secret',
+}
+
+describe('OIDCProvider.validateConfiguration', () => {
+	const provider = new OIDCProvider()
+
+	test('accepts tokenEndpointAuthMethod', () => {
+		const config = provider.validateConfiguration({ ...baseConfig, tokenEndpointAuthMethod: 'client_secret_post' })
+		expect(config.tokenEndpointAuthMethod).toBe('client_secret_post')
+	})
+
+	test('rejects an unknown tokenEndpointAuthMethod', () => {
+		expect(() => provider.validateConfiguration({ ...baseConfig, tokenEndpointAuthMethod: 'magic' }))
+			.toThrow(InvalidIDPConfigurationError)
+	})
+})

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcProvider.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcProvider.test.ts
@@ -20,4 +20,12 @@ describe('OIDCProvider.validateConfiguration', () => {
 		expect(() => provider.validateConfiguration({ ...baseConfig, tokenEndpointAuthMethod: 'magic' }))
 			.toThrow(InvalidIDPConfigurationError)
 	})
+
+	test('accepts a claimMapping with attributesKey and dot-path subject', () => {
+		const config = provider.validateConfiguration({
+			...baseConfig,
+			claimMapping: { externalIdentifier: 'oid', email: 'email', attributesKey: 'attributes' },
+		})
+		expect(config.claimMapping).toEqual({ externalIdentifier: 'oid', email: 'email', attributesKey: 'attributes' })
+	})
 })

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, test } from 'bun:test'
 import { handleOIDCResponse } from '../../../../src/model/service/idp/providers/OIDCHelpers.js'
 
 /** A stub openid-client whose `callback` yields the given id-token claims and `userinfo` the given object. */
-const stubClient = (idTokenClaims: Record<string, unknown>, userInfo?: Record<string, unknown>) => ({
-	callback: async () => ({
-		access_token: 'access-token',
-		claims: () => idTokenClaims,
-	}),
-	userinfo: async () => userInfo ?? {},
-}) as any
+const stubClient = (idTokenClaims: Record<string, unknown>, userInfo?: Record<string, unknown>) =>
+	({
+		callback: async () => ({
+			access_token: 'access-token',
+			claims: () => idTokenClaims,
+		}),
+		userinfo: async () => userInfo ?? {},
+	}) as any
 
 const responseData = { parameters: {}, redirectUrl: 'https://app.example.com/cb' }
 

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { handleOIDCResponse } from '../../../../src/model/service/idp/providers/OIDCHelpers.js'
+import { IDPValidationError } from '../../../../src/model/service/idp/IDPValidationError.js'
 
 /** A stub openid-client whose `callback` yields the given id-token claims and `userinfo` the given object. */
 const stubClient = (idTokenClaims: Record<string, unknown>, userInfo?: Record<string, unknown>) =>
@@ -67,5 +68,65 @@ describe('handleOIDCResponse — claim mapping', () => {
 			claimMapping: { attributesKey: 'attributes' },
 		})
 		expect(result.emailVerified).toBe(true)
+	})
+})
+
+describe('handleOIDCResponse — externalIdentifier scalar guard', () => {
+	// The federation key is persisted and matched on the next sign-in; a non-scalar coerced via
+	// String() would collapse every user of the provider onto one key, so we fail closed.
+	test('rejects a mapped subject that is an object', async () => {
+		const client = stubClient({ sub: 's', obj: { a: 1 } })
+		await expect(handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'obj' } }))
+			.rejects.toThrow(IDPValidationError)
+	})
+
+	test('rejects a mapped subject that is an array', async () => {
+		const client = stubClient({ sub: 's', list: ['a', 'b'] })
+		await expect(handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'list' } }))
+			.rejects.toThrow(IDPValidationError)
+	})
+
+	test('accepts a numeric mapped subject, coercing it to its string form', async () => {
+		const client = stubClient({ sub: 's', uid: 12345 })
+		const result = await handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'uid' } })
+		expect(result.externalIdentifier).toBe('12345')
+	})
+})
+
+describe('handleOIDCResponse — signed claims win over unwrapped attributes', () => {
+	// `attributes` come from the unsigned userinfo response; they must not override a claim already
+	// present in the signature-verified ID-token / userInfo merge.
+	test('a signed id_token `sub` is not overridden by an attributes-level `sub`', async () => {
+		const client = stubClient(
+			{ sub: 'signed-subject' },
+			{ sub: 'signed-subject', attributes: { sub: 'spoofed-subject', email: 'a@b.cz' } },
+		)
+		const result = await handleOIDCResponse(client, responseData, {
+			fetchUserInfo: true,
+			claimMapping: { attributesKey: 'attributes' },
+		})
+		expect(result.externalIdentifier).toBe('signed-subject')
+	})
+
+	test('a top-level email_verified is not overridden by an attributes-level one', async () => {
+		const client = stubClient(
+			{ sub: 's' },
+			{ sub: 's', email_verified: false, attributes: { email: 'a@b.cz', email_verified: 'true' } },
+		)
+		const result = await handleOIDCResponse(client, responseData, {
+			fetchUserInfo: true,
+			claimMapping: { attributesKey: 'attributes' },
+		})
+		expect(result.emailVerified).toBe(false)
+	})
+})
+
+describe('handleOIDCResponse — non-string email/name do not leak', () => {
+	// A non-string `email` claim must be dropped, not passed through `...source` — it would
+	// otherwise reach the by-e-mail lookup and crash normalizeEmail (TypeError -> 500).
+	test('a non-string e-mail claim is dropped to undefined, not leaked', async () => {
+		const client = stubClient({ sub: 's', email: ['a@b.cz', 'c@d.cz'] })
+		const result = await handleOIDCResponse(client, responseData)
+		expect(result.email).toBeUndefined()
 	})
 })

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test'
+import { handleOIDCResponse } from '../../../../src/model/service/idp/providers/OIDCHelpers.js'
+
+/** A stub openid-client whose `callback` yields the given id-token claims and `userinfo` the given object. */
+const stubClient = (idTokenClaims: Record<string, unknown>, userInfo?: Record<string, unknown>) => ({
+	callback: async () => ({
+		access_token: 'access-token',
+		claims: () => idTokenClaims,
+	}),
+	userinfo: async () => userInfo ?? {},
+}) as any
+
+const responseData = { parameters: {}, redirectUrl: 'https://app.example.com/cb' }
+
+describe('handleOIDCResponse — claim mapping', () => {
+	test('defaults: subject from `sub`, e-mail from `email`', async () => {
+		const client = stubClient({ sub: 'jan.pokusny@npi.cz', email: 'jan.pokusny@npi.cz', given_name: 'Jan' })
+		const result = await handleOIDCResponse(client, responseData)
+		expect(result.externalIdentifier).toBe('jan.pokusny@npi.cz')
+		expect(result.email).toBe('jan.pokusny@npi.cz')
+	})
+
+	test('maps the external identifier to a stable claim (oid) from a flat id_token', async () => {
+		const client = stubClient({ sub: 'jan.pokusny@npi.cz', email: 'jan.pokusny@npi.cz', oid: 'cf0f5802-4afa-42bf' })
+		const result = await handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'oid' } })
+		expect(result.externalIdentifier).toBe('cf0f5802-4afa-42bf')
+		expect(result.email).toBe('jan.pokusny@npi.cz')
+	})
+
+	test('unwraps userinfo claims nested under `attributes` (Apereo CAS shape)', async () => {
+		const client = stubClient(
+			{ sub: 'jan.pokusny@npi.cz' },
+			{
+				sub: 'jan.pokusny@npi.cz',
+				attributes: { oid: 'cf0f5802-4afa-42bf', email: 'jan.pokusny@npi.cz', given_name: 'Jan', family_name: 'Pokusný' },
+			},
+		)
+		const result = await handleOIDCResponse(client, responseData, {
+			fetchUserInfo: true,
+			claimMapping: { externalIdentifier: 'oid', attributesKey: 'attributes' },
+		})
+		expect(result.externalIdentifier).toBe('cf0f5802-4afa-42bf')
+		expect(result.email).toBe('jan.pokusny@npi.cz')
+		expect(result.given_name).toBe('Jan')
+	})
+
+	test('dot-path mapping reaches into a nested claim without unwrapping', async () => {
+		const client = stubClient({ sub: 's', user: { id: 'nested-id' } })
+		const result = await handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'user.id' } })
+		expect(result.externalIdentifier).toBe('nested-id')
+	})
+
+	test('falls back to `sub` when the mapped subject claim is absent', async () => {
+		const client = stubClient({ sub: 'fallback-sub' })
+		const result = await handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'oid' } })
+		expect(result.externalIdentifier).toBe('fallback-sub')
+	})
+
+	test('email_verified is read from unwrapped attributes (string "true" accepted)', async () => {
+		const client = stubClient(
+			{ sub: 's' },
+			{ sub: 's', attributes: { email: 'a@b.cz', email_verified: 'true' } },
+		)
+		const result = await handleOIDCResponse(client, responseData, {
+			fetchUserInfo: true,
+			claimMapping: { attributesKey: 'attributes' },
+		})
+		expect(result.emailVerified).toBe(true)
+	})
+})

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
@@ -91,6 +91,18 @@ describe('handleOIDCResponse — externalIdentifier scalar guard', () => {
 		const result = await handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'uid' } })
 		expect(result.externalIdentifier).toBe('12345')
 	})
+
+	test('rejects a mapped subject that resolves to an empty string', async () => {
+		const client = stubClient({ sub: 's', oid: '' })
+		await expect(handleOIDCResponse(client, responseData, { claimMapping: { externalIdentifier: 'oid' } }))
+			.rejects.toThrow(IDPValidationError)
+	})
+
+	test('rejects an empty `sub` on the default path', async () => {
+		const client = stubClient({ sub: '' })
+		await expect(handleOIDCResponse(client, responseData))
+			.rejects.toThrow(IDPValidationError)
+	})
 })
 
 describe('handleOIDCResponse — signed claims win over unwrapped attributes', () => {


### PR DESCRIPTION
## Why

Evaluating an integration against an external **Apereo CAS** OIDC provider (NPI's "AM" auth service) surfaced a few places where Contember's IdP handler couldn't consume a spec-compliant-but-non-default provider without per-integration code. This makes the core ready for CAS-style providers (and similar) **via configuration**, no patches per integration.

Two layers, deliberately kept separate:
- **provider-specific** OIDC bits → live in the opaque `configuration` Json (cheap, no SDL/codegen)
- **provider-agnostic** behavior → lives in the typed `IDPOptions` (next to `requireVerifiedEmail`)

## Changes (one commit each)

### 1. `tokenEndpointAuthMethod` (OIDC configuration)
`openid-client` defaults to `client_secret_basic` with no override. Some CAS registrations only accept the secret in the body (`client_secret_post`). Expose `tokenEndpointAuthMethod` and pass it through.

### 2. OIDC claim mapping (OIDC configuration)
Optional `claimMapping` to map provider claims onto the normalized `IDPResponse`:
- `externalIdentifier` can target a **stable** claim (e.g. Entra `oid`) instead of the default `sub` — important when `sub` is a mutable e-mail/UPN,
- `email` / `name` mapping, all with **dot-path** support,
- `attributesKey` lifts a nested object to the top level — Apereo CAS userinfo nests the actual claims under `attributes`.

Defaults preserve current behavior (`sub`/`email`/`name`, no unwrap).

### 3. `assumeEmailVerified` (general IDP option)
Provider-agnostic option (sibling of `requireVerifiedEmail`) that treats e-mails from a **trusted** IdP as verified even when it emits no `email_verified` claim — applied in the general sign-in layer so it works for every provider. Lets `requireVerifiedEmail` stay on with an IdP (e.g. CAS) that never sends the claim. Defaults to `false`.

Full vertical slice: migration + regenerated snapshot, SDL + regenerated `schema/index.ts`, command/query/type/resolver/audit plumbing, gate in `IDPSignInManager`. Also fixes the snapshot template to keep `.js` import extensions (regen would otherwise break the import-extension lint rule).

## Out of scope (deferred)
- **Encrypted (JWE) id_token** decryption — needs client JWKS + key lifecycle; not required since claims can come from the signed id_token or userinfo.
- Other candidate general options (email-domain allowlist, default roles on auto-signup, profile-sync-on-login).

## Tests
- `oidcProvider.test.ts` — config validation for `tokenEndpointAuthMethod` + `claimMapping`
- `oidcResponse.test.ts` — claim mapping: subject→`oid`, `attributes` unwrap, dot-paths, `sub` fallback, `email_verified` from attributes
- `signInIdpMutation.test.ts` — new case: `assumeEmailVerified` lets e-mail linking proceed under `requireVerifiedEmail` with an unverified claim

`tsc --build`, biome lint, and dprint check all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)