### PR TITLE
ci: bump deprecated GitHub Actions to current majors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -75,7 +75,7 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.10
@@ -100,7 +100,7 @@ jobs:
     needs: [ ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check migration ordering against base
@@ -130,7 +130,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
             bun-version: 1.3.10

--- a/.github/workflows/deploy-playground.yaml
+++ b/.github/workflows/deploy-playground.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,10 +11,10 @@ jobs:
   publish-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -46,13 +46,13 @@ jobs:
       matrix:
         image: [cli, engine]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## What

Bumps GitHub Actions that are pinned to deprecated major versions:

| action | before | after | why |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | v4 runs on the deprecated **Node 20** runtime — every CI run currently logs a deprecation warning |
| `actions/setup-node` | v4 | **v5** | same Node 20 deprecation |
| `docker/setup-qemu-action` | v1 | **v3** | v1 dates to the Node 12/16 era |
| `docker/setup-buildx-action` | v1 | **v3** | v1 dates to the Node 12/16 era |

`oven-sh/setup-bun@v2` is already the current major and is left as-is. The composite `extract-version` action already targets `node24`.

## Notes / out of scope

- The `bun-version: 1.3.10` pin in `build.yaml`/`publish.yaml` lags local dev (`1.3.14`). Left out of this PR on purpose — that's a runtime bump, not an action-deprecation fix, and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)