### PR TITLE
fix(engine-content-api): resolve nested relation predicates against the through (all) permission set

### DIFF
--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -13,7 +13,7 @@ export class PredicatesInjector {
 	): Input.OptionalWhere {
 		const isQueryRoot = !relationContext && (!ancestorPath || ancestorPath.length === 0)
 		const restrictedWhere = this.injectToWhere(where, entity, true, relationContext, false, ancestorPath ?? [], isQueryRoot)
-		return this.createWhere(entity, undefined, restrictedWhere, relationContext, false, ancestorPath ?? [], isQueryRoot)
+		return this.createWhere(entity, undefined, restrictedWhere, true, relationContext, false, ancestorPath ?? [], isQueryRoot)
 	}
 
 	/**
@@ -38,6 +38,7 @@ export class PredicatesInjector {
 		entity: Model.Entity,
 		fieldNames: string[] | undefined,
 		where: Input.OptionalWhere,
+		isRoot: boolean,
 		relationContext?: Model.AnyRelationContext,
 		isBackReferenceContext?: boolean,
 		ancestorPath?: readonly Model.AnyRelationContext[],
@@ -53,18 +54,24 @@ export class PredicatesInjector {
 			&& relationContext !== undefined
 			&& this.findBackReferencedAncestor(ancestorPath, relationContext.relation.name, relationContext.entity.name) !== undefined
 
+		// An entity is treated as a query root (consulting root-only permissions) only when it is both the
+		// root of this injection and `isQueryRoot`. A nested relation target is reached THROUGH a relation,
+		// so it must consult the `all` permission set (`isRoot = false`), otherwise a through-only target
+		// resolves to its restrictive root predicate (e.g. `{ primary: never }`) and the relation cannot be
+		// filtered/read at all. `isQueryRoot === undefined` (callers not tracking it) is preserved as-is.
+		const effectiveIsRoot = isRoot ? isQueryRoot : false
+
 		let predicatesWhere: Input.OptionalWhere
 		if (shouldSimplify) {
 			predicatesWhere = { [entity.primary]: { always: true } }
 		} else {
-			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
+			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, effectiveIsRoot)
 			// Process the predicate to inject nested entity predicates
 			predicatesWhere = this.injectPredicatesToPredicate(
 				rawPredicate,
 				entity,
 				isBackReferenceContext ?? false,
 				ancestorPath ?? [],
-				isQueryRoot,
 			)
 		}
 
@@ -88,22 +95,21 @@ export class PredicatesInjector {
 		entity: Model.Entity,
 		isBackReferenceContext: boolean,
 		ancestorPath: readonly Model.AnyRelationContext[],
-		isQueryRoot?: boolean,
 	): Input.OptionalWhere {
 		const resultWhere: Writable<Input.OptionalWhere> = {}
 
 		if (where.and) {
 			resultWhere.and = where.and
 				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
+				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath))
 		}
 		if (where.or) {
 			resultWhere.or = where.or
 				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
+				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath))
 		}
 		if (where.not) {
-			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath, isQueryRoot)
+			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath)
 		}
 
 		const fields = Object.keys(where).filter(it => !['and', 'or', 'not'].includes(it))
@@ -132,17 +138,17 @@ export class PredicatesInjector {
 						context.targetEntity,
 						nestedIsBackReferenceContext,
 						nestedAncestorPath,
-						isQueryRoot,
 					)
 
 					// Check if we should simplify the target entity's predicate
 					const shouldSimplifyNested = nestedIsBackReferenceContext
 						&& this.findBackReferencedAncestor(nestedAncestorPath, context.relation.name, context.entity.name) !== undefined
 
-					// Get target entity's predicate (simplified if back-reference)
+					// Get target entity's predicate (simplified if back-reference). A relation target reached from
+					// within a predicate is always through-access, so it consults the `all` permission set (isRoot=false).
 					const targetPredicate = shouldSimplifyNested
 						? { [context.targetEntity.primary]: { always: true } }
-						: this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, isQueryRoot)
+						: this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, false)
 
 					// Optimization: avoid duplicate { id: always } when both are simplified
 					const primaryKey = context.targetEntity.primary
@@ -224,6 +230,6 @@ export class PredicatesInjector {
 			? fields
 			: fields.filter(it => this.predicateFactory.shouldApplyCellLevelPredicate(entity, Acl.Operation.read, it, isQueryRoot))
 
-		return this.createWhere(entity, fieldsForPredicate, resultWhere, relationContext, isBackReferenceContext, ancestorPath, isQueryRoot)
+		return this.createWhere(entity, fieldsForPredicate, resultWhere, isRoot, relationContext, isBackReferenceContext, ancestorPath, isQueryRoot)
 	}
 }

--- a/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
@@ -1257,6 +1257,75 @@ describe('predicates injector - many-to-many relations', () => {
 	})
 })
 
+// A relation target whose root and through (noRoot) permissions diverge: role `editor` can read Secret at
+// the query root only for visible rows, while role `viewer` can read any Secret THROUGH a relation. The
+// `all` (through-inclusive) set is the union (readable unconditionally). When Secret is reached through a
+// relation, its predicate must come from `all`, not from the restrictive root set — otherwise a row the
+// viewer role is allowed to read through the relation is wrongly filtered out (fail-closed over-restriction).
+namespace MixedRootThroughModel {
+	export const editorRole = acl.createRole('editor')
+	export const viewerRole = acl.createRole('viewer')
+
+	@acl.allow([editorRole, viewerRole], {
+		read: ['name', 'secret'],
+	})
+	export class Document {
+		name = def.stringColumn()
+		secret = def.manyHasOne(Secret, 'documents')
+	}
+
+	@acl.allow(editorRole, {
+		when: { isVisible: { eq: true } },
+		read: ['label', 'isVisible', 'documents'],
+	})
+	@acl.allow(viewerRole, {
+		through: true,
+		read: ['label', 'isVisible', 'documents'],
+	})
+	export class Secret {
+		label = def.stringColumn()
+		isVisible = def.boolColumn()
+		documents = def.oneHasMany(Document, 'secret')
+	}
+}
+
+describe('predicates injector - root vs through (noRoot) relation target permissions', () => {
+	const schema = createSchema(MixedRootThroughModel)
+	const contextual = new PermissionFactory().createContextual(schema, ['editor', 'viewer'])
+
+	const injector = new PredicatesInjector(
+		schema.model,
+		new PredicateFactory(contextual.root, schema.model, new VariableInjector(schema.model, {}), contextual.all),
+	)
+
+	it('resolves a nested relation target predicate against the `all` permission set', () => {
+		const injected = injector.inject(schema.model.entities.Document, {
+			secret: { label: { eq: 'x' } },
+		})
+
+		// Secret is reached through Document.secret, so the through (viewer) permission applies: any row is
+		// readable, no predicate. Before the fix the nested target consulted the root set and the editor's
+		// `isVisible` predicate was wrongly ANDed in, hiding rows the viewer role may read through the relation.
+		assert.deepStrictEqual(injected, {
+			secret: { label: { eq: 'x' } },
+		})
+	})
+
+	it('still resolves a query-root entity against the root permission set (unchanged)', () => {
+		const injected = injector.inject(schema.model.entities.Secret, {
+			label: { eq: 'x' },
+		})
+
+		// As a root entry point only the editor's root permission applies, so the `isVisible` predicate is enforced.
+		assert.deepStrictEqual(injected, {
+			and: [
+				{ label: { eq: 'x' } },
+				{ isVisible: { eq: true } },
+			],
+		})
+	})
+})
+
 describe('predicate injector input handling', () => {
 	const schema = createSchema(DeepFilterModel)
 	const permissions = new AllowAllPermissionFactory().create(schema.model)


### PR DESCRIPTION
## What

`isQueryRoot` was computed once in `PredicatesInjector.inject()` and threaded unchanged into every nested level. A relation target reached **through** a relation therefore consulted the **root-only** permission set instead of the through-inclusive `all` set.

When a role's root and through (`noRoot`) permissions for the same target diverge — e.g. root-readable only for visible rows, but readable for **any** row when accessed through a relation — the stricter root predicate was wrongly enforced on the nested access. This is a **fail-closed over-restriction**: rows the role may legitimately read through the relation were hidden.

This corresponds to **SEC-3** in the read-ACL review. Note: the *leak* manifestation SEC-3 originally described required the syntactic `expandRelationAbsence` rewrite, which #897 removed — what remains (and is fixed here) is the over-restriction root cause.

## Fix

Thread a per-level `isRoot` into `createWhere` and pass an effective `isRoot ? isQueryRoot : false` to `PredicateFactory.create`. Relation targets reached from within an injected predicate likewise use the `all` set (`isRoot = false`). `isQueryRoot === undefined` semantics are preserved.

Only the **contextual (4-arg) PredicateFactory** used in production is affected; the genuine query-root entry point is unchanged (still uses root permissions, verified by test).

## Tests

A 2-role schema (root-read for `editor` under a predicate, through-read for `viewer`) where the nested predicate now resolves against `all`; the test fails without the source change. A second case asserts the query root is unchanged.

## Base

Stacked on `fix/acl-isnull-relation-predicate` (#897) — merge that first. The fix is logically independent, but the touched methods are cleanest on that branch (post-`expandRelationAbsence` removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)