### PR TITLE
refactor(engine-content-api): share read-predicate guard primitives

### DIFF
--- a/packages/engine-content-api/src/acl/PredicateFactory.ts
+++ b/packages/engine-content-api/src/acl/PredicateFactory.ts
@@ -52,6 +52,20 @@ export class PredicateFactory {
 		}
 	}
 
+	/**
+	 * The field's read predicate for a given query path. An entity is treated as a query root (root-only
+	 * permissions) only when `relationPath` is empty; anything reached through a relation consults the
+	 * through-inclusive `all` set. This is the single place that maps a `relationPath` to the read context,
+	 * shared by projection (cell masking) and ordering (order-key guarding) so they always agree.
+	 */
+	public getFieldReadPredicate(
+		entity: Model.Entity,
+		fieldName: string,
+		relationPath: readonly Model.AnyRelationContext[],
+	): FieldRequiredPredicate {
+		return this.getFieldPredicate(entity, Acl.Operation.read, fieldName, relationPath.length === 0)
+	}
+
 	public shouldApplyCellLevelPredicate(
 		entity: Model.Entity,
 		operation: Acl.Operation.read,

--- a/packages/engine-content-api/src/mapper/select/OrderByBuilder.ts
+++ b/packages/engine-content-api/src/mapper/select/OrderByBuilder.ts
@@ -1,7 +1,7 @@
 import { Acl, Input, Model } from '@contember/schema'
 import { Path } from './Path.js'
 import { JoinBuilder } from './JoinBuilder.js'
-import { CaseStatement, ConditionBuilder as SqlConditionBuilder, Literal, QueryBuilder, SelectBuilder, wrapIdentifier } from '@contember/database'
+import { CaseStatement, Literal, QueryBuilder, SelectBuilder, wrapIdentifier } from '@contember/database'
 import { acceptFieldVisitor, getColumnName, getTargetEntity } from '@contember/schema-utils'
 import { UserError } from '../../exception.js'
 import { PredicateFactory } from '../../acl/index.js'
@@ -117,8 +117,7 @@ export class OrderByBuilder {
 		const orderColumn: QueryBuilder.ColumnIdentifier = [path.alias, columnName]
 		const applyPlain = <O extends QueryBuilder.Orderable<any>>(o: O) => o.orderBy(orderColumn, direction)
 
-		const isRoot = relationPath.length === 0
-		const fieldPredicate = this.predicateFactory.getFieldPredicate(entity, Acl.Operation.read, fieldName, isRoot)
+		const fieldPredicate = this.predicateFactory.getFieldReadPredicate(entity, fieldName, relationPath)
 
 		// On the ACL-filtered entity a field whose read predicate equals the row-level predicate is readable
 		// for every returned row, so no guard is needed. Through a relation we always guard.
@@ -141,6 +140,7 @@ export class OrderByBuilder {
 			return [qb, orderable]
 		}
 
+		const isRoot = relationPath.length === 0
 		const relationContext = relationPath[relationPath.length - 1]
 		const predicateWhere = this.predicateFactory.buildPredicates(entity, [guardPredicate], relationContext, isRoot)
 		// The row-level predicate is already guaranteed in the WHERE of the ACL-filtered entity, so let the
@@ -150,26 +150,15 @@ export class OrderByBuilder {
 			: []
 
 		const columnLiteral = new Literal(`${wrapIdentifier(path.alias)}.${wrapIdentifier(columnName)}`)
-		let orderLiteral: Literal | undefined
-
-		qb = this.whereBuilder.buildAdvanced(
+		const { qb: guardedQb, condition } = this.whereBuilder.buildConditionLiteral(
+			qb,
 			entity,
 			path,
 			predicateWhere,
-			applyCondition => {
-				const condition = SqlConditionBuilder.process(clause => {
-					const applied = applyCondition(clause)
-					return applied.isEmpty() ? applied.raw('true') : applied
-				}).getSql() ?? new Literal('true')
-				orderLiteral = CaseStatement.createEmpty().when(condition, columnLiteral).compile()
-				return qb
-			},
 			{ relationPath, evaluatedPredicates },
 		)
-
-		if (orderLiteral === undefined) {
-			throw new Error('OrderByBuilder: order expression was not built')
-		}
+		qb = guardedQb
+		const orderLiteral = CaseStatement.createEmpty().when(condition, columnLiteral).compile()
 		qb = qb.orderBy(orderLiteral, direction)
 		if (orderable !== null) {
 			orderable = orderable.orderBy(orderLiteral, direction)

--- a/packages/engine-content-api/src/mapper/select/SelectBuilder.ts
+++ b/packages/engine-content-api/src/mapper/select/SelectBuilder.ts
@@ -99,21 +99,14 @@ export class SelectBuilder {
 				const primaryPredicate = this.predicateFactory.create(entity, Acl.Operation.read, undefined, relationContext)
 				const fieldPredicate = this.predicateFactory.buildPredicates(entity, [predicate], relationContext)
 
-				this.qb = this.whereBuilder.buildAdvanced(
+				const { qb, condition } = this.whereBuilder.buildConditionLiteral(
+					this.qb,
 					entity,
 					path.back(),
 					fieldPredicate,
-					apply =>
-						this.qb.select(expr =>
-							expr.selectCondition(condition => {
-								condition = apply(condition)
-								if (condition.isEmpty()) {
-									return condition.raw('true')
-								}
-								return condition
-							}), predicatePath.alias),
 					{ relationPath: this.relationPath, evaluatedPredicates: [primaryPredicate] },
 				)
+				this.qb = qb.select(condition, predicatePath.alias)
 				fetchedPredicates.add(predicate)
 			}
 			return row => row[predicatePath.alias] === true

--- a/packages/engine-content-api/src/mapper/select/WhereBuilder.ts
+++ b/packages/engine-content-api/src/mapper/select/WhereBuilder.ts
@@ -51,6 +51,36 @@ export class WhereBuilder {
 		})
 	}
 
+	/**
+	 * Compiles a where into a single boolean SQL condition (a `Literal`), applying any relation joins it needs
+	 * to `qb`. Shared by the read-predicate consumers that need the condition as an expression rather than a
+	 * WHERE clause: the projection predicate column (selected as a boolean) and the order-by guard (wrapped in
+	 * `CASE WHEN <condition> THEN <column> END`). An empty/trivially-true predicate compiles to `true`.
+	 */
+	public buildConditionLiteral<R extends SelectBuilder.Result>(
+		qb: SelectBuilder<R>,
+		entity: Model.Entity,
+		path: Path,
+		where: Input.OptionalWhere,
+		optimizationHints: WhereOptimizationHints = {},
+	): { qb: SelectBuilder<R>; condition: Literal } {
+		let condition: Literal = new Literal('true')
+		const resultQb = this.buildAdvanced<R>(
+			entity,
+			path,
+			where,
+			applyCondition => {
+				condition = SqlConditionBuilder.process(clause => {
+					const applied = applyCondition(clause)
+					return applied.isEmpty() ? applied.raw('true') : applied
+				}).getSql() ?? new Literal('true')
+				return qb
+			},
+			optimizationHints,
+		)
+		return { qb: resultQb, condition }
+	}
+
 	private buildInternal<R extends SelectBuilder.Result>({
 		callback,
 		...args

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
@@ -235,8 +235,7 @@ export class FieldsVisitor implements Model.RelationByTypeVisitor<void>, Model.C
 	}
 
 	private getRequiredPredicate(entity: Model.Entity, field: Model.AnyField): Acl.Predicate | undefined {
-		const isRoot = this.relationPath.length === 0
-		const fieldPredicate = this.predicateFactory.getFieldPredicate(entity, Acl.Operation.read, field.name, isRoot)
+		const fieldPredicate = this.predicateFactory.getFieldReadPredicate(entity, field.name, this.relationPath)
 		return fieldPredicate.isSameAsPrimary ? undefined : fieldPredicate.predicate
 	}
 }


### PR DESCRIPTION
Stacked on #900 — review/merge #900 first.

Refactor step A of the ACL read-guard consolidation: turn the per-call-site read-predicate guard logic into two shared primitives. **No behavior change** — the generated SQL is byte-identical (verified by the existing SQL-assertion tests; full `engine-content-api` suite green, 455 pass).

## What was duplicated
- `SelectBuilder.addPredicate` (projection predicate column) and `OrderByBuilder` (order-key `CASE`) each inlined the same *"compile a predicate to a boolean SQL condition via `buildAdvanced` + `selectCondition`, falling back to `true` when empty"* dance.
- `FieldsVisitor.getRequiredPredicate` and `OrderByBuilder` both derived the read permission context from `relationPath.length === 0` by hand.

## Extracted primitives
- **`PredicateFactory.getFieldReadPredicate(entity, field, relationPath)`** — the single place mapping a query path to the read context (root-only vs the through-inclusive `all` set). Projection cell-masking and order-by guarding now share it, so they can't disagree on whether a field is cell-level.
- **`WhereBuilder.buildConditionLiteral(qb, entity, path, where, hints)`** — compiles a where into a boolean condition `Literal` (applying its relation joins to `qb`), consumed both as the selected predicate column and inside the order-by `CASE WHEN … THEN col END`.

## Why
This makes the read-guard a reused building block rather than a convention re-typed at each site. The planned **follow-up (step B)** is to move projection cell-masking out of JS hydration into the same SQL expression, so every SQL consumer (ordering, and later aggregations / cursor pagination) is guarded by construction rather than per call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
