### PR TITLE
fix(engine-content-api): keep cell-level read predicates on back-reference simplification

### DIFF
--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -53,29 +53,19 @@ export class PredicatesInjector {
 			&& relationContext !== undefined
 			&& this.findBackReferencedAncestor(ancestorPath, relationContext.relation.name, relationContext.entity.name) !== undefined
 
+		// The back-referenced ancestor only guarantees the row-level (primary) predicate,
+		// so only that part can be simplified away. Cell-level predicates of the fields
+		// being filtered on must still be enforced, otherwise filtering on a field with
+		// a stricter read predicate would leak its value through row presence.
+		const effectiveFieldNames = shouldSimplify
+			? (fieldNames ?? []).filter(it => this.predicateFactory.shouldApplyCellLevelPredicate(entity, Acl.Operation.read, it, isQueryRoot))
+			: fieldNames
+
 		let predicatesWhere: Input.OptionalWhere
-		if (shouldSimplify) {
-			// The back-referenced ancestor only guarantees the row-level (primary) predicate,
-			// so only that part can be simplified away. Cell-level predicates of the fields
-			// being filtered on must still be enforced, otherwise filtering on a field with
-			// a stricter read predicate would leak its value through row presence.
-			const cellLevelFields = (fieldNames ?? []).filter(it =>
-				this.predicateFactory.shouldApplyCellLevelPredicate(entity, Acl.Operation.read, it, isQueryRoot)
-			)
-			if (cellLevelFields.length === 0) {
-				predicatesWhere = { [entity.primary]: { always: true } }
-			} else {
-				const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, cellLevelFields, relationContext, isQueryRoot)
-				predicatesWhere = this.injectPredicatesToPredicate(
-					rawPredicate,
-					entity,
-					isBackReferenceContext ?? false,
-					ancestorPath ?? [],
-					isQueryRoot,
-				)
-			}
+		if (shouldSimplify && effectiveFieldNames?.length === 0) {
+			predicatesWhere = { [entity.primary]: { always: true } }
 		} else {
-			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
+			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, effectiveFieldNames, relationContext, isQueryRoot)
 			// Process the predicate to inject nested entity predicates
 			predicatesWhere = this.injectPredicatesToPredicate(
 				rawPredicate,

--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -55,7 +55,25 @@ export class PredicatesInjector {
 
 		let predicatesWhere: Input.OptionalWhere
 		if (shouldSimplify) {
-			predicatesWhere = { [entity.primary]: { always: true } }
+			// The back-referenced ancestor only guarantees the row-level (primary) predicate,
+			// so only that part can be simplified away. Cell-level predicates of the fields
+			// being filtered on must still be enforced, otherwise filtering on a field with
+			// a stricter read predicate would leak its value through row presence.
+			const cellLevelFields = (fieldNames ?? []).filter(it =>
+				this.predicateFactory.shouldApplyCellLevelPredicate(entity, Acl.Operation.read, it, isQueryRoot)
+			)
+			if (cellLevelFields.length === 0) {
+				predicatesWhere = { [entity.primary]: { always: true } }
+			} else {
+				const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, cellLevelFields, relationContext, isQueryRoot)
+				predicatesWhere = this.injectPredicatesToPredicate(
+					rawPredicate,
+					entity,
+					isBackReferenceContext ?? false,
+					ancestorPath ?? [],
+					isQueryRoot,
+				)
+			}
 		} else {
 			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
 			// Process the predicate to inject nested entity predicates

--- a/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
@@ -1419,6 +1419,314 @@ describe('predicates injector - SECURITY: cell-level predicates on back-referenc
 			],
 		})
 	})
+
+	it('keeps cell-level predicate on a simplified back-reference inside an or branch', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				or: [
+					{ parent: { secret: { eq: 'X' } } },
+					{ name: { eq: 'A' } },
+				],
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// The guard of `secret` must be preserved inside the or branch as well
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					or: [
+						{
+							and: [
+								{ parent: { and: [{ secret: { eq: 'X' } }, { secretVisible: { eq: true } }] } },
+								{ isPublished: { eq: true } },
+							],
+						},
+						{
+							and: [
+								{ name: { eq: 'A' } },
+								{ isPublished: { eq: true } },
+							],
+						},
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+
+	it('keeps cell-level predicate on a simplified back-reference inside a not branch', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				not: { parent: { secret: { eq: 'X' } } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					not: {
+						and: [
+							{ parent: { and: [{ secret: { eq: 'X' } }, { secretVisible: { eq: true } }] } },
+							{ isPublished: { eq: true } },
+						],
+					},
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+
+	it('keeps only the stricter field guard when filtering on a mix of row-covered and cell-level fields', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				parent: { id: { in: [testUuid(1)] }, secret: { eq: 'X' } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// `id` carries the row-level predicate (already verified upstream) and is filtered out,
+		// `secret` is stricter and its cell-level guard must be enforced
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{ parent: { and: [{ id: { in: [testUuid(1)] }, secret: { eq: 'X' } }, { secretVisible: { eq: true } }] } },
+						{ isPublished: { eq: true } },
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+})
+
+// SECURITY TEST: same as CellLevelPredicateModel, but the back-reference is a many-has-many
+// relation — the cell-level guard must survive simplification on both the owning and the
+// inverse traversal.
+namespace CellLevelM2MModel {
+	export const readerRole = acl.createRole('reader')
+
+	@acl.allow(readerRole, {
+		when: { isPublished: { eq: true } },
+		read: ['title', 'tags'],
+	})
+	@acl.allow(readerRole, {
+		when: { internalVisible: { eq: true } },
+		read: ['internalNote'],
+	})
+	export class Post {
+		title = def.stringColumn()
+		internalNote = def.stringColumn()
+		isPublished = def.boolColumn()
+		internalVisible = def.boolColumn()
+		tags = def.manyHasMany(Tag, 'posts')
+	}
+
+	@acl.allow(readerRole, {
+		when: { isActive: { eq: true } },
+		read: ['name', 'posts'],
+	})
+	@acl.allow(readerRole, {
+		when: { secretVisible: { eq: true } },
+		read: ['secret'],
+	})
+	export class Tag {
+		name = def.stringColumn()
+		secret = def.stringColumn()
+		isActive = def.boolColumn()
+		secretVisible = def.boolColumn()
+		posts = def.manyHasManyInverse(Post, 'tags')
+	}
+}
+
+describe('predicates injector - SECURITY: cell-level predicates on many-to-many back-reference', () => {
+	const schema = createSchema(CellLevelM2MModel)
+	const permissions = new PermissionFactory().create(schema, ['reader'])
+
+	const injector = new PredicatesInjector(
+		schema.model,
+		new PredicateFactory(permissions, schema.model, new VariableInjector(schema.model, {})),
+	)
+
+	const getOwningContext = () => {
+		const relation = acceptFieldVisitor(schema.model, schema.model.entities.Post, 'tags', {
+			visitColumn: () => {
+				throw new Error()
+			},
+			visitRelation: ctx => ctx,
+		})
+		return { relation, ancestorPath: [relation] }
+	}
+
+	const getInverseContext = () => {
+		const relation = acceptFieldVisitor(schema.model, schema.model.entities.Tag, 'posts', {
+			visitColumn: () => {
+				throw new Error()
+			},
+			visitRelation: ctx => ctx,
+		})
+		return { relation, ancestorPath: [relation] }
+	}
+
+	it('keeps cell-level predicate when filtering back via posts (m:n inverse back-reference)', () => {
+		const { relation, ancestorPath } = getOwningContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Tag,
+			{
+				posts: { internalNote: { eq: 'X' } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// Post's row-level predicate is simplified away, but the cell-level guard
+		// of `internalNote` must stay
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{ posts: { and: [{ internalNote: { eq: 'X' } }, { internalVisible: { eq: true } }] } },
+						{ isActive: { eq: true } },
+					],
+				},
+				{ or: [{ isActive: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+
+	it('keeps cell-level predicate when filtering back via tags (m:n owning back-reference)', () => {
+		const { relation, ancestorPath } = getInverseContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Post,
+			{
+				tags: { secret: { eq: 'X' } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{ tags: { and: [{ secret: { eq: 'X' } }, { secretVisible: { eq: true } }] } },
+						{ isPublished: { eq: true } },
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { internalVisible: { eq: true } }] },
+			],
+		})
+	})
+})
+
+// SECURITY TEST: the cell-level read predicate itself traverses a relation. When such
+// a field is filtered through a simplified back-reference, the retained cell-level
+// predicate must additionally get the nested entity's predicate injected (the
+// injectPredicatesToPredicate pass) — otherwise the guard would be evaluated against
+// rows of the related entity that the role cannot read.
+namespace CellLevelRelationPredicateModel {
+	export const readerRole = acl.createRole('reader')
+
+	@acl.allow(readerRole, {
+		when: { isVisible: { eq: true } },
+		read: true,
+	})
+	export class ArticleMeta {
+		secretVisible = def.boolColumn()
+		isVisible = def.boolColumn()
+	}
+
+	@acl.allow(readerRole, {
+		when: { isPublished: { eq: true } },
+		read: ['name', 'meta', 'parent', 'children'],
+	})
+	@acl.allow(readerRole, {
+		when: { meta: { secretVisible: { eq: true } } },
+		read: ['secret'],
+	})
+	export class Article {
+		name = def.stringColumn()
+		secret = def.stringColumn()
+		isPublished = def.boolColumn()
+		meta = def.manyHasOne(ArticleMeta)
+		parent = def.manyHasOne(Article, 'children')
+		children = def.oneHasMany(Article, 'parent')
+	}
+}
+
+describe('predicates injector - SECURITY: relation-traversing cell-level predicate on back-reference', () => {
+	const schema = createSchema(CellLevelRelationPredicateModel)
+	const permissions = new PermissionFactory().create(schema, ['reader'])
+
+	const injector = new PredicatesInjector(
+		schema.model,
+		new PredicateFactory(permissions, schema.model, new VariableInjector(schema.model, {})),
+	)
+
+	const getChildrenContext = () => {
+		const relation = acceptFieldVisitor(schema.model, schema.model.entities.Article, 'children', {
+			visitColumn: () => {
+				throw new Error()
+			},
+			visitRelation: ctx => ctx,
+		})
+		return { relation, ancestorPath: [relation] }
+	}
+
+	it('injects nested entity predicate into the retained cell-level predicate', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Article,
+			{
+				parent: { secret: { eq: 'X' } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// The retained guard of `secret` traverses `meta`, so ArticleMeta's own
+		// predicate (isVisible) must be injected into it
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{
+							parent: {
+								and: [
+									{ secret: { eq: 'X' } },
+									{ meta: { and: [{ secretVisible: { eq: true } }, { isVisible: { eq: true } }] } },
+								],
+							},
+						},
+						{ isPublished: { eq: true } },
+					],
+				},
+				{
+					or: [
+						{ isPublished: { eq: true } },
+						{ meta: { and: [{ secretVisible: { eq: true } }, { isVisible: { eq: true } }] } },
+					],
+				},
+			],
+		})
+	})
 })
 
 describe('predicate injector input handling', () => {

--- a/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
@@ -1257,6 +1257,170 @@ describe('predicates injector - many-to-many relations', () => {
 	})
 })
 
+// SECURITY TEST: a field whose read predicate is stricter than the row-level predicate.
+// The row-level (primary) predicate is the OR-union of all field predicates, so any field
+// with its own predicate is stricter than the row union. When such a field is used in
+// a back-referenced filter, its cell-level predicate must NOT be dropped by the
+// back-reference simplification — otherwise row presence becomes an oracle on a field
+// the user cannot read.
+namespace CellLevelPredicateModel {
+	export const readerRole = acl.createRole('reader')
+
+	@acl.allow(readerRole, {
+		when: { isPublished: { eq: true } },
+		read: ['name', 'parent', 'children'],
+	})
+	@acl.allow(readerRole, {
+		when: { secretVisible: { eq: true } },
+		read: ['secret'],
+	})
+	export class Category {
+		name = def.stringColumn()
+		secret = def.stringColumn()
+		isPublished = def.boolColumn()
+		secretVisible = def.boolColumn()
+		parent = def.manyHasOne(Category, 'children')
+		children = def.oneHasMany(Category, 'parent')
+	}
+}
+
+describe('predicates injector - SECURITY: cell-level predicates on back-reference', () => {
+	const schema = createSchema(CellLevelPredicateModel)
+	const permissions = new PermissionFactory().create(schema, ['reader'])
+
+	const injector = new PredicatesInjector(
+		schema.model,
+		new PredicateFactory(permissions, schema.model, new VariableInjector(schema.model, {})),
+	)
+
+	const getChildrenContext = () => {
+		const relation = acceptFieldVisitor(schema.model, schema.model.entities.Category, 'children', {
+			visitColumn: () => {
+				throw new Error()
+			},
+			visitRelation: ctx => ctx,
+		})
+		return { relation, ancestorPath: [relation] }
+	}
+
+	it('keeps cell-level predicate of the filtered field on a simplified back-reference', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				parent: { secret: { eq: 'X' } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// The parent row-level predicate is simplified away (verified on the ancestor),
+		// but the cell-level predicate of `secret` must stay — without it, the filter
+		// would leak the value of an unreadable field through row presence
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{ parent: { and: [{ secret: { eq: 'X' } }, { secretVisible: { eq: true } }] } },
+						{ isPublished: { eq: true } },
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+
+	it('keeps cell-level predicates of all filtered fields on a simplified back-reference', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				parent: { name: { eq: 'A' }, secret: { eq: 'X' } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// Both `name` and `secret` have predicates stricter than the row union,
+		// so both cell-level predicates are enforced
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{
+							parent: {
+								and: [
+									{ name: { eq: 'A' }, secret: { eq: 'X' } },
+									{ and: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+								],
+							},
+						},
+						{ isPublished: { eq: true } },
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+
+	it('still simplifies to { id: always } when filtering on the primary only', () => {
+		const { relation, ancestorPath } = getChildrenContext()
+
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				parent: { id: { in: [testUuid(1)] } },
+			},
+			relation,
+			ancestorPath,
+		)
+
+		// The primary's predicate IS the row-level predicate, already verified upstream
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{ parent: { and: [{ id: { in: [testUuid(1)] } }, { id: { always: true } }] } },
+						{ isPublished: { eq: true } },
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+
+	it('keeps cell-level predicate for a back-reference inside a root query filter', () => {
+		// The full attack shape: listCategory(filter: { children: { parent: { secret: { eq: 'X' } } } })
+		const injected = injector.inject(
+			schema.model.entities.Category,
+			{
+				children: { parent: { secret: { eq: 'X' } } },
+			},
+		)
+
+		assert.deepStrictEqual(injected, {
+			and: [
+				{
+					and: [
+						{
+							children: {
+								and: [
+									{ parent: { and: [{ secret: { eq: 'X' } }, { secretVisible: { eq: true } }] } },
+									{ isPublished: { eq: true } },
+								],
+							},
+						},
+						{ isPublished: { eq: true } },
+					],
+				},
+				{ or: [{ isPublished: { eq: true } }, { secretVisible: { eq: true } }] },
+			],
+		})
+	})
+})
+
 describe('predicate injector input handling', () => {
 	const schema = createSchema(DeepFilterModel)
 	const permissions = new AllowAllPermissionFactory().create(schema.model)


### PR DESCRIPTION
## Problem

The back-reference simplification in `PredicatesInjector.createWhere` replaces the whole injected predicate with `{ [primary]: { always: true } }`, discarding the `fieldNames` argument. That is sound for the **row-level** predicate — the back-referenced ancestor row was already verified upstream — but it also drops the **cell-level** read predicates of the fields being filtered on.

Since the row-level predicate is built as the OR-union of all field predicates (`PermissionFactory.makePrimaryPredicatesUnionOfAllFields`), a field with its own read predicate is typically *stricter* than the row union. Filtering on such a field through a back-reference:

```graphql
listCategory(filter: { children: { parent: { secret: { eq: "X" } } } })
```

emitted no guard for `secret` at all (`WHERE secret = 'X' AND true`), so row presence/count became a binary-search oracle on a field the role cannot read.

## Fix

In the simplified branch, only the row-level part is simplified away. Fields whose read predicate differs from the row-level predicate (`PredicateFactory.shouldApplyCellLevelPredicate`) keep their cell-level predicates, which are built and processed through the same `injectPredicatesToPredicate` path as the non-simplified branch. Filters touching only the primary key still simplify to `{ [primary]: { always: true } }` as before, so the existing optimization (and all existing tests) are preserved.

The analogous `{ primary: always }` shortcut in `injectPredicatesToPredicate` was audited and is unaffected: its non-simplified path injects only the row-level predicate (`fieldNames` is `undefined`), so there is no cell-level predicate to lose there.

## Tests

New unit tests in `predicatesInjector.test.ts` with a model where field read predicates are granted by two separate `@acl.allow` rules, making each field's predicate stricter than the row union (the case existing tests missed — their models share a single predicate across all fields):

- filtered field's cell-level predicate is kept on a simplified back-reference (relation-context and root-query shapes — the exact attack shape above)
- multiple filtered fields keep all their cell-level predicates
- primary-key-only filters still simplify to `{ id: { always: true } }`

The three security assertions fail against the previous implementation; the full `engine-content-api` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)