### PR TITLE
docs(react-ui-lib): add JSDoc with examples to components

### DIFF
--- a/build/api/react-binding.api.md
+++ b/build/api/react-binding.api.md
@@ -569,7 +569,6 @@ export interface PersistTriggerAttributes {
 // @public (undocumented)
 export interface PersistTriggerProps {
     children: ReactElement;
-    // (undocumented)
     onPersistError?: (result: ErrorPersistResult) => void;
     onPersistSuccess?: (result: SuccessfulPersistResult) => void;
 }

--- a/build/api/react-repeater.api.md
+++ b/build/api/react-repeater.api.md
@@ -82,7 +82,7 @@ export const RepeaterNotEmpty: (input: {
     children: ReactNode;
 }) => JSX.Element | null;
 
-// @public (undocumented)
+// @public
 export type RepeaterProps = RepeaterQualifiedProps | RepeaterRelativeProps;
 
 // @public (undocumented)

--- a/build/api/react-utils.api.md
+++ b/build/api/react-utils.api.md
@@ -50,7 +50,7 @@ export const emptyObject: Readonly<{}>;
 // @public
 export function getChildrenAsLabel(node: ReactNode): string | undefined;
 
-// @public (undocumented)
+// @public
 export const getStateStorage: (storageOrName: StateStorageOrName | StateStorageOrName[]) => StateStorage;
 
 // @public (undocumented)
@@ -59,7 +59,7 @@ export const identityFunction: <Value>(value: Value) => Value;
 // @public (undocumented)
 export function isNoopScopedConsole(value: unknown): boolean;
 
-// @public (undocumented)
+// @public
 export const localStateStorage: StateStorage;
 
 // @public (undocumented)
@@ -120,7 +120,7 @@ export type Serializable = string | number | boolean | null | readonly Serializa
     readonly [K in string]?: Serializable;
 };
 
-// @public (undocumented)
+// @public
 export const sessionStateStorage: StateStorage;
 
 // @public (undocumented)
@@ -143,7 +143,7 @@ export type StateStorageOrName = StateStorage | 'url' | 'session' | 'local' | 'n
 // @public
 export function unwrapRefValue<T>(value: RefObjectOrElement<T>): T | null;
 
-// @public (undocumented)
+// @public
 export const urlStateStorage: StateStorage;
 
 // @public (undocumented)
@@ -190,7 +190,7 @@ export function useId(): string;
 // @public (undocumented)
 export const useIsMounted: () => RefObject<boolean>;
 
-// @public (undocumented)
+// @public
 export const useLocalStorageState: <V extends Serializable>(key: StateStorageKey, initializeValue: ValueInitializer<V>) => [V, SetState<V>];
 
 // @public (undocumented)
@@ -217,10 +217,10 @@ export const useReferentiallyStableCallback: <T extends Function>(callback: NoCo
 // @public (undocumented)
 export const useScopedConsoleRef: (prefix: string, override?: boolean) => RefObject<ScopedConsoleContextType>;
 
-// @public (undocumented)
+// @public
 export const useSessionStorageState: <V extends Serializable>(key: StateStorageKey, initializeValue: ValueInitializer<V>) => [V, SetState<V>];
 
-// @public (undocumented)
+// @public
 export const useStoredState: <V extends Serializable>(storageOrName: StateStorageOrName | StateStorageOrName[], key: StateStorageKey, initializeValue: ValueInitializer<V>) => [V, SetState<V>];
 
 // @public

--- a/build/api/ui-lib-binding.api.md
+++ b/build/api/ui-lib-binding.api.md
@@ -15,7 +15,9 @@ import { ReactNode } from 'react';
 import { RoutingLinkTarget } from '@contember/interface';
 import { SuccessfulPersistResult } from '@contember/interface';
 
-// @public (undocumented)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "NavigationGuardDialog"
+//
+// @public
 export const Binding: (input: {
     children: ReactNode;
 }) => JSX.Element;
@@ -28,42 +30,41 @@ export interface BindingStateRendererProps {
     children?: ReactNode;
 }
 
-// @public (undocumented)
+// @public
 export const DeleteEntityDialog: FC<DeleteEntityDialogProps>;
 
-// @public (undocumented)
+// @public
 export type DeleteEntityDialogProps = {
     trigger: ReactElement;
     immediatePersist?: boolean;
     onSuccessRedirectTo?: RoutingLinkTarget;
 };
 
-// @public (undocumented)
+// @public
 export const IdentityLoader: (input: {
     children: React.ReactNode;
 }) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export const PersistButton: (input: PersistButtonProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export interface PersistButtonProps extends ComponentProps<typeof Button> {
-    // (undocumented)
     label?: ReactNode;
 }
 
-// @public (undocumented)
+// @public
 export const usePersistErrorHandler: () => (result: ErrorPersistResult) => void;
 
-// @public (undocumented)
+// @public
 export const usePersistFeedbackHandlers: () => {
     onPersistSuccess: (result: SuccessfulPersistResult) => void;
 };
 
-// @public (undocumented)
+// @public
 export const usePersistSuccessHandler: () => (result: SuccessfulPersistResult) => void;
 
-// @public (undocumented)
+// @public
 export const usePersistWithFeedback: () => () => Promise<void | null>;
 
 // (No @packageDocumentation comment for this package)

--- a/build/api/ui-lib-block-repeater.api.md
+++ b/build/api/ui-lib-block-repeater.api.md
@@ -10,7 +10,7 @@ import { NamedExoticComponent } from 'react';
 // @public
 export const DefaultBlockRepeater: NamedExoticComponent<BlockRepeaterProps>;
 
-// @public (undocumented)
+// @public
 export type DefaultBlockRepeaterProps = BlockRepeaterProps;
 
 // (No @packageDocumentation comment for this package)

--- a/build/api/ui-lib-buttons.api.md
+++ b/build/api/ui-lib-buttons.api.md
@@ -8,15 +8,15 @@ import { JSX } from 'react/jsx-runtime';
 import { ReactNode } from 'react';
 import { RoutingLinkTarget } from '@contember/interface';
 
-// @public (undocumented)
+// @public
 export const BackButton: (input: BackButtonProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type BackButtonProps = {
     label?: string;
 };
 
-// @public (undocumented)
+// @public
 export const LinkBackButton: (input: {
     children: ReactNode;
     to: RoutingLinkTarget;

--- a/build/api/ui-lib-datagrid.api.md
+++ b/build/api/ui-lib-datagrid.api.md
@@ -57,6 +57,8 @@ export const DataGridBooleanFilter: React_2.NamedExoticComponent<Omit<DataViewBo
     label: ReactNode;
 }>;
 
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "DataViewBooleanFilterProps"
+//
 // @public
 export type DataGridBooleanFilterProps = Omit<DataViewBooleanFilterProps, 'children'> & {
     label: ReactNode;
@@ -341,10 +343,10 @@ export type DataGridNumberFilterProps = Omit<DataViewNumberFilterProps, 'childre
 // @public
 export const DataGridPagination: FC<DataGridPaginationProps>;
 
-// @public (undocumented)
+// @public
 export const DataGridPerPageSelector: () => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type DataGridPredefinedDateRange = {
     start: string;
     end: string;

--- a/build/api/ui-lib-dev.api.md
+++ b/build/api/ui-lib-dev.api.md
@@ -7,14 +7,14 @@
 import { JSX } from 'react/jsx-runtime';
 import { PropsWithChildren } from 'react';
 
-// @public (undocumented)
+// @public
 export interface CommentProps extends PropsWithChildren {
 }
 
-// @public (undocumented)
+// @public
 export const LoginWithEmail: () => JSX.Element;
 
-// @public (undocumented)
+// @public
 export const Todo: (input: CommentProps) => JSX.Element | null;
 
 // (No @packageDocumentation comment for this package)

--- a/build/api/ui-lib-dimensions.api.md
+++ b/build/api/ui-lib-dimensions.api.md
@@ -18,10 +18,10 @@ export const DimensionLabel: (input: {
     dimensionValue: ReactNode;
 }) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export const DimensionsSwitcher: NamedExoticComponent<DimensionsSwitcherProps>;
 
-// @public (undocumented)
+// @public
 export type DimensionsSwitcherProps = {
     options: SugaredQualifiedEntityList['entities'];
     orderBy?: DataViewSortingDirections;
@@ -37,10 +37,10 @@ export type RenderLabelProps = {
     dimensionValue: string | null;
 };
 
-// @public (undocumented)
+// @public
 export const SideDimensions: NamedExoticComponent<SideDimensionsProps>;
 
-// @public (undocumented)
+// @public
 export type SideDimensionsProps = {
     dimension: string;
     as: string;

--- a/build/api/ui-lib-editor.api.md
+++ b/build/api/ui-lib-editor.api.md
@@ -23,7 +23,7 @@ import { SugaredRelativeEntityList } from '@contember/interface';
 import { SugaredRelativeSingleField } from '@contember/interface';
 import { TextareaHTMLAttributes } from 'react';
 
-// @public (undocumented)
+// @public
 export const baseEditorPlugins: {
     anchor: <E extends Editor>(editor: E) => E;
     paragraph: <E extends Editor>(editor: E) => E;
@@ -41,7 +41,7 @@ export const baseEditorPlugins: {
     underline: EditorPlugin;
 };
 
-// @public (undocumented)
+// @public
 export const BlockEditorField: NamedExoticComponent<BlockEditorFieldProps>;
 
 // @public (undocumented)
@@ -57,7 +57,7 @@ export const BlockEditorInner: (input: {
     children: ReactNode;
 }) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export const blockEditorPlugins: EditorPlugin[];
 
 // @public (undocumented)
@@ -73,21 +73,17 @@ export interface BlockElementProps extends RenderElementProps {
     withBoundaries?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export const EditorBlock: NamedExoticComponent<EditorBlockProps>;
 
-// @public (undocumented)
+// @public
 export const EditorBlockContent: NamedExoticComponent<    {}>;
 
 // @public (undocumented)
 export interface EditorBlockProps {
-    // (undocumented)
     alternate?: ReactNode;
-    // (undocumented)
     children: ReactNode;
-    // (undocumented)
     label: ReactNode;
-    // (undocumented)
     name: string;
 }
 
@@ -140,10 +136,10 @@ export interface EditorInlineToolbarProps {
 export interface HTMLTextAreaDivTargetProps extends TextareaHTMLAttributes<HTMLDivElement> {
 }
 
-// @public (undocumented)
+// @public
 export const RichTextField: React_3.NamedExoticComponent<RichTextFieldProps>;
 
-// @public (undocumented)
+// @public
 export const richTextFieldPlugins: EditorPlugin[];
 
 // Warning: (ae-forgotten-export) The symbol "FormContainerProps" needs to be exported by the entry point index.d.ts
@@ -159,7 +155,7 @@ export type RichTextRendererProps = {
     field: SugaredRelativeSingleField['field'];
 } & Omit<RichTextFieldRendererProps, 'source'>;
 
-// @public (undocumented)
+// @public
 export const RichTextView: NamedExoticComponent<RichTextRendererProps>;
 
 // (No @packageDocumentation comment for this package)

--- a/build/api/ui-lib-errors.api.md
+++ b/build/api/ui-lib-errors.api.md
@@ -7,7 +7,7 @@
 import { ErrorAccessor } from '@contember/interface';
 import { ReactNode } from 'react';
 
-// @public (undocumented)
+// @public
 export const useErrorFormatter: () => (errors: ErrorAccessor.Error[]) => ReactNode[];
 
 // (No @packageDocumentation comment for this package)

--- a/build/api/ui-lib-field.api.md
+++ b/build/api/ui-lib-field.api.md
@@ -22,12 +22,13 @@ export type EnumListFieldProps = {
     fallback?: ReactNode;
 };
 
-// @public (undocumented)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "FieldView"
+//
+// @public
 export const FormattedField: NamedExoticComponent<FormattedFieldProps>;
 
-// @public (undocumented)
+// @public
 export interface FormattedFieldProps {
-    // (undocumented)
     field: SugaredRelativeSingleField['field'];
 }
 

--- a/build/api/ui-lib-form.api.md
+++ b/build/api/ui-lib-form.api.md
@@ -34,13 +34,13 @@ import { TextareaAutosize } from '@contember/react-ui-lib-base';
 import { UploaderBaseFieldProps } from '@contember/react-uploader';
 import { VideoFileTypeProps } from '@contember/react-uploader';
 
-// @public (undocumented)
+// @public
 export const AudioField: React_2.NamedExoticComponent<AudioFieldProps>;
 
 // @public (undocumented)
 export type AudioFieldProps = BaseUploadFieldProps & AudioFileTypeProps;
 
-// @public (undocumented)
+// @public
 export const AudioRepeaterField: React_2.NamedExoticComponent<AudioRepeaterFieldProps>;
 
 // @public (undocumented)
@@ -64,7 +64,7 @@ export type BaseUploadFieldProps = Omit<FormContainerProps, 'children'> & Upload
     getUploadOptions?: (file: File) => S3FileOptions;
 };
 
-// @public (undocumented)
+// @public
 export const CheckboxField: NamedExoticComponent<Omit<FormCheckboxProps, "children"> & Omit<FormContainerProps, "children"> & {
 required?: boolean;
 inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, "defaultValue">;
@@ -76,22 +76,22 @@ export type CheckboxFieldProps = Omit<FormCheckboxProps, 'children'> & Omit<Form
     inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'defaultValue'>;
 };
 
-// @public (undocumented)
+// @public
 export const FileField: React_2.NamedExoticComponent<FileFieldProps>;
 
 // @public (undocumented)
 export type FileFieldProps = BaseUploadFieldProps & AnyFileTypeProps;
 
-// @public (undocumented)
+// @public
 export const FileRepeaterField: React_2.NamedExoticComponent<FileRepeaterFieldProps>;
 
 // @public (undocumented)
 export type FileRepeaterFieldProps = BaseFileRepeaterFieldProps & AnyFileTypeProps;
 
-// @public (undocumented)
+// @public
 export const FormContainer: NamedExoticComponent<FormContainerProps>;
 
-// @public (undocumented)
+// @public
 export type FormContainerProps = {
     label?: ReactNode;
     description?: ReactNode;
@@ -112,31 +112,34 @@ export { FormLabelWrapperUI }
 
 export { FormLayout }
 
-// @public (undocumented)
+// @public
 export const ImageField: React_2.NamedExoticComponent<ImageFieldProps>;
 
 // @public (undocumented)
 export type ImageFieldProps = BaseUploadFieldProps & ImageFileTypeProps;
 
-// @public (undocumented)
+// @public
 export const ImageRepeaterField: React_2.NamedExoticComponent<ImageRepeaterFieldProps>;
 
 // @public (undocumented)
 export type ImageRepeaterFieldProps = BaseFileRepeaterFieldProps & ImageFileTypeProps;
 
-// @public (undocumented)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "FormFieldScope"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "FormInput"
+//
+// @public
 export const InputField: NamedExoticComponent<Omit<FormInputProps, "children"> & Omit<FormContainerProps, "children"> & {
 required?: boolean;
 inputProps?: ComponentProps<typeof Input>;
 }>;
 
-// @public (undocumented)
+// @public
 export type InputFieldProps = Omit<FormInputProps, 'children'> & Omit<FormContainerProps, 'children'> & {
     required?: boolean;
     inputProps?: ComponentProps<typeof Input>;
 };
 
-// @public (undocumented)
+// @public
 export const MultiSelectField: React_2.NamedExoticComponent<MultiSelectFieldProps>;
 
 // Warning: (ae-forgotten-export) The symbol "MultiSelectInputProps" needs to be exported by the entry point index.d.ts
@@ -144,7 +147,7 @@ export const MultiSelectField: React_2.NamedExoticComponent<MultiSelectFieldProp
 // @public (undocumented)
 export type MultiSelectFieldProps = MultiSelectInputProps & Omit<FormContainerProps, 'children' | 'required'>;
 
-// @public (undocumented)
+// @public
 export const RadioEnumField: NamedExoticComponent<RadioEnumFieldProps>;
 
 // @public (undocumented)
@@ -158,7 +161,10 @@ export type RadioEnumFieldProps = Omit<FormRadioItemProps, 'children' | 'value'>
     inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'defaultValue'>;
 };
 
-// @public (undocumented)
+// Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
+// Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+//
+// @public
 export const SelectEnumField: React_2.NamedExoticComponent<SelectEnumFieldProps>;
 
 // @public (undocumented)
@@ -173,7 +179,7 @@ export type SelectEnumFieldProps = Omit<FormContainerProps, 'children'> & {
     required?: boolean;
 };
 
-// @public (undocumented)
+// @public
 export const SelectField: React_2.NamedExoticComponent<SelectFieldProps>;
 
 // Warning: (ae-forgotten-export) The symbol "SelectInputProps" needs to be exported by the entry point index.d.ts
@@ -181,7 +187,7 @@ export const SelectField: React_2.NamedExoticComponent<SelectFieldProps>;
 // @public (undocumented)
 export type SelectFieldProps = SelectInputProps & Omit<FormContainerProps, 'children'>;
 
-// @public (undocumented)
+// @public
 export const SortableMultiSelectField: React_2.NamedExoticComponent<SortableMultiSelectFieldProps>;
 
 // Warning: (ae-forgotten-export) The symbol "SortableMultiSelectInputProps" needs to be exported by the entry point index.d.ts
@@ -192,25 +198,25 @@ export type SortableMultiSelectFieldProps = SortableMultiSelectInputProps & Omit
 // @public @deprecated (undocumented)
 export const StandaloneFormContainer: NamedExoticComponent<FormContainerProps>;
 
-// @public (undocumented)
+// @public
 export const TextareaField: NamedExoticComponent<Omit<FormInputProps, "children"> & Omit<FormContainerProps, "children"> & {
 required?: boolean;
 inputProps?: ComponentProps<typeof TextareaAutosize>;
 }>;
 
-// @public (undocumented)
+// @public
 export type TextareaFieldProps = Omit<FormInputProps, 'children'> & Omit<FormContainerProps, 'children'> & {
     required?: boolean;
     inputProps?: ComponentProps<typeof TextareaAutosize>;
 };
 
-// @public (undocumented)
+// @public
 export const VideoField: React_2.NamedExoticComponent<VideoFieldProps>;
 
 // @public (undocumented)
 export type VideoFieldProps = BaseUploadFieldProps & VideoFileTypeProps;
 
-// @public (undocumented)
+// @public
 export const VideoRepeaterField: React_2.NamedExoticComponent<VideoRepeaterFieldProps>;
 
 // @public (undocumented)

--- a/build/api/ui-lib-formatting.api.md
+++ b/build/api/ui-lib-formatting.api.md
@@ -6,34 +6,34 @@
 
 import { SchemaColumn } from '@contember/interface';
 
-// @public (undocumented)
+// @public
 export const createEnumFormatter: (enumValues: Record<string, string>) => (value: string | null) => string | null;
 
-// @public (undocumented)
+// @public
 export const formatBoolean: (value: boolean | null) => string | null;
 
-// @public (undocumented)
+// @public
 export const formatBytes: (bytes: number, decimals?: number) => string;
 
-// @public (undocumented)
+// @public
 export const formatDate: (date: string | null) => string | null;
 
-// @public (undocumented)
+// @public
 export const formatDateTime: (date: string | null) => string | null;
 
-// @public (undocumented)
+// @public
 export const formatDuration: (duration: number) => string;
 
-// @public (undocumented)
+// @public
 export const formatJson: (value: any) => string;
 
-// @public (undocumented)
+// @public
 export const formatNumber: (value: number | null) => string | null;
 
-// @public (undocumented)
+// @public
 export const getFormatter: (schema: SchemaColumn) => ((date: string | null) => string | null) | ((value: boolean | null) => string | null) | ((value: number | null) => string | null) | ((value: any) => any);
 
-// @public (undocumented)
+// @public
 export const withFallback: <T>(formatter: (value: T) => string, fallback: string) => (value: T | null) => string;
 
 // (No @packageDocumentation comment for this package)

--- a/build/api/ui-lib-images.api.md
+++ b/build/api/ui-lib-images.api.md
@@ -4,22 +4,16 @@
 
 ```ts
 
-// @public (undocumented)
+// @public
 export const formatImageResizeUrl: (src: string, options?: ImageResizeOptions) => string;
 
 // @public (undocumented)
 export interface ImageResizeOptions {
-    // (undocumented)
     blur?: number;
-    // (undocumented)
     fit?: 'scale-down' | 'contain' | 'cover' | 'crop' | 'pad';
-    // (undocumented)
     format?: 'auto' | 'avif' | 'webp' | 'jpeg' | 'baseline-jpeg' | 'json';
-    // (undocumented)
     height?: number;
-    // (undocumented)
     quality?: number;
-    // (undocumented)
     width?: number;
 }
 

--- a/build/api/ui-lib-repeater.api.md
+++ b/build/api/ui-lib-repeater.api.md
@@ -17,20 +17,20 @@ import { RepeaterProps } from '@contember/react-repeater';
 // @public
 export const DefaultRepeater: NamedExoticComponent<DefaultRepeaterProps>;
 
-// @public (undocumented)
+// @public
 export type DefaultRepeaterProps = {
     title?: ReactNode;
     addButtonPosition?: 'none' | 'after' | 'before' | 'around';
     addButtonLabel?: ReactNode;
 } & RepeaterProps;
 
-// @public (undocumented)
+// @public
 export const RepeaterAddItemButton: (input: {
     children?: React.ReactNode;
     index?: RepeaterAddItemIndex;
 }) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export const RepeaterDropIndicator: (input: {
     position: "before" | "after";
 }) => JSX.Element;

--- a/build/api/ui-lib-select.api.md
+++ b/build/api/ui-lib-select.api.md
@@ -16,20 +16,21 @@ import { SugaredRelativeEntityList } from '@contember/interface';
 import { SugaredRelativeSingleEntity } from '@contember/interface';
 import { SugaredRelativeSingleField } from '@contember/interface';
 
-// @public (undocumented)
+// @public
 export const DefaultSelectDataView: React_2.NamedExoticComponent<DefaultSelectDataViewProps>;
 
-// @public (undocumented)
+// @public
 export interface DefaultSelectDataViewProps {
-    // (undocumented)
     children: ReactNode;
-    // (undocumented)
     initialSorting?: DataViewSortingDirections;
-    // (undocumented)
     queryField?: DataViewUnionFilterFields;
 }
 
-// @public (undocumented)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "SelectItemTrigger"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "Popover"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "PopoverTrigger"
+//
+// @public
 export const MultiSelectInput: React_2.NamedExoticComponent<MultiSelectInputProps>;
 
 // @public (undocumented)
@@ -43,61 +44,67 @@ export type MultiSelectInputProps = {
     initialSorting?: DataViewSortingDirections;
 };
 
-// @public (undocumented)
+// @public
 export const MultiSelectItemContentUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLSpanElement> & React_2.HTMLAttributes<HTMLSpanElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLSpanElement>>;
 
-// @public (undocumented)
+// @public
 export const MultiSelectItemDragOverlayUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLSpanElement> & React_2.HTMLAttributes<HTMLSpanElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLSpanElement>>;
 
-// @public (undocumented)
+// @public
 export const MultiSelectItemRemoveButtonUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLSpanElement> & React_2.HTMLAttributes<HTMLSpanElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLSpanElement>>;
 
-// @public (undocumented)
+// @public
 export const MultiSelectItemUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLSpanElement> & React_2.HTMLAttributes<HTMLSpanElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLSpanElement>>;
 
-// @public (undocumented)
+// @public
 export const MultiSelectItemWrapperUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLDivElement> & React_2.HTMLAttributes<HTMLDivElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLDivElement>>;
 
-// @public (undocumented)
+// @public
 export const MultiSelectSortableItemContentUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLSpanElement> & React_2.HTMLAttributes<HTMLSpanElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLSpanElement>>;
 
-// @public (undocumented)
+// @public
 export const SelectCreateNewTrigger: React_2.ForwardRefExoticComponent<React_2.RefAttributes<HTMLButtonElement>>;
 
-// @public (undocumented)
+// @public
 export const SelectDefaultFilter: React_2.MemoExoticComponent<() => JSX.Element>;
 
-// @public (undocumented)
+// @public
 export const SelectDefaultPlaceholderUI: () => JSX.Element;
 
-// @public (undocumented)
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "SelectPlaceholder"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "SelectEachValue"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "SelectItemTrigger"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "Popover"
+// Warning: (ae-unresolved-link) The @link reference could not be resolved: The package "@contember/react-ui-lib" does not have an export "PopoverTrigger"
+//
+// @public
 export const SelectInput: React_2.NamedExoticComponent<SelectInputProps>;
 
-// @public (undocumented)
+// @public
 export const SelectInputActionsUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLSpanElement> & React_2.HTMLAttributes<HTMLSpanElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
@@ -116,14 +123,14 @@ export type SelectInputProps = {
     required?: boolean;
 };
 
-// @public (undocumented)
+// @public
 export const SelectInputUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLButtonElement> & React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLButtonElement>>;
 
-// @public (undocumented)
+// @public
 export const SelectInputWrapperUI: React_2.ForwardRefExoticComponent<Omit<React_2.ClassAttributes<HTMLDivElement> & React_2.HTMLAttributes<HTMLDivElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
@@ -133,7 +140,7 @@ export const SelectInputWrapperUI: React_2.ForwardRefExoticComponent<Omit<React_
 // @public (undocumented)
 export const SelectListInner: React_2.NamedExoticComponent<SelectListProps>;
 
-// @public (undocumented)
+// @public
 export const SelectListItemUI: React_2.ForwardRefExoticComponent<Omit<Omit<React_2.ClassAttributes<HTMLButtonElement> & React_2.ButtonHTMLAttributes<HTMLButtonElement> & {
     asChild?: boolean;
     children?: ReactNode;
@@ -153,14 +160,14 @@ export type SelectListProps = {
     filterToolbar?: ReactNode;
 };
 
-// @public (undocumented)
+// @public
 export const SelectPopoverContent: React_2.ForwardRefExoticComponent<Omit<Omit<PopoverContentProps & React_2.RefAttributes<HTMLDivElement>, "ref"> & React_2.RefAttributes<HTMLDivElement> & {
     asChild?: boolean;
     children?: React_2.ReactNode;
     className?: string;
 }, "ref"> & React_2.RefAttributes<HTMLDivElement>>;
 
-// @public (undocumented)
+// @public
 export const SortableMultiSelectInput: NamedExoticComponent<SortableMultiSelectInputProps>;
 
 // @public (undocumented)

--- a/build/api/ui-lib-upload.api.md
+++ b/build/api/ui-lib-upload.api.md
@@ -51,7 +51,7 @@ export const UploadedVideoView: React_2.NamedExoticComponent<UploadedVideoViewPr
 // @public (undocumented)
 export type UploadedVideoViewProps = FileUrlDataExtractorProps & GenericFileMetadataExtractorProps & VideoFileDataExtractorProps & BaseFileViewProps;
 
-// @public (undocumented)
+// @public
 export const UploaderDropzone: (input: {
     inactiveOnUpload?: boolean;
     dropzonePlaceholder?: ReactNode;

--- a/packages/react-binding/src/helperComponents/persist/PersistTrigger.tsx
+++ b/packages/react-binding/src/helperComponents/persist/PersistTrigger.tsx
@@ -24,6 +24,9 @@ export interface PersistTriggerProps {
 	 * Callback that is called when persist is successful.
 	 */
 	onPersistSuccess?: (result: SuccessfulPersistResult) => void
+	/**
+	 * Callback that is called when an error occurs during persist.
+	 */
 	onPersistError?: (result: ErrorPersistResult) => void
 }
 

--- a/packages/react-repeater/src/components/Repeater.tsx
+++ b/packages/react-repeater/src/components/Repeater.tsx
@@ -34,6 +34,9 @@ export type RepeaterQualifiedProps =
 		sortableBy?: SugaredRelativeSingleField['field']
 	}
 
+/**
+ * Props for {@link Repeater}
+ */
 export type RepeaterProps =
 	| RepeaterQualifiedProps
 	| RepeaterRelativeProps

--- a/packages/react-ui-lib-base/src/ui/alert-dialog.tsx
+++ b/packages/react-ui-lib-base/src/ui/alert-dialog.tsx
@@ -4,21 +4,90 @@ import { uic } from '../utils/index.js'
 import { createComponentOpenHooks } from '../utils/createComponentOpenHooks.js'
 import { buttonConfig } from './button.js'
 
+/**
+ * `AlertDialog` component - an interruptive modal dialog that requires a user interaction
+ * to be dismissed. It is used to confirm user actions or to inform the user
+ * about important information that requires attention.
+ *
+ * ## Example
+ * ```tsx
+ * <AlertDialog>
+ *   <AlertDialogTrigger>Open Dialog</AlertDialogTrigger>
+ *   <AlertDialogContent>
+ *     <AlertDialogHeader>
+ *       <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+ *       <AlertDialogDescription>
+ *         This action cannot be undone.
+ *       </AlertDialogDescription>
+ *     </AlertDialogHeader>
+ *     <AlertDialogFooter>
+ *       <AlertDialogCancel>Cancel</AlertDialogCancel>
+ *       <AlertDialogAction>Continue</AlertDialogAction>
+ *     </AlertDialogFooter>
+ *   </AlertDialogContent>
+ * </AlertDialog>
+ * ```
+ *
+ * ## Sub-components
+ * - {@link AlertDialogPortal}
+ * - {@link AlertDialogContent}
+ * - {@link AlertDialogHeader}
+ * - {@link AlertDialogFooter}
+ * - {@link AlertDialogTitle}
+ * - {@link AlertDialogDescription}
+ * - {@link AlertDialogAction}
+ * - {@link AlertDialogCancel}
+ *
+ * ## Hooks
+ * - {@link useAlertDialogOpenState}
+ */
 export const {
 	Component: AlertDialog,
 	useOpen: useAlertDialogOpenState,
 } = createComponentOpenHooks(AlertDialogPrimitive.Root)
 
+/**
+ * `AlertDialogTrigger` is the trigger button to open the dialog.
+ * Must be used within `AlertDialog`.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogTrigger = AlertDialogPrimitive.Trigger
 
+/**
+ * `AlertDialogPortal` is the portal to render the dialog.
+ * Must be used within `AlertDialog`.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogPortal = AlertDialogPrimitive.Portal
 
+/**
+ * `AlertDialogOverlay` is the overlay to render the dialog.
+ * Must be used within `AlertDialog`.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogOverlay = uic(AlertDialogPrimitive.Overlay, {
 	baseClass:
 		'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
 	displayName: 'AlertDialogOverlay',
 })
 
+/**
+ * `AlertDialogContent` is the content of the alert dialog.
+ * Must be used within `AlertDialog`.
+ *
+ * For documentation see {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogContent = uic(AlertDialogPrimitive.Content, {
 	baseClass:
 		'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
@@ -33,27 +102,69 @@ export const AlertDialogContent = uic(AlertDialogPrimitive.Content, {
 	displayName: 'AlertDialogContent',
 })
 
+/**
+ * `AlertDialogHeader` is the header of the alert dialog. Must be used within `AlertDialog`. Usually contains the title and description of the alert dialog.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogHeader = uic('div', {
 	baseClass: 'flex flex-col space-y-2 text-center sm:text-left',
 	displayName: 'AlertDialogHeader',
 })
 
+/**
+ * `AlertDialogFooter` is the footer of the alert dialog. Must be used within `AlertDialog`. Usually contains the buttons of the alert dialog.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogFooter = uic('div', {
 	baseClass: 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
 	displayName: 'AlertDialogFooter',
 })
 
+/**
+ * `AlertDialogTitle` is the title of the alert dialog. Must be used within `AlertDialogHeader`. Usually contains the title of the alert dialog.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogTitle = uic(AlertDialogPrimitive.Title, {
 	baseClass: 'text-lg font-semibold',
 	displayName: 'AlertDialogTitle',
 })
 
+/**
+ * `AlertDialogDescription` is the description of the alert dialog. Must be used within `AlertDialogHeader`. Usually contains the description of the alert dialog.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogDescription = uic(AlertDialogPrimitive.Description, {
 	baseClass: 'text-sm text-muted-foreground',
 	displayName: 'AlertDialogDescription',
 })
 
+/**
+ * `AlertDialogAction` is the action button of the alert dialog. Must be used within `AlertDialogFooter`. Usually contains the action button of the alert dialog.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogAction = uic(AlertDialogPrimitive.Action, buttonConfig)
+/**
+ * `AlertDialogCancel` is the cancel button of the alert dialog. Must be used within `AlertDialogFooter`. Usually contains the cancel button of the alert dialog.
+ *
+ * See more {@link AlertDialog}
+ *
+ * @group AlertDialog
+ */
 export const AlertDialogCancel = uic(AlertDialogPrimitive.Cancel, {
 	...buttonConfig,
 	defaultVariants: {

--- a/packages/react-ui-lib-base/src/ui/select.tsx
+++ b/packages/react-ui-lib-base/src/ui/select.tsx
@@ -3,6 +3,48 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 import { uic } from '../utils/index.js'
 import { createComponentOpenHooks } from '../utils/createComponentOpenHooks.js'
 
+/**
+ * Select Component
+ *
+ * ### Example: Basic
+ * ```tsx
+ *  <Select>
+ *    <SelectTrigger>Choose</SelectTrigger>
+ *    <SelectContent>
+ *      <SelectItem value="apple">Apple</SelectItem>
+ *      <SelectItem value="banana">Banana</SelectItem>
+ *    </SelectContent>
+ *  </Select>
+ * ```
+ *
+ * ### Example: With Group
+ * ```tsx
+ * <Select>
+ *    <SelectTrigger>Choose country</SelectTrigger>
+ *    <SelectContent>
+ *      <SelectGroup>
+ *        <SelectItem value="apple">Apple</SelectItem>
+ *        <SelectItem value="banana">Banana</SelectItem>
+ *      </SelectGroup>
+ *      <SelectGroup>
+ *        <SelectItem value="cucumber">Cucumber</SelectItem>
+ *        <SelectItem value="paprika">Paprika</SelectItem>
+ *      </SelectGroup>
+ *    </SelectContent>
+ * </Select>
+ * ```
+ *
+ * ### Sub-components
+ * - {@link SelectTrigger}
+ * - {@link SelectContent}
+ * - {@link SelectItem}
+ * - {@link SelectGroup}
+ * - {@link SelectValue}
+ * - {@link SelectLabel}
+ *
+ * ## Hooks
+ * - {@link useSelectOpenState}
+ */
 export const { Component: Select, useOpen: useSelectOpenState } = createComponentOpenHooks(SelectPrimitive.Root)
 
 export const SelectGroup = SelectPrimitive.Group

--- a/packages/react-ui-lib-base/src/utils/cn.ts
+++ b/packages/react-ui-lib-base/src/utils/cn.ts
@@ -1,4 +1,22 @@
 import { ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
+/**
+ * `cn` is a utility function that combines Tailwind CSS class names using `clsx`
+ * and merges conflicting classes with `twMerge`.
+ *
+ * Useful for composing conditional and dynamic className values in React components
+ * with Tailwind, ensuring the final output avoids duplicates or conflicts.
+ *
+ * ## Example: Conditional class merging
+ * ```tsx
+ * const Button = ({ isPrimary }: { isPrimary?: boolean }) => {
+ *   return (
+ *     <button className={cn('px-4 py-2', isPrimary && 'bg-blue-500', 'text-white')}>
+ *       Click me
+ *     </button>
+ *   )
+ * }
+ * ```
+ */
 export const cn = (...inputs: ClassValue[]) => twMerge(clsx(...inputs))

--- a/packages/react-ui-lib-base/src/utils/createComponentOpenHooks.tsx
+++ b/packages/react-ui-lib-base/src/utils/createComponentOpenHooks.tsx
@@ -1,6 +1,39 @@
 import { ComponentType, memo, SetStateAction, useCallback, useState } from 'react'
 import { createRequiredContext } from '@contember/react-utils'
 
+/**
+ * `createComponentOpenHooks` wraps a component that supports open state management
+ * (`open`, `defaultOpen`, `onOpenChange`) and injects context-based control and access hooks.
+ *
+ * It returns:
+ * - A `Component` wrapped with open state context
+ * - A `useOpen` hook to access and control the open state
+ *
+ * This is especially useful for modals, drawers, popovers, and similar toggleable UI components.
+ *
+ * ## Example: Creating a toggleable modal with context access
+ * ```tsx
+ * const BaseModal: React.FC<{ open?: boolean; defaultOpen?: boolean; onOpenChange?: (open: boolean) => void }> = ({ open, onOpenChange }) => (
+ *   <div style={{ display: open ? 'block' : 'none' }}>
+ *     <button onClick={() => onOpenChange?.(false)}>Close</button>
+ *     <p>Modal Content</p>
+ *   </div>
+ * )
+ *
+ * const { Component: ModalWithHooks, useOpen } = createComponentOpenHooks(BaseModal)
+ *
+ * const App = () => {
+ *   const [open, setOpen] = useOpen()
+ *
+ *   return (
+ *     <>
+ *       <button onClick={() => setOpen(true)}>Open Modal</button>
+ *       <ModalWithHooks />
+ *     </>
+ *   )
+ * }
+ * ```
+ */
 export const createComponentOpenHooks = <
 	P extends {
 		open?: boolean

--- a/packages/react-ui-lib-base/src/utils/uic.tsx
+++ b/packages/react-ui-lib-base/src/utils/uic.tsx
@@ -47,6 +47,65 @@ export const uiconfig = <T extends ConfigSchema | undefined>(config: Config<T, C
 
 export type NoInfer<T> = T & { [K in keyof T]: T[K] }
 
+/**
+ * Props are inferred from the base element and the provided config.
+ *
+ * `uic` is a utility function that enhances a base React component with configurable
+ * styling and structural behaviors using a utility-based class variance system (e.g., `cva`).
+ *
+ * It wraps the base component and provides features including:
+ * - Variant-based styling using `cva` configuration
+ * - Optional mapping of variant values to `data-*` attributes
+ * - Conditional rendering via `asChild` to support component composition
+ * - Structural wrapping of children (`wrapInner`) and of the whole component (`wrapOuter`)
+ * - Automatic filtering of unused variant props unless passed in `passVariantProps`
+ *
+ * The `wrapInner` and `wrapOuter` props in the config allow injecting extra layout structure:
+ * - `wrapInner`: Wraps the component's children in a custom element (e.g., for padding or effects)
+ * - `wrapOuter`: Wraps the entire rendered component (e.g., for layout constraints or portals)
+ *
+ * Must be used with a `Config` object that defines styling, variant options, and optional wrappers.
+ *
+ * ## Example: Basic usage with variant styling
+ * ```tsx
+ * const Button = uic('button', {
+ *   baseClass: 'px-4 py-2 font-bold',
+ *   variants: {
+ *     intent: {
+ *       primary: 'bg-blue-500 text-white',
+ *       secondary: 'bg-gray-500 text-white',
+ *     },
+ *   },
+ *   defaultVariants: { intent: 'primary' },
+ *   displayName: 'Button',
+ * })
+ *
+ * <Button intent="secondary">Click me</Button>
+ * ```
+ *
+ * ## Example: Using `wrapInner` and `wrapOuter`
+ * ```tsx
+ * const Card = uic('div', {
+ *   baseClass: 'bg-white shadow-md rounded',
+ *   wrapInner: 'section',
+ *   wrapOuter: ({ children }) => <div className="p-4 border">{children}</div>,
+ *   displayName: 'Card',
+ * })
+ *
+ * <Card>
+ *   <p>Hello world</p>
+ * </Card>
+ *
+ * // Results in:
+ * // <div class="p-4 border">
+ * //   <div class="bg-white shadow-md rounded">
+ * //     <section>
+ * //       <p>Hello world</p>
+ * //     </section>
+ * //   </div>
+ * // </div>
+ * ```
+ */
 export const uic = <El extends React.ElementType, Variants extends ConfigSchema | undefined = undefined>(
 	Component: El,
 	config: Config<Variants, NoInfer<El>>,

--- a/packages/react-ui-lib-base/src/utils/use-mobile.ts
+++ b/packages/react-ui-lib-base/src/utils/use-mobile.ts
@@ -2,6 +2,25 @@ import { useEffect, useState } from 'react'
 
 const MOBILE_BREAKPOINT = 768
 
+/**
+ * `useIsMobile` is a responsive utility hook that returns a boolean indicating
+ * whether the current viewport width is below the mobile breakpoint (768px).
+ *
+ * Useful for conditional rendering or styling based on mobile layout needs.
+ *
+ * ## Example: Conditional rendering for mobile
+ * ```tsx
+ * const MyComponent = () => {
+ *   const isMobile = useIsMobile()
+ *
+ *   return (
+ *     <div>
+ *       {isMobile ? <MobileMenu /> : <DesktopMenu />}
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
 export const useIsMobile = () => {
 	const [isMobile, setIsMobile] = useState(() => typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false)
 

--- a/packages/react-ui-lib-tenant/src/forms/update-project-member.tsx
+++ b/packages/react-ui-lib-tenant/src/forms/update-project-member.tsx
@@ -5,6 +5,15 @@ import { TenantFormError, TenantFormLabel } from './common.js'
 import { MembershipsControl, RolesConfig, useIntrospectionRolesConfig } from './memberships-control.js'
 import { dict } from '../dict.js'
 
+/**
+ * `UpdateProjectMemberFormFields` is a component for managing and updating a project member's roles and memberships.
+ * It integrates with the `useUpdateProjectMemberForm` hook and supports role introspection.
+ *
+ * ## Example
+ * ```tsx
+ * <UpdateProjectMemberFormFields projectSlug="my-project" />
+ * ```
+ */
 export const UpdateProjectMemberFormFields = ({ projectSlug, roles }: { projectSlug: string; roles?: RolesConfig }) => {
 	const form = useUpdateProjectMemberForm()
 	const rolesResolved = roles ?? useIntrospectionRolesConfig(projectSlug)

--- a/packages/react-ui-lib-tenant/src/hooks/useInvite.ts
+++ b/packages/react-ui-lib-tenant/src/hooks/useInvite.ts
@@ -8,6 +8,47 @@ const InviteFetcher = TenantApi.inviteResponse$$
 
 export type InviteErrorCodes = TenantApi.InviteErrorCode
 
+/**
+ * `useInvite` is a React hook for managing user invitations in a Contember project.
+ * It interacts with the tenant API to send an invitation with specific memberships and project details.
+ *
+ * ## Features
+ * - Sends invitations to users via the tenant API.
+ * - Supports specifying project membership details.
+ * - Automatically includes options for password reset during the invitation process.
+ *
+ * ## Returns
+ * A callback function that accepts an object with the following properties:
+ * - `email` (string): The email address of the invitee.
+ * - `projectSlug` (string): The slug of the project the user is being invited to.
+ * - `memberships` (TenantApi.MembershipInput[]): An array defining the memberships to be assigned.
+ *
+ * ## Example: Sending an Invitation
+ * ```tsx
+ * import { useInvite } from './useInvite'
+ *
+ * const InviteUser = () => {
+ *   const invite = useInvite()
+ *
+ *   const handleInvite = async () => {
+ *     try {
+ *       const response = await invite({
+ *         email: 'user@example.com',
+ *         projectSlug: 'my-project',
+ *         memberships: [
+ *           { role: 'editor', variables: {} },
+ *         ],
+ *       });
+ *       console.log('Invitation sent:', response)
+ *     } catch (error) {
+ *       console.error('Failed to send invitation:', error)
+ *     }
+ *   };
+ *
+ *   return <button onClick={handleInvite}>Send Invite</button>
+ * };
+ * ```
+ */
 export const useInvite = () => {
 	const api = useTenantApi()
 

--- a/packages/react-ui-lib-tenant/src/hooks/useInviteUser.tsx
+++ b/packages/react-ui-lib-tenant/src/hooks/useInviteUser.tsx
@@ -8,6 +8,35 @@ import * as TenantApi from '@contember/graphql-client-tenant'
 import { useReferentiallyStableCallback } from '@contember/react-utils'
 import { dict } from '../dict.js'
 
+/**
+ * `useInviteUser` is a React hook for managing user invitations within a Contember project.
+ * It integrates with the tenant API and project-specific configurations to invite users dynamically
+ * based on entity accessor fields.
+ *
+ * ## Example: Inviting a User
+ * ```tsx
+ * import { useInviteUser } from './useInviteUser'
+ *
+ * const InviteUserButton = ({ entityAccessor }: { entityAccessor: EntityAccessor }) => {
+ *   const inviteUser = useInviteUser({
+ *     emailField: 'email',
+ *     personIdField: 'personId',
+ *     memberships: [{ role: 'admin', variables: {} }],
+ *   })
+ *
+ *   const handleInvite = async () => {
+ *     try {
+ *       await inviteUser(() => entityAccessor)
+ *       console.log('Invitation sent successfully')
+ *     } catch (error) {
+ *       console.error('Failed to send invitation:', error)
+ *     }
+ *   }
+ *
+ *   return <button onClick={handleInvite}>Invite User</button>
+ * };
+ * ```
+ */
 export const useInviteUser = ({ emailField, personIdField, memberships }: {
 	personIdField: string
 	emailField: string

--- a/packages/react-ui-lib/src/binding/binding.tsx
+++ b/packages/react-ui-lib/src/binding/binding.tsx
@@ -5,6 +5,21 @@ import { NavigationGuardDialog } from './navigation-guard-dialog.js'
 import { usePersistErrorHandler } from './hooks.js'
 import { ErrorBoundary } from '../errors/error-boundary.js'
 
+/**
+ * `Binding` component - Core data management wrapper for Contember applications
+ *
+ * ## Subcomponents
+ * - {@link NavigationGuardDialog}: Prevents accidental navigation with unsaved changes
+ *
+ * ## Example
+ * ```tsx
+ * <Binding>
+ *   <EntitySubTree entity="Project(id: $id)">
+ *     <ArticleForm />
+ *   </EntitySubTree>
+ * </Binding>
+ * ```
+ */
 export const Binding = ({ children }: {
 	children: ReactNode
 }) => {

--- a/packages/react-ui-lib/src/binding/delete.tsx
+++ b/packages/react-ui-lib/src/binding/delete.tsx
@@ -15,12 +15,46 @@ import {
 } from '@contember/react-ui-lib-base'
 import { Button } from '@contember/react-ui-lib-base'
 
+/**
+ * Props for {@link DeleteEntityDialog} component.
+ */
 export type DeleteEntityDialogProps = {
+	/** Element that opens the dialog */
 	trigger: ReactElement
+	/** Controls if deletion happens immediately (default: true) */
 	immediatePersist?: boolean
+	/** Routing target after successful deletion */
 	onSuccessRedirectTo?: RoutingLinkTarget
 }
 
+/**
+ * `DeleteEntityDialog` component - Confirmation dialog for entity deletion
+ *
+ * Provides a user-friendly confirmation flow before deleting entities while handling persistence and redirects
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <DeleteEntityDialog
+ *   trigger={<Button>Delete User</Button>}
+ * />
+ * ```
+ *
+ * ## Example: With delayed persistence
+ * ```tsx
+ * <DeleteEntityDialog
+ *   immediatePersist={false}
+ *   trigger={<Button>Mark for Deletion</Button>}
+ * />
+ * ```
+ *
+ * ## Example: With redirect
+ * ```tsx
+ * <DeleteEntityDialog
+ *   onSuccessRedirectTo="users"
+ *   trigger={<Button variant="destructive">Delete</Button>}
+ * />
+ * ```
+ */
 export const DeleteEntityDialog: FC<DeleteEntityDialogProps> = ({ trigger, immediatePersist, onSuccessRedirectTo }) => {
 	const redirect = useRedirect()
 	const handlePersistSuccess = onSuccessRedirectTo ? () => redirect(onSuccessRedirectTo) : undefined

--- a/packages/react-ui-lib/src/binding/hooks.tsx
+++ b/packages/react-ui-lib/src/binding/hooks.tsx
@@ -4,6 +4,25 @@ import { ToastContent, useShowToast } from '@contember/react-ui-lib-base'
 import { ErrorPersistResult, SuccessfulPersistResult, usePersist } from '@contember/interface'
 import { useErrorFormatter } from '../errors/index.js'
 
+/**
+ * A hook `usePersistWithFeedback` that combines persistence with automatic feedback notifications. Triggers data persistence and shows success/error toasts.
+ *
+ * ## Returns
+ * A callback function that triggers persistence with feedback
+ *
+ * ## Example
+ * ```tsx
+ * const SaveButton = () => {
+ *   const persistWithFeedback = usePersistWithFeedback()
+ *
+ *   return (
+ *     <button onClick={() => persistWithFeedback()}>
+ *       Save changes
+ *     </button>
+ *   )
+ * }
+ * ```
+ */
 export const usePersistWithFeedback = () => {
 	const triggerPersist = usePersist()
 	const { onPersistSuccess } = usePersistFeedbackHandlers()
@@ -14,12 +33,42 @@ export const usePersistWithFeedback = () => {
 	}, [onPersistSuccess, triggerPersist])
 }
 
+/**
+ * A hook `usePersistFeedbackHandlers` that provides handlers for persistence feedback. Currently returns success handler. Used in {@link usePersistWithFeedback}.
+ *
+ * ## Returns
+ * Object containing persistence feedback handlers
+ *
+ * ## Example
+ * ```tsx
+ * const { onPersistSuccess } = usePersistFeedbackHandlers()
+ *
+ * persistData().then(onPersistSuccess)
+ * ```
+ */
 export const usePersistFeedbackHandlers = () => {
 	return {
 		onPersistSuccess: usePersistSuccessHandler(),
 	}
 }
 
+/**
+ * A hook `usePersistErrorHandler` that handles persistence errors by showing appropriate toast notifications.
+ *
+ * ## Returns
+ * Callback function to handle persistence errors
+ *
+ * ## Example
+ * ```tsx
+ * const handleError = usePersistErrorHandler()
+ *
+ * try {
+ *   await persist()
+ * } catch (error) {
+ *   handleError(error)
+ * }
+ * ```
+ */
 export const usePersistErrorHandler = () => {
 	const showToast = useShowToast()
 	const errorFormatter = useErrorFormatter()
@@ -50,6 +99,19 @@ export const usePersistErrorHandler = () => {
 	}, [errorFormatter, showToast])
 }
 
+/**
+ * A hook `usePersistSuccessHandler` that handles successful persistence by showing appropriate toast notifications.
+ *
+ * ## Returns
+ * Callback function to handle successful persistence
+ *
+ * ## Example
+ * ```tsx
+ * const handleSuccess = usePersistSuccessHandler()
+ *
+ * persistData().then(result => handleSuccess(result))
+ * ```
+ */
 export const usePersistSuccessHandler = () => {
 	const showToast = useShowToast()
 

--- a/packages/react-ui-lib/src/binding/identity.tsx
+++ b/packages/react-ui-lib/src/binding/identity.tsx
@@ -6,6 +6,19 @@ import { Card, CardContent } from '@contember/react-ui-lib-base'
 import { CircleAlert } from 'lucide-react'
 import { useEffect } from 'react'
 
+/**
+ * `IdentityLoader` component manages the loading state of user identity and renders appropriate UI based on state.
+ *
+ * This component handles different identity states, such as loading, failure, and successful authentication,
+ * ensuring a smooth user experience.
+ *
+ * ## Example: Wrapping an authenticated component
+ * ```tsx
+ * <IdentityLoader>
+ *   <Dashboard />
+ * </IdentityLoader>
+ * ```
+ */
 export const IdentityLoader = ({ children }: {
 	children: React.ReactNode
 }) => {

--- a/packages/react-ui-lib/src/binding/navigation-guard-dialog.tsx
+++ b/packages/react-ui-lib/src/binding/navigation-guard-dialog.tsx
@@ -5,6 +5,18 @@ import { usePersistFeedbackHandlers } from './hooks.js'
 import { Button } from '@contember/react-ui-lib-base'
 import { SaveIcon } from 'lucide-react'
 
+/**
+ * `NavigationGuardDialog` component prompts users with a confirmation dialog when attempting to navigate away
+ * from a page with unsaved changes.
+ *
+ * This component integrates with {@link useBlockNavigationOnDirtyState} to prevent accidental data loss.
+ * The user can choose to save, discard, or cancel the navigation attempt.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <NavigationGuardDialog />
+ * ```
+ */
 export const NavigationGuardDialog = () => {
 	const [resolver, setResolver] = useState<((value: BlockNavigationOnDirtyStateResult) => void) | null>(null)
 

--- a/packages/react-ui-lib/src/binding/persist.tsx
+++ b/packages/react-ui-lib/src/binding/persist.tsx
@@ -6,10 +6,32 @@ import { Loader } from '@contember/react-ui-lib-base'
 import { usePersistSuccessHandler } from './hooks.js'
 import { cn } from '@contember/react-ui-lib-base'
 
+/**
+ * Props for the {@link PersistButton} component.
+ */
 export interface PersistButtonProps extends ComponentProps<typeof Button> {
+	/**
+	 * Custom button text (default: dictionary.persist.persistButton)
+	 */
 	label?: ReactNode
 }
 
+/**
+ * `PersistButton` is a button component that triggers a persistence action (saves unsaved data).
+ *
+ * ## Used hooks
+ * - {@link usePersistSuccessHandler}: Handles success feedback after persistence
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <PersistButton />
+ * ```
+ *
+ * ## Example: Custom label
+ * ```tsx
+ * <PersistButton label="Save Article" />
+ * ```
+ */
 export const PersistButton = ({ label, className, ...buttonProps }: PersistButtonProps) => {
 	return (
 		<PersistTrigger onPersistSuccess={usePersistSuccessHandler()}>

--- a/packages/react-ui-lib/src/block-repeater/block-repeater.tsx
+++ b/packages/react-ui-lib/src/block-repeater/block-repeater.tsx
@@ -49,13 +49,17 @@ const BlockRepeaterContentWrapperUI = uic('div', {
 	baseClass: 'flex flex-col gap-2',
 })
 
+/**
+ * Props for {@link DefaultBlockRepeater} component.
+ */
 export type DefaultBlockRepeaterProps = BlockRepeaterProps
 
 const [BlockRepeaterEditModeContext, useBlockRepeaterEditMode] = createRequiredContext<boolean>('BlockRepeaterEditMode')
 
 /**
- *  The `DefaultBlockRepeater` component is a versatile and customizable block repeater shipped with a UI.
- *  It allows for the creation and management of repeatable content blocks within a form.
+ * `DefaultBlockRepeater` component is a versatile and customizable block repeater shipped with a UI.
+ * It allows for the creation and management of repeatable content blocks within a form.
+ *
  * Supports two modes of operation:
  *   - **Inline Edit Mode**: By providing only `children`, the blocks can be edited inline.
  *   - **Dual-Mode**: By providing both `form` and `children`, the component supports a dual-mode where blocks can be edited in a separate form view.

--- a/packages/react-ui-lib/src/buttons/back-button.tsx
+++ b/packages/react-ui-lib/src/buttons/back-button.tsx
@@ -2,10 +2,30 @@ import { Button } from '@contember/react-ui-lib-base'
 import { ArrowLeftIcon } from 'lucide-react'
 import { dict } from '@contember/react-ui-lib-base'
 
+/**
+ * Props for the {@link BackButton} component.
+ */
 export type BackButtonProps = {
+	/**
+	 * Optional custom button text (default: dictionary backButton.back value)
+	 */
 	label?: string
 }
 
+/**
+ * `BackButton` is a navigation button that returns the user to the previous page using the browser's history API.
+ * It provides a default label but allows customization via the `label` prop.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <BackButton />
+ * ```
+ *
+ * ## Example: Custom label
+ * ```tsx
+ * <BackButton label="Return to list" />
+ * ```
+ */
 export const BackButton = ({ label }: BackButtonProps) => {
 	return (
 		<Button

--- a/packages/react-ui-lib/src/buttons/link-back-button.tsx
+++ b/packages/react-ui-lib/src/buttons/link-back-button.tsx
@@ -4,6 +4,15 @@ import { ArrowLeftIcon } from 'lucide-react'
 import { Link, type RoutingLinkTarget } from '@contember/interface'
 import { Slots } from '../layout/index.js'
 
+/**
+ * `LinkBackButton` is a navigational button that provides a back navigation link.
+ * It wraps the link inside a `Slots.Back` container and renders an `AnchorButton` with an arrow icon.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <LinkBackButton to="articles">Back to Articles</LinkBackButton>
+ * ```
+ */
 export const LinkBackButton = ({ children, to }: {
 	children: ReactNode
 	to: RoutingLinkTarget

--- a/packages/react-ui-lib/src/datagrid/columns.tsx
+++ b/packages/react-ui-lib/src/datagrid/columns.tsx
@@ -33,14 +33,15 @@ import { DataViewFieldLabel, DataViewHasManyLabel, DataViewHasOneLabel } from '.
 import { DataGridColumnLeaf } from './column-leaf.js'
 
 /**
- * Renders a column with action buttons. Should be used in a {@link DataGridTable}.
+ * `DataGridActionColumn` renders a column with action buttons in a `DataGridTable`.
+ * It is typically used to provide interactive controls such as edit, delete, or custom actions.
  *
- * ## Example
+ * ## Example: Basic usage with a button
  * ```tsx
  * <DataGridTable>
- *     <DataGridActionColumn>
- *         <Button>Click me</Button>
- *     </DataGridActionColumn>
+ *   <DataGridActionColumn>
+ *     <Button variant="outline">Click me</Button>
+ *   </DataGridActionColumn>
  * </DataGridTable>
  * ```
  */
@@ -84,10 +85,18 @@ export type DataGridTextColumnProps = {
 /**
  * Renders a column with text content and column controls in a header. Should be used in a {@link DataGridTable}.
  *
- * ## Example
+ * ## Example: Basic Usage
  * ```tsx
  * <DataGridTable>
  *     <DataGridTextColumn field="title" />
+ *     <DataGridTextColumn
+ *         field="subtitle"
+ *         format={it => (
+ *             <span className="text-blue-500 flex items-center gap-2">
+ *                 {it}
+ *             </span>
+ *         )}
+ *     />
  *     <DataGridTextColumn field="description" format={it => it.slice(0, 100)} />
  * </DataGridTable>
  * ```
@@ -140,6 +149,8 @@ export type DataGridBooleanColumnProps = {
  * ```tsx
  * <DataGridTable>
  *     <DataGridBooleanColumn field="isPublished" />
+ *     <DataGridBooleanColumn field="isActive" format={it => it ? 'Hooray' : 'Oh noooo!'} />
+ *     <DataGridBooleanColumn field="hasImage" format={it => it ? <CheckIcon /> : <XIcon />} />
  * </DataGridTable>
  * ```
  */
@@ -193,6 +204,9 @@ export type DataGridNumberColumnProps = {
  * ```tsx
  * <DataGridTable>
  *     <DataGridNumberColumn field="price" format={it => it.toFixed(2)} />
+ *     <DataGridNumberColumn field="price" header="Price with currency">
+ *         <Field field="price" /> <Field field="currency" />
+ *     </DataGridNumberColumn>
  * </DataGridTable>
  * ```
  */

--- a/packages/react-ui-lib/src/datagrid/filters/boolean.tsx
+++ b/packages/react-ui-lib/src/datagrid/filters/boolean.tsx
@@ -13,22 +13,22 @@ import { DataViewFieldLabel } from '../labels.js'
 
 /**
  * Props for {@link DataGridBooleanFilter}.
+ *
+ * Extends {@link DataViewBooleanFilterProps}, excluding the `children` prop.
  */
 export type DataGridBooleanFilterProps =
 	& Omit<DataViewBooleanFilterProps, 'children'>
 	& {
+		/** Label for the filter UI */
 		label: ReactNode
 	}
 
 /**
- * Boolean filter for DataGrid with default UI.
- *
- * ## Props {@link DataGridBooleanFilterProps}
- * field, label, ?name
+ * `DataGridBooleanFilter` provides a boolean filter for `DataGrid` with a default UI.
  *
  * ## Example
  * ```tsx
- * <DataGridBooleanFilter field={'locked'} label="Locked" />
+ * <DataGridBooleanFilter field="locked" label="Locked" />
  * ```
  */
 export const DataGridBooleanFilter = Component(({ label, ...props }: DataGridBooleanFilterProps) => (

--- a/packages/react-ui-lib/src/datagrid/filters/date.tsx
+++ b/packages/react-ui-lib/src/datagrid/filters/date.tsx
@@ -23,6 +23,10 @@ import { Label } from '@contember/react-ui-lib-base'
 import { XIcon } from 'lucide-react'
 import { DataViewFieldLabel } from '../labels.js'
 
+/**
+ * A predefined date range for use with {@link DataGridDateFilter}.
+ * Each range has a `start` and `end` date in ISO (`YYYY-MM-DD`) format.
+ */
 export type DataGridPredefinedDateRange = { start: string; end: string; label: ReactNode }
 
 /**
@@ -36,14 +40,17 @@ export type DataGridDateFilterProps =
 	}
 
 /**
- * Date filter for DataGrid with default UI.
+ * `DataGridDateFilter` is a date filter component designed for use within a `DataGrid`.
+ * It provides a default UI for selecting date ranges and filtering data accordingly.
  *
- * ## Props {@link DataGridDateFilterProps}
- * field, label, ?ranges, ?name
- *
- * ## Example
+ * ## Example: Basic usage
  * ```tsx
- * <DataGridDateFilter field={'createdAt'} label="Created at" />
+ * <DataGridDateFilter field="createdAt" label="Created at" />
+ * ```
+ *
+ * ## Example: With predefined date ranges
+ * ```tsx
+ * <DataGridDateFilter field="updatedAt" ranges={[createDataGridDateRange('Last 7 days', -7, 0)]} />
  * ```
  */
 export const DataGridDateFilter = Component(({ label, ranges, ...props }: DataGridDateFilterProps) => (
@@ -94,7 +101,21 @@ const DataGridDateFilterList = () => (
 )
 
 /**
- * Utility function to create a predefined date range
+ * Creates a predefined date range object for use in a `DataGrid` filter.
+ *
+ * - Computes start and end dates based on the given day offsets.
+ * - Returns the range in `YYYY-MM-DD` format.
+ *
+ * @param label - The displayed label for the predefined range.
+ * @param dayDeltaStart - The number of days from today for the start date (negative for past dates).
+ * @param dayDeltaEnd - The number of days from today for the end date.
+ * @returns A `DataGridPredefinedDateRange` object with formatted start and end dates.
+ *
+ * ## Example: Last 7 days
+ * ```tsx
+ * const lastWeek = createDataGridDateRange('Last 7 days', -7, 0)
+ * // { label: 'Last 7 days', start: '2025-01-01', end: '2025-01-07' }
+ * ```
  */
 export const createDataGridDateRange = (label: ReactNode, dayDeltaStart: number, dayDeltaEnd: number): DataGridPredefinedDateRange => {
 	const start = new Date(new Date().setDate(new Date().getDate() + dayDeltaStart))

--- a/packages/react-ui-lib/src/datagrid/filters/defined.tsx
+++ b/packages/react-ui-lib/src/datagrid/filters/defined.tsx
@@ -16,18 +16,19 @@ import { DataViewFieldLabel } from '../labels.js'
 export type DataGridIsDefinedFilterProps =
 	& Omit<DataViewBooleanFilterProps, 'children'>
 	& {
+		/**
+		 * Label for the filter.
+		 */
 		label: ReactNode
 	}
 
 /**
- * Is defined filter for DataGrid with default UI.
+ * `DataGridIsDefinedFilter` is a filter component for `DataGrid` that checks whether a field is defined or not.
+ * It provides a default UI for filtering records based on the presence of a value.
  *
- * ## Props {@link DataGridIsDefinedFilterProps}
- * field, label, ?name
- *
- * ## Example
+ * ## Example: Basic usage
  * ```tsx
- * <DataGridIsDefinedFilter field={'deletedAt'} label="Is Deleted?" />
+ * <DataGridIsDefinedFilter field="deletedAt" label="Is Deleted?" />
  * ```
  */
 export const DataGridIsDefinedFilter = Component(({ label, ...props }: DataGridIsDefinedFilterProps) => (

--- a/packages/react-ui-lib/src/datagrid/filters/enum.tsx
+++ b/packages/react-ui-lib/src/datagrid/filters/enum.tsx
@@ -34,19 +34,31 @@ import { DataViewFieldLabel } from '../labels.js'
 export type DataGridEnumFilterProps =
 	& Omit<DataViewEnumFilterProps, 'children'>
 	& {
+		/**
+		 * Options for the filter.
+		 */
 		options?: Record<string, ReactNode>
+		/**
+		 * Label for the filter.
+		 */
 		label?: ReactNode
 	}
 
 /**
- * Enum filter for DataGrid with default UI.
+ * `DataGridEnumFilter` is an enum-based filter component for `DataGrid` with a default UI.
+ * It allows filtering records based on predefined enum values.
  *
- * ## Props {@link DataGridEnumFilterProps}
- * field, label, ?name, ?options
- *
- * ## Example
+ * ## Example: Basic usage
  * ```tsx
- * <DataGridEnumFilter field={'status'} />
+ * <DataGridEnumFilter field="status" />
+ * ```
+ *
+ * ## Example: With custom enum options
+ * ```tsx
+ * <DataGridEnumFilter
+ *   field="status"
+ *   options={{ active: 'Active', inactive: 'Inactive' }}
+ * />
  * ```
  */
 export const DataGridEnumFilter = Component(({ options, label, ...props }: DataGridEnumFilterProps) => (
@@ -66,19 +78,36 @@ export const DataGridEnumFilter = Component(({ options, label, ...props }: DataG
 export type DataGridEnumListFilterProps =
 	& Omit<DataViewEnumFilterProps, 'children'>
 	& {
+		/**
+		 * Options for the filter.
+		 */
 		options?: Record<string, ReactNode>
+		/**
+		 * Label for the filter.
+		 */
 		label?: ReactNode
 	}
 
 /**
- * Enum list filter for DataGrid with default UI.
+ * `DataGridEnumListFilter` is a multi-select enum filter component for `DataGrid` with a default UI.
+ * It allows filtering records by selecting multiple predefined enum values.
  *
- * ## Props {@link DataGridEnumListFilterProps}
- * field, label, ?name, ?options
+ * - Wraps `DataViewEnumListFilter` to handle multi-selection filtering.
+ * - Uses `DataGridSingleFilterUI` for a structured filter layout.
+ * - Supports custom labels or defaults to the field's label.
+ * - Accepts an `options` prop to define available enum values.
  *
- * ## Example
+ * ## Example: Basic usage
  * ```tsx
- * <DataGridEnumFilter field={'status'} />
+ * <DataGridEnumListFilter field="status" />
+ * ```
+ *
+ * ## Example: With custom enum options
+ * ```tsx
+ * <DataGridEnumListFilter
+ *   field="status"
+ *   options={{ active: 'Active', inactive: 'Inactive', pending: 'Pending' }}
+ * />
  * ```
  */
 export const DataGridEnumListFilter = Component(({ options, label, ...props }: DataGridEnumListFilterProps) => (
@@ -97,11 +126,16 @@ export const DataGridEnumListFilter = Component(({ options, label, ...props }: D
  */
 export type DataGridEnumFieldTooltipProps = Omit<DataViewEnumFilterProps, 'children'>
 /**
- * Component for rendering a value with a tooltip that allows to include/exclude the value from the filter.
- * Used in {@link DataGridEnumColumn} but can be used in custom columns as well.
+ * `DataGridEnumFieldTooltip` renders a value with a tooltip that allows users to include or exclude
+ * the value from the filter. It is primarily used in {@link DataGridEnumColumn}, but can be
+ * utilized in custom columns as well.
  *
- * ## Props {@link DataGridEnumFieldTooltipProps}
- * field, label, ?name, ?options
+ * ## Example: Basic usage inside a custom column
+ * ```tsx
+ * <DataGridEnumFieldTooltip field="status" value="active">
+ *   <span>Active</span>
+ * </DataGridEnumFieldTooltip>
+ * ```
  */
 export const DataGridEnumFieldTooltip = (
 	{ children, actions, value, ...props }: DataGridEnumFieldTooltipProps & { children: ReactNode; value: string; actions?: ReactNode },

--- a/packages/react-ui-lib/src/datagrid/filters/mobile.tsx
+++ b/packages/react-ui-lib/src/datagrid/filters/mobile.tsx
@@ -4,6 +4,24 @@ import { createContext, ReactNode, useContext } from 'react'
 
 export const DataGridShowFiltersContext = createContext(true)
 
+/**
+ * `DataGridFilterMobileHiding` conditionally hides or displays filters based on their state.
+ * It ensures that filters are visible when active or when {@link DataGridShowFiltersContext} is set to `true`.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <DataGridFilterMobileHiding>
+ *   <DataGridTextFilter field="name" label="Name" />
+ * </DataGridFilterMobileHiding>
+ * ```
+ *
+ * ## Example: With a specific filter name
+ * ```tsx
+ * <DataGridFilterMobileHiding name="status">
+ *   <DataGridEnumFilter field="status" label="Status" />
+ * </DataGridFilterMobileHiding>
+ * ```
+ */
 export const DataGridFilterMobileHiding = ({ name, children }: { name?: string; children: ReactNode }) => {
 	name ??= useDataViewFilterName()
 	const [, , { isEmpty }] = useDataViewFilter(name)

--- a/packages/react-ui-lib/src/datagrid/filters/number.tsx
+++ b/packages/react-ui-lib/src/datagrid/filters/number.tsx
@@ -29,14 +29,11 @@ export type DataGridNumberFilterProps =
 		label: ReactNode
 	}
 /**
- * Number filter for DataGrid with default UI.
- *
- * ## Props {@link DataGridNumberFilterProps}
- * field, label, ?name
+ * `DataGridNumberFilter` provides a number filter UI for `DataGrid`, allowing users to filter numerical values efficiently.
  *
  * ## Example
  * ```tsx
- * <DataGridNumberFilter field={'views'} label="Views" />
+ * <DataGridNumberFilter field="views" label="Views" />
  * ```
  */
 export const DataGridNumberFilter = Component(({ label, ...props }: DataGridNumberFilterProps) => (

--- a/packages/react-ui-lib/src/datagrid/grid.tsx
+++ b/packages/react-ui-lib/src/datagrid/grid.tsx
@@ -24,43 +24,48 @@ const dataGridDefaultStorages: Partial<DataGridProps> = {
 }
 
 /**
- * Base DataGrid component. The UI is up to you.
+ * `DataGrid` is a flexible data display component that provides sorting, filtering, selection,
+ * and pagination capabilities. The UI is customizable, allowing you to define how data is presented.
  *
  * ## Props {@link DataGridProps}
- * Primary: children, entities
- * Optional: queryField, filterTypes, dataViewKey, onSelectHighlighted
- * Initial values:  initialFilters, initialSorting, initialSelection, initialItemsPerPage
- * Storage settings: filteringStateStorage, sortingStateStorage, currentPageStateStorage, selectionStateStorage, pagingSettingsStorage
+ * - **Primary:** `children`, `entities`
+ * - **Optional:** `queryField`, `filterTypes`, `dataViewKey`, `onSelectHighlighted`
+ * - **Initial values:** `initialFilters`, `initialSorting`, `initialSelection`, `initialItemsPerPage`
+ * - **Storage settings:** `filteringStateStorage`, `sortingStateStorage`, `currentPageStateStorage`, `selectionStateStorage`, `pagingSettingsStorage`
  *
- * ## Example
+ * ## Example: Basic Usage
  * ```tsx
  * <DataGrid
- *     entities="GridArticle"
+ *     entities="Project"
  *     initialSorting={{
- *         publishedAt: 'asc',
+ *         createdAt: 'asc',
  *     }}
  * >
  *     <DataGridToolbar>
  *         <DataGridQueryFilter />
- *         <DataGridEnumFilter field={'state'} />
- *          <DataGridHasOneFilter field={'author'} label="Author">
+ *         <DataGridEnumFilter field="state" />
+ *         <DataGridHasOneFilter field="author" label="Author">
  *             <Field field="name" />
  *         </DataGridHasOneFilter>
  *     </DataGridToolbar>
  *     <DataGridLoader>
  *         <DataGridTable>
- *             <DataGridActionColumn><Button>Show detail</Button></DataGridActionColumn>
+ *             <DataGridActionColumn>
+ *                 <Button>Show detail</Button>
+ *             </DataGridActionColumn>
  *             <DataGridTextColumn header="Title" field="title" />
  *             <DataGridEnumColumn field="state" />
- *             <DataGridDateColumn header="Published at" field="publishedAt" />
- *             <DataGridHasOneColumn header="Author" field="author">
+ *             <DataGridDateColumn header="Created at" field="createdAt" />
+ *             <DataGridHasOneColumn header="Company" field="company">
  *                 <Field field="name" />
  *             </DataGridHasOneColumn>
  *         </DataGridTable>
+ *
  *         <DataGridTiles>
  *             <MyCustomTile />
  *         </DataGridTiles>
- *         <DataViewLayout name="rows" label='Rows'>
+ *
+ *         <DataViewLayout name="rows" label="Rows">
  *             <DataViewEachRow>
  *                 <MyCustomRow />
  *             </DataViewEachRow>
@@ -94,14 +99,17 @@ export type DefaultDataGridProps =
 	}
 
 /**
- * Default DataGrid with toolbar, loader, table and pagination.
+ * `DefaultDataGrid` is a pre-configured `DataGrid` component that includes a toolbar, loader, table, and pagination.
+ * It provides a structured layout for displaying data with minimal configuration.
  *
- * ## Example
+ * ## Example: Basic Usage
  * ```tsx
- * <DefaultDataGrid entities="GridArticle">
- *     <DataGridActionColumn><Button>Show detail</Button></DataGridActionColumn>
+ * <DefaultDataGrid entities="Project">
+ *     <DataGridActionColumn>
+ *         <Button>Show detail</Button>
+ *     </DataGridActionColumn>
  *     <DataGridTextColumn header="Title" field="title" />
- *     <DataGridEnumColumn header="State" field="state" options={GridArticleStateLabels} />
+ *     <DataGridEnumColumn header="State" field="state" />
  * </DefaultDataGrid>
  * ```
  */

--- a/packages/react-ui-lib/src/datagrid/labels.tsx
+++ b/packages/react-ui-lib/src/datagrid/labels.tsx
@@ -3,7 +3,13 @@ import { useDataViewTargetFieldSchema, useDataViewTargetHasManySchema, useDataVi
 import { useFieldLabelFormatter } from '../labels/index.js'
 
 /**
- * Utility component that renders a label for a field.
+ * `DataViewFieldLabel` renders a label for a specific field within an entity.
+ * It utilizes schema information to determine the appropriate label.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <DataViewFieldLabel field="title" />
+ * ```
  */
 export const DataViewFieldLabel = ({ field }: { field: SugaredRelativeSingleField['field'] }) => {
 	const { field: targetField, entity } = useDataViewTargetFieldSchema(field)
@@ -12,7 +18,13 @@ export const DataViewFieldLabel = ({ field }: { field: SugaredRelativeSingleFiel
 }
 
 /**
- * Utility component that renders a label for a has-one relation.
+ * `DataViewHasOneLabel` renders a label for a has-one relation field within an entity.
+ * It extracts the label dynamically from the entity schema.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <DataViewHasOneLabel field="author" />
+ * ```
  */
 export const DataViewHasOneLabel = ({ field }: { field: SugaredRelativeSingleEntity['field'] }) => {
 	const { field: targetField, entity } = useDataViewTargetHasOneSchema(field)
@@ -21,7 +33,13 @@ export const DataViewHasOneLabel = ({ field }: { field: SugaredRelativeSingleEnt
 }
 
 /**
- * Utility component that renders a label for a has-many relation.
+ * `DataViewHasManyLabel` renders a label for a has-many relation field within an entity.
+ * It retrieves the correct label dynamically based on the entity schema.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <DataViewHasManyLabel field="comments" />
+ * ```
  */
 export const DataViewHasManyLabel = ({ field }: { field: SugaredRelativeEntityList['field'] }) => {
 	const { field: targetField, entity } = useDataViewTargetHasManySchema(field)

--- a/packages/react-ui-lib/src/datagrid/layout-switcher.tsx
+++ b/packages/react-ui-lib/src/datagrid/layout-switcher.tsx
@@ -13,7 +13,13 @@ const LayoutSwitchButton = uic(Button, {
 })
 
 /**
- * Layout switcher UI for data grid. Displays buttons for each layout.
+ * `DataGridLayoutSwitcher` is a UI component for switching between different data grid layouts.
+ * It renders a set of buttons, allowing users to select and apply a layout dynamically.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <DataGridLayoutSwitcher />
+ * ```
  */
 export const DataGridLayoutSwitcher = () => {
 	const layouts = useDataViewSelectionState().layouts

--- a/packages/react-ui-lib/src/datagrid/loader.tsx
+++ b/packages/react-ui-lib/src/datagrid/loader.tsx
@@ -11,10 +11,10 @@ export interface DataGridLoaderProps {
 }
 
 /**
- * A component that provides a loading state for a data grid.
- * It displays different loaders based on the current loading state.
+ * `DataGridLoader` manages the loading state for a data grid, displaying appropriate loaders
+ * based on the current state (refreshing, initial load, or failure).
  *
- * ## Example
+ * ## Example: Basic Usage
  * ```tsx
  * <DataGridLoader>
  *     <DataGridTable>

--- a/packages/react-ui-lib/src/datagrid/pagination.tsx
+++ b/packages/react-ui-lib/src/datagrid/pagination.tsx
@@ -21,9 +21,10 @@ interface DataGridPaginationProps {
 }
 
 /**
- * Pagination controls UI for DataView.
+ * `DataGridPagination` provides pagination controls for navigating through pages in a `DataView`.
+ * It includes buttons for navigating to the first, previous, next, and last pages.
  *
- * ## Example
+ * ## Example: Basic Usage
  * ```tsx
  * <DataGridPagination />
  * ```
@@ -102,6 +103,15 @@ export const DataGridPagination: FC<DataGridPaginationProps> = ({ sticky }) => (
 	</PaginationWrapper>
 )
 
+/**
+ * `DataGridPerPageSelector` allows users to set the number of items displayed per page
+ * in a `DataView`. It provides a dropdown menu with preset options.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <DataGridPerPageSelector />
+ * ```
+ */
 export const DataGridPerPageSelector = () => (
 	<div>
 		<p className="text-gray-400 text-xs font-semibold mb-1">{dict.datagrid.paginationRowsPerPage}</p>

--- a/packages/react-ui-lib/src/datagrid/table.tsx
+++ b/packages/react-ui-lib/src/datagrid/table.tsx
@@ -17,12 +17,14 @@ export interface DataViewTableProps {
 }
 
 /**
- * Table layout for DataView.
+ * `DataGridTable` provides a table layout for `DataView`, allowing structured data representation.
+ * It must be used within a `DataView` context to function correctly.
  *
- * ## Example
+ * ## Example: Basic usage
  * ```tsx
  * <DataGridTable>
- *     <DataGridTextColumn header="Title" field="title" />
+ *   <DataGridTextColumn header="Title" field="title" />
+ *   <DataGridTextColumn header="Author" field="author" />
  * </DataGridTable>
  * ```
  */

--- a/packages/react-ui-lib/src/datagrid/tiles.tsx
+++ b/packages/react-ui-lib/src/datagrid/tiles.tsx
@@ -14,12 +14,13 @@ export interface DataGridTilesProps {
 }
 
 /**
- * Simple grid layout for DataView.
+ * `DataGridTiles` provides a simple grid layout for `DataView`, enabling a tile-based display.
+ * It must be used within a `DataView` context.
  *
- * ## Example
+ * ## Example: Basic usage
  * ```tsx
  * <DataGridTiles>
- *     <MyCustomTile />
+ *   <MyCustomTile />
  * </DataGridTiles>
  * ```
  */

--- a/packages/react-ui-lib/src/datagrid/toolbar.tsx
+++ b/packages/react-ui-lib/src/datagrid/toolbar.tsx
@@ -26,18 +26,14 @@ export interface DataGridToolbarProps {
 }
 
 /**
- * Toolbar for DataGrid with default UI.
- * It contains
- * 	- filters (with default DataGridQueryFilter, which can be replaced by custom filters in children)
- * 	- settings (layout switcher, visible elements, per page selector)
- * 	- export button
- * 	- reload button
+ * `DataGridToolbar` provides a toolbar for `DataGrid` with default UI components.
+ * It includes filtering, layout settings, export functionality, and a reload button.
  *
- * ## Example
+ * ## Example: Basic usage with custom filters
  * ```tsx
  * <DataGridToolbar>
- *     <DataGridQueryFilter />
- *     <DataGridTextFilter field={'name'} label="Name" />
+ *   <DataGridQueryFilter />
+ *   <DataGridTextFilter field="name" label="Name" />
  * </DataGridToolbar>
  * ```
  */

--- a/packages/react-ui-lib/src/dev/login-panel.tsx
+++ b/packages/react-ui-lib/src/dev/login-panel.tsx
@@ -4,6 +4,15 @@ import { CreateSessionTokenForm, useCreateSessionTokenForm } from '@contember/re
 import { Loader } from '@contember/react-ui-lib-base'
 import { TenantFormError, TenantFormField } from '@contember/react-ui-lib-tenant'
 
+/**
+ * `LoginWithEmail` component handles user authentication using email.
+ * It integrates with session token management to facilitate authentication.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <LoginWithEmail />
+ * ```
+ */
 export const LoginWithEmail = () => {
 	const sessionToken = useSessionTokenWithMeta()
 	const setSessionToken = useSetSessionToken()

--- a/packages/react-ui-lib/src/dev/todo.tsx
+++ b/packages/react-ui-lib/src/dev/todo.tsx
@@ -1,8 +1,20 @@
 import { PropsWithChildren } from 'react'
 
+/**
+ * Props for the {@link Todo} component.
+ */
 export interface CommentProps extends PropsWithChildren {
 }
 
+/**
+ * `Todo` is a development-only helper component for marking TODOs in the UI.
+ * It displays a highlighted message when in development mode (`import.meta.env.DEV`).
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <Todo>Implement authentication logic</Todo>
+ * ```
+ */
 export const Todo = ({ children }: CommentProps) => {
 	if (!import.meta.env.DEV) return null
 

--- a/packages/react-ui-lib/src/dimensions/dimensions.tsx
+++ b/packages/react-ui-lib/src/dimensions/dimensions.tsx
@@ -22,15 +22,63 @@ import { Popover, PopoverContent, PopoverTrigger } from '@contember/react-ui-lib
 import { Button } from '@contember/react-ui-lib-base'
 import { DimensionLabelUI, DimensionLabelWrapperUI } from '@contember/react-ui-lib-base'
 
+/**
+ * Props for the {@link DimensionsSwitcher} component.
+ */
 export type DimensionsSwitcherProps = {
+	/**
+	 * Entity list for dimension options.
+	 */
 	options: SugaredQualifiedEntityList['entities']
+	/**
+	 * Specifies initial sorting of the options (e.g., `{ label: 'desc' }`).
+	 */
 	orderBy?: DataViewSortingDirections
+	/**
+	 * The name of the dimension to switch.
+	 */
 	dimension: string
+	/**
+	 * Child components or fields to render within the dimension selector.
+	 */
 	children: ReactNode
+	/**
+	 * Field containing unique dimension identifiers.
+	 */
 	slugField: SugaredRelativeSingleField['field']
+	/**
+	 * Enables multi-selection mode.
+	 */
 	isMulti?: boolean
 }
 
+/**
+ * `DimensionsSwitcher` is a UI component for switching between different dimensions of data.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <DimensionsSwitcher
+ *   dimension="locale"
+ *   slugField="code"
+ *   options="DimensionsLocale"
+ * >
+ *   <Field field="label" />
+ * </DimensionsSwitcher>
+ * ```
+ *
+ * ## Example: With initial sorting and multi-selection
+ * ```tsx
+ * <DimensionsSwitcher
+ *   dimension="locale"
+ *   slugField="code"
+ *   options="DimensionsLocale"
+ *   orderBy={{ label: 'desc' }}
+ *   isMulti
+ * >
+ *   <Field field="label" />
+ * </DimensionsSwitcher>
+ * ```
+ */
 export const DimensionsSwitcher = Component(({ options, dimension, children, slugField, orderBy, isMulti }: DimensionsSwitcherProps) => (
 	<DataView entities={options} initialSorting={orderBy}>
 		<DataViewLoaderState initial refreshing>
@@ -122,14 +170,47 @@ export type RenderLabelProps = {
 	dimensionValue: string | null
 }
 
+/**
+ * Props for the {@link SideDimensions} component.
+ */
 export type SideDimensionsProps = {
+	/**
+	 * The name of the dimension to render.
+	 */
 	dimension: string
+	/**
+	 * The name of the dimension variable to expose in the context.
+	 */
 	as: string
+	/**
+	 * The field to traverse via `HasOne` relationship.
+	 */
 	field: SugaredRelativeSingleEntity['field']
+	/**
+	 * Child components or fields to render within the dimension selector.
+	 */
 	children: ReactNode
+	/**
+	 * Optional custom label renderer. Receives the label and the current dimension value.
+	 */
 	renderLabel?: ({ label, dimensionValue }: RenderLabelProps) => ReactNode
 }
 
+/**
+ * `SideDimensions` is a layout component that renders content for a specific dimension
+ * within a flexible side panel. It wraps its content inside a `DimensionRenderer` and `HasOne` field relationship.
+ *
+ * ## Example: Basic Usage
+ * ```tsx
+ * <SideDimensions
+ *   dimension="locale"
+ *   as="currentLocale"
+ *   field="locales(locale.code = $currentLocale)"
+ * >
+ *   <InputField field="title" />
+ * </SideDimensions>
+ * ```
+ */
 export const SideDimensions = Component<SideDimensionsProps>(({ dimension, children, as, field, renderLabel }) => (
 	<div className="flex mt-4 gap-4">
 		<DimensionRenderer dimension={dimension} as={as}>

--- a/packages/react-ui-lib/src/editor/block-editor.tsx
+++ b/packages/react-ui-lib/src/editor/block-editor.tsx
@@ -22,11 +22,80 @@ import { Transforms } from 'slate'
 export type BlockEditorFieldProps =
 	& BlockEditorProps
 	& {
+		/** Field for storing related entities */
 		referencesField: SugaredRelativeEntityList['field']
+		/** Field for entity type discrimination */
 		referenceDiscriminationField: SugaredRelativeSingleField['field']
+		/** Editor placeholder text */
 		placeholder?: string
 	}
 
+/**
+ * BlockEditorField component - Rich text editor with drag-and-drop block management
+ *
+ * ## Purpose
+ * Provides a structured content editing experience with sortable blocks and reference management
+ *
+ * ## Features
+ * - Drag-and-drop block reordering
+ * - Reference entity integration
+ * - Slate.js editor core
+ * - Plugin system extensibility
+ * - Collision detection and measuring strategies
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <BlockEditorField
+ *   field="data"
+ *   referencesField="references"
+ *   referenceDiscriminationField="type"
+ * >
+ *   <EditorBlockToolbar>
+ *     <EditorReferenceTrigger referenceType="image">
+ *       <BlockButton><ImageIcon /> Image</BlockButton>
+ *     </EditorReferenceTrigger>
+ *   </EditorBlockToolbar>
+ *
+ *   <EditorBlock name="image" label="Image">
+ *     <ImageField baseField="image" urlField="url" />
+ *   </EditorBlock>
+ * </BlockEditorField>
+ * ```
+ *
+ * ## Example with custom plugins and toolbars (inline and block)
+ * ```tsx
+ * <BlockEditorField
+ *   field="data"
+ *   referencesField="references"
+ *   referenceDiscriminationField="type"
+ *   plugins={[
+ *     editor => {
+ *       editor.registerElement({
+ *         type: 'link',
+ *         isInline: true,
+ *         render: LinkElement,
+ *       })
+ *     },
+ *   ]}
+ * >
+ *   <EditorBlockToolbar>
+ *     <EditorReferenceTrigger referenceType="image">
+ *       <BlockButton>
+ *         <ImageIcon /> Image
+ *       </BlockButton>
+ *     </EditorReferenceTrigger>
+ *   </EditorBlockToolbar>
+ *
+ *   <EditorBlock name="quote" label="Quote">
+ *     <EditorBlockContent />
+ *   </EditorBlock>
+ *
+ *   <EditorBlock name="image" label="Image">
+ *     <ImageField baseField="image" urlField="url" />
+ *   </EditorBlock>
+ * </BlockEditorField>
+ * ```
+ */
 export const BlockEditorField = Component<BlockEditorFieldProps>(({ placeholder, children, ...props }) => {
 	return (
 		<BlockEditor

--- a/packages/react-ui-lib/src/editor/common/baseEditorPlugins.tsx
+++ b/packages/react-ui-lib/src/editor/common/baseEditorPlugins.tsx
@@ -27,6 +27,49 @@ import { TableElementRenderer } from './elements/TableElementRenderer.js'
 import { TableCellElementRenderer } from './elements/TableCellElementRenderer.js'
 import { TableRowElementRenderer } from './elements/TableRowElementRenderer.js'
 
+/**
+ * baseEditorPlugins - Core plugin configuration for Slate.js editor components
+ *
+ * ### Plugin Structure
+ * Contains renderer configurations and basic formatting capabilities for:
+ *
+ * ## Structural Elements
+ * - **anchor**: Link handling with `AnchorRenderer`
+ * - **paragraph**: Text blocks with `ParagraphRenderer`
+ * - **heading**: Headings with `HeadingRenderer`
+ * - **list**: List structures with:
+ *   - `ListItemRenderer`
+ *   - `OrderedListRenderer`
+ *   - `UnorderedListRenderer`
+ * - **horizontalRule**: Dividers with `HorizontalRuleRenderer`
+ * - **scrollTarget**: Navigation anchors with `ScrollTargetRenderer`
+ * - **table**: Tabular data with:
+ *   - `TableElementRenderer`
+ *   - `TableCellElementRenderer`
+ *   - `TableRowElementRenderer`
+ *
+ * ## Text Formatting
+ * - **bold**: Bold text formatting
+ * - **code**: Inline code styling
+ * - **highlight**: Text highlighting
+ * - **italic**: Italic text
+ * - **newline**: Manual line breaks
+ * - **strikeThrough**: Strikethrough text
+ * - **underline**: Underlined text
+ *
+ * ### Usage
+ * ```tsx
+ * // Create editor with base configuration
+ * <RichTextEditor
+ *   plugins={[
+ *     baseEditorPlugins.paragraph,
+ *     baseEditorPlugins.heading,
+ *     baseEditorPlugins.bold,
+ *     baseEditorPlugins.italic
+ *   ]}
+ * />
+ * ```
+ */
 export const baseEditorPlugins = {
 	anchor: withAnchors({
 		render: AnchorRenderer,

--- a/packages/react-ui-lib/src/editor/editor-block.tsx
+++ b/packages/react-ui-lib/src/editor/editor-block.tsx
@@ -9,12 +9,46 @@ import { ReactEditor, useSlateStatic } from 'slate-react'
 import { Node, Transforms } from 'slate'
 
 export interface EditorBlockProps {
+	/** Unique block type identifier */
 	name: string
+	/** Display name for block type */
 	label: ReactNode
+	/** Primary block content */
 	children: ReactNode
+	/** Alternate configuration UI (optional) */
 	alternate?: ReactNode
 }
 
+/**
+ * EditorBlock component - Configurable content block for rich text editor
+ *
+ * ## Purpose
+ * Creates reusable, customizable content blocks within a Slate.js editor instance
+ *
+ * ## Features
+ * - Drag-and-drop enabled block structure
+ * - Alternate configuration UI via popover
+ * - Block type labeling and identification
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <BlockEditorField
+ *   field="data"
+ *   referencesField="references"
+ *   referenceDiscriminationField="type"
+ * >
+ *   <EditorBlockToolbar>
+ *     <EditorReferenceTrigger referenceType="image">
+ *       <BlockButton><ImageIcon /> Image</BlockButton>
+ *     </EditorReferenceTrigger>
+ *   </EditorBlockToolbar>
+ *
+ *   <EditorBlock name="image" label="Image">
+ *     <ImageField baseField="image" urlField="url" />
+ *   </EditorBlock>
+ * </BlockEditorField>
+ * ```
+ */
 export const EditorBlock = Component<EditorBlockProps>(() => {
 	return null
 }, blockProps => {
@@ -29,6 +63,23 @@ export const EditorBlock = Component<EditorBlockProps>(() => {
 	)
 })
 
+/**
+ * EditorBlockContent component - Editable content area for blocks
+ *
+ * ## Purpose
+ * Provides the main editable region within a content block
+ *
+ * ## Features
+ * - Automatic placeholder text when empty
+ * - ContentEditable management
+ * - Text presence detection
+ * - Proper padding and positioning
+ *
+ * ## Example
+ * ```tsx
+ * <EditorBlockContent />
+ * ```
+ */
 export const EditorBlockContent = Component(() => {
 	const el = useEditorBlockElement().element
 	const hasText = Node.string(el).length > 0

--- a/packages/react-ui-lib/src/editor/plugins.tsx
+++ b/packages/react-ui-lib/src/editor/plugins.tsx
@@ -4,6 +4,25 @@ import { baseEditorPlugins } from './common/baseEditorPlugins.js'
 
 const plugins = baseEditorPlugins
 
+/**
+ * richTextFieldPlugins - Basic text formatting plugins for Slate editor
+ *
+ * ## Purpose
+ * Provides essential inline formatting tools for rich text fields
+ *
+ * ## Included Features:
+ * - Anchor/links
+ * - Bold/italic/underline
+ * - Code blocks
+ * - Text highlighting
+ * - Strikethrough
+ * - Manual newlines
+ *
+ * ## Example Usage
+ * ```tsx
+ * <RichTextEditor plugins={richTextFieldPlugins} />
+ * ```
+ */
 export const richTextFieldPlugins = [
 	plugins.anchor,
 	plugins.bold,
@@ -15,6 +34,31 @@ export const richTextFieldPlugins = [
 	plugins.underline,
 ]
 
+/**
+ * blockEditorPlugins - Advanced content editing plugins with structural elements
+ *
+ * ## Purpose
+ * Enables complex document structures and block management in Slate editor
+ *
+ * ## Additional Features beyond richTextFieldPlugins:
+ * - Paragraph/heading formatting
+ * - Lists (ordered/unordered)
+ * - Horizontal rules
+ * - Tables
+ * - Scroll targets
+ * - Drag-and-drop block sorting
+ *
+ * ## Key Integration
+ * - `withSortable` enables block reordering
+ * - Requires `SortableBlock` component for drag handles
+ *
+ * ## Example Usage
+ * ```tsx
+ * <BlockEditor plugins={blockEditorPlugins}>
+ *   <SortableBlock name="section" />
+ * </BlockEditor>
+ * ```
+ */
 export const blockEditorPlugins = [
 	plugins.anchor,
 	plugins.paragraph,

--- a/packages/react-ui-lib/src/editor/rich-text-view.tsx
+++ b/packages/react-ui-lib/src/editor/rich-text-view.tsx
@@ -3,10 +3,54 @@ import { RichTextFieldRenderer, RichTextFieldRendererProps } from '@contember/re
 
 export type RichTextRendererProps =
 	& {
+		/** Field containing rich text content */
 		field: SugaredRelativeSingleField['field']
 	}
 	& Omit<RichTextFieldRendererProps, 'source'>
 
+/**
+ * RichTextView component - Displays formatted rich text content from a Contember field
+ *
+ * ## Purpose
+ * Renders stored rich text content with proper formatting and structure
+ *
+ * ## Features
+ * - Safe JSON parsing of stored rich text data
+ * - Conditional rendering when content is empty
+ * - Integration with Contember's rich text rendering system
+ * - Customizable through RichTextFieldRenderer props
+ *
+ * ## Example
+ * ```tsx
+ * <RichTextView field="content" />
+ * ```
+ *
+ * ## Example with renderers
+ * ```tsx
+ * const renderLeaf = (leaf: Leaf) => {
+ * 	let content = <>{leaf.text}</>
+ *
+ *  if (leaf.isBold) {
+ *    content = <strong>{content}</strong>
+ * 	}
+ *
+ * 	if (leaf.isItalic) {
+ *    content = <em>{content}</em>
+ * 	}
+ *
+ * 	if (leaf.isUnderlined) {
+ *    content = <u>{content}</u>
+ * 	}
+ *
+ * 	return content
+ * }
+ *
+ * <RichTextView
+ *   field="content"
+ *   renderLeaf={renderLeaf}
+ * />
+ * ```
+ */
 export const RichTextView = Component<RichTextRendererProps>(({ field, ...props }) => {
 	return (
 		<FieldView<string>

--- a/packages/react-ui-lib/src/editor/rich-text.tsx
+++ b/packages/react-ui-lib/src/editor/rich-text.tsx
@@ -10,11 +10,39 @@ import { richTextFieldPlugins } from './plugins.js'
 
 export type RichTextFieldProps =
 	& {
+		/** Form field name for storing content */
 		field: SugaredRelativeSingleField['field']
 		children: ReactNode
 	}
 	& Omit<FormContainerProps, 'children'>
 
+/**
+ * RichTextField component - Form-integrated rich text editor with basic formatting
+ *
+ * ## Purpose
+ * Provides a rich text editing experience within Contember forms with common formatting tools
+ *
+ * ## Features
+ * - Integrated with Contember form field management
+ * - Basic text formatting (bold, italic, code, etc.)
+ * - Read-only state during mutations
+ * - Custom placeholder support
+ * - Plugin-based architecture
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <RichTextField field="content" />
+ * ```
+ *
+ * ## Example: With custom placeholder
+ * ```tsx
+ * <RichTextField
+ *   field="content"
+ *   label="Article body"
+ *   placeholder="Enter your text here"
+ * />
+ * ```
+ */
 export const RichTextField = Component<RichTextFieldProps>(({ field, description, label, children }) => {
 	return (
 		<FormFieldScope field={field}>

--- a/packages/react-ui-lib/src/editor/sortable-block.tsx
+++ b/packages/react-ui-lib/src/editor/sortable-block.tsx
@@ -7,12 +7,44 @@ import { DropIndicator } from '@contember/react-ui-lib-base'
 import { Portal } from '@radix-ui/react-portal'
 import { DragOverlay } from '@dnd-kit/core'
 
+/**
+ * BlockEditorHandle component - Drag handle for sortable blocks
+ *
+ * ## Example
+ * ```tsx
+ * <BlockEditorHandle />
+ * ```
+ */
 export const BlockEditorHandle = uic('span', {
 	baseClass:
 		'absolute top-1/2 -left-3 h-6 w-6 flex justify-end items-center opacity-10 hover:opacity-100 transition-opacity -translate-y-1/2 cursor-grab',
 	beforeChildren: <GripVerticalIcon size={16} />,
 })
 
+/**
+ * SortableBlock component - Drag-and-drop enabled block container for Slate editor
+ *
+ * ## Purpose
+ * Implements sortable functionality for editor blocks with visual feedback and overlay
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <SortableBlock element={slateElement}>
+ *   <BlockContent />
+ * </SortableBlock>
+ * ```
+ *
+ * ## Example: Used within a BlockEditor
+ * ```tsx
+ * <BlockEditor
+ *   plugins={[
+ *     withSortable({
+ *       render: SortableBlock,
+ *     }),
+ *   ]}
+ * />
+ * ```
+ */
 export const SortableBlock = ({ children, element }: { children: ReactNode; element: Element }) => {
 	const sortable = useSortable({
 		id: element.key as string,

--- a/packages/react-ui-lib/src/errors/use-error-formatter.ts
+++ b/packages/react-ui-lib/src/errors/use-error-formatter.ts
@@ -2,6 +2,27 @@ import { ReactNode, useCallback } from 'react'
 import { dict } from '@contember/react-ui-lib-base'
 import { ErrorAccessor } from '@contember/interface'
 
+/**
+ * `useErrorFormatter` is a custom hook that formats an array of errors into readable messages.
+ * It processes validation and execution errors and returns corresponding user-friendly messages.
+ *
+ * ## Returns
+ * A memoized callback function that takes an array of `ErrorAccessor.Error` and returns an array of `ReactNode` messages.
+ *
+ * ## Example: Formatting validation and execution errors
+ * ```tsx
+ * const formatErrors = useErrorFormatter();
+ *
+ * const errors = [
+ *   { type: 'validation', code: 'fieldRequired', message: 'This field is required' },
+ *   { type: 'execution', code: 'UniqueConstraintViolation' }
+ * ];
+ *
+ * const formattedErrors = formatErrors(errors);
+ *
+ * return <>{formattedErrors.map((error, i) => <div key={i}>{error}</div>)}</>;
+ * ```
+ */
 export const useErrorFormatter = () => {
 	return useCallback((errors: ErrorAccessor.Error[]): ReactNode[] => {
 		return errors.map((it, i) => {

--- a/packages/react-ui-lib/src/field/formatted-field.tsx
+++ b/packages/react-ui-lib/src/field/formatted-field.tsx
@@ -1,10 +1,25 @@
 import { Component, FieldView, SugaredRelativeSingleField } from '@contember/interface'
 import { getFormatter } from '../formatting/index.js'
 
+/**
+ * Props for the {@link FormattedField} component.
+ */
 export interface FormattedFieldProps {
+	/**
+	 * The field to render.
+	 */
 	field: SugaredRelativeSingleField['field']
 }
 
+/**
+ * `FormattedField` is a wrapper around {@link FieldView} that applies a formatter to the field's value
+ * based on its schema definition.
+ *
+ * ## Example: Rendering a formatted field
+ * ```tsx
+ * <FormattedField field={myField} />
+ * ```
+ */
 export const FormattedField = Component<FormattedFieldProps>(({ field }) => {
 	return <FieldView field={field} render={it => getFormatter(it.schema)(it.value)} />
 })

--- a/packages/react-ui-lib/src/form/container.tsx
+++ b/packages/react-ui-lib/src/form/container.tsx
@@ -5,14 +5,44 @@ import { Component, ErrorAccessor, useLabelMiddleware } from '@contember/interfa
 import { FormError, FormFieldStateProvider, FormLabel, useFormFieldState } from '@contember/react-form'
 import { FormFieldLabel } from './labels.js'
 
+/**
+ * Props for the {@link FormContainer} component.
+ */
 export type FormContainerProps = {
+	/**
+	 * The label for the form element.
+	 */
 	label?: ReactNode
+	/**
+	 * The description text for the form element.
+	 */
 	description?: ReactNode
+	/**
+	 * The child components or form elements to render within the container.
+	 */
 	children: ReactNode
+	/**
+	 * The error message to display.
+	 */
 	errors?: ErrorAccessor.Error[] | ReactNode
+	/**
+	 * Indicates whether the form element is required.
+	 */
 	required?: boolean
 }
 
+/**
+ * `FormContainer` is a layout component for form fields, providing consistent styling and handling
+ * of labels, descriptions, and error messages. It ensures accessibility and state management
+ * within form contexts.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <FormContainer label="Email" description="Enter a valid email address" required errors={errors}>
+ *   <FormInput field="email" />
+ * </FormContainer>
+ * ```
+ */
 export const FormContainer = Component(
 	({ children, description, label, required, errors }: FormContainerProps) => {
 		const errorsNode = Array.isArray(errors) ? undefined : errors

--- a/packages/react-ui-lib/src/form/inputs.tsx
+++ b/packages/react-ui-lib/src/form/inputs.tsx
@@ -18,6 +18,9 @@ import { Component, Field } from '@contember/interface'
 import { useEnumOptionsFormatter } from '../labels/index.js'
 import { FormFieldLabel } from './labels.js'
 
+/**
+ * Props for the {@link InputField} component.
+ */
 export type InputFieldProps =
 	& Omit<FormInputProps, 'children'>
 	& Omit<FormContainerProps, 'children'>
@@ -26,6 +29,24 @@ export type InputFieldProps =
 		inputProps?: ComponentProps<typeof Input>
 	}
 
+/**
+ * `InputField` is a form input component that integrates with {@link FormFieldScope},
+ * {@link FormContainer}, and {@link FormInput} to provide a structured and configurable input field.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <InputField field="title" label="Article title" />
+ * ```
+ *
+ * ## Example: With additional input properties
+ * ```tsx
+ * <InputField
+ *   field="title"
+ *   label="Article title"
+ *   inputProps={{ placeholder: 'Enter a title' }}
+ * />
+ * ```
+ */
 export const InputField = Component((
 	{ field, label, description, inputProps, isNonbearing, defaultValue, required, parseValue, formatValue }: InputFieldProps,
 ) => (
@@ -38,6 +59,9 @@ export const InputField = Component((
 	</FormFieldScope>
 ))
 
+/**
+ * Props for the {@link TextareaField} component.
+ */
 export type TextareaFieldProps =
 	& Omit<FormInputProps, 'children'>
 	& Omit<FormContainerProps, 'children'>
@@ -46,6 +70,30 @@ export type TextareaFieldProps =
 		inputProps?: ComponentProps<typeof TextareaAutosize>
 	}
 
+/**
+ * `TextareaField` is a form textarea component that integrates with `FormFieldScope`,
+ * `FormContainer`, and `FormInput` to provide a structured and configurable multi-line input field.
+ *
+ * Must be used within a form context.
+ *
+ * ## Features
+ * - Supports field scoping for form state management
+ * - Includes a label and description for accessibility
+ * - Handles required validation
+ * - Supports automatic resizing with `TextareaAutosize`
+ * - Allows custom input properties via `inputProps`
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <TextareaField
+ *   field="bio"
+ *   label="Biography"
+ *   description="Tell us about yourself"
+ *   required
+ *   inputProps={{ placeholder: "Write something..." }}
+ * />
+ * ```
+ */
 export const TextareaField = Component(({ field, label, description, inputProps, isNonbearing, defaultValue, required }: TextareaFieldProps) => (
 	<FormFieldScope field={field}>
 		<FormContainer description={description} label={label} required={required}>
@@ -64,6 +112,25 @@ export type CheckboxFieldProps =
 		inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'defaultValue'>
 	}
 
+/**
+ * CheckboxField is a component for boolean fields. Must be used within an Entity context.
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features:
+ * - Renders as a standard checkbox input
+ * - Label appears adjacent to the checkbox
+ * - Required state reflects field nullability (can be overridden)
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <CheckboxField
+ *   field="isPublished"
+ *   label="Publish immediately"
+ * />
+ * ```
+ */
 export const CheckboxField = Component(({ field, label, description, inputProps, isNonbearing, defaultValue, required }: CheckboxFieldProps) => (
 	<FormFieldScope field={field}>
 		<FormContainer description={description} label={false}>
@@ -89,6 +156,38 @@ export type RadioEnumFieldProps =
 		inputProps?: Omit<React.InputHTMLAttributes<HTMLInputElement>, 'defaultValue'>
 	}
 
+/**
+ * RadioEnumField is a component for enum fields with radio button selection. Must be used within an Entity context.
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Can auto-generate options from enum definitions
+ * - Supports horizontal or vertical layout
+ * - Options can be provided explicitly or derived from enum labels
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <RadioEnumField
+ *   field="status"
+ *   label="Article Status"
+ *   orientation="horizontal"
+ *   options={[
+ *     { value: 'draft', label: 'Draft' },
+ *     { value: 'published', label: 'Published' }
+ *   ]}
+ * />
+ * ```
+ *
+ * ## Example: Using enum auto-detection
+ * ```tsx
+ * <RadioEnumField
+ *   field="category"
+ *   label="Article Category"
+ * />
+ * ```
+ */
 export const RadioEnumField = Component<RadioEnumFieldProps>(({ field, label, description, required, ...rest }) => {
 	return (
 		<FormFieldScope field={field}>

--- a/packages/react-ui-lib/src/form/select.tsx
+++ b/packages/react-ui-lib/src/form/select.tsx
@@ -26,6 +26,51 @@ export type SelectFieldProps =
 	& SelectInputProps
 	& Omit<FormContainerProps, 'children'>
 
+/**
+ * `SelectField` is a component for single-entity relationship selection (hasOne). Must be used within an Entity context.
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Manages hasOne relationships through a dropdown interface.
+ * - Supports custom option rendering and creation of new entities.
+ * - Sorts options by a specified field.
+ * - Query-based option filtering.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <SelectField
+ *   field="country"
+ *   label="Home Country"
+ * >
+ *   <Field field="name" />
+ * </SelectField>
+ * ```
+ *
+ * ## Example: With sorting and form allowing creation of new entities
+ * ```tsx
+ * <SelectField
+ *   field="author"
+ *   label="Author"
+ *   initialSorting={{ name: 'asc' }}
+ *   createNewForm={<CountryForm />}
+ * >
+ *   <Field field="name" />
+ * </SelectField>
+ * ```
+ *
+ * ## Example: With query-based filtering
+ * ```tsx
+ * <SelectField
+ *   field="author"
+ *   label="Author"
+ *   options="Author[archived != false]"
+ * >
+ *   <Field field="name" />
+ * </SelectField>
+ * ```
+ */
 export const SelectField = Component<SelectFieldProps>(
 	({ field, label, description, children, options, queryField, placeholder, createNewForm, errors, initialSorting, required }, env) => {
 		return (
@@ -54,6 +99,41 @@ export type MultiSelectFieldProps =
 	& MultiSelectInputProps
 	& Omit<FormContainerProps, 'children' | 'required'>
 
+/**
+ * MultiSelectField component for managing multiple-entity (hasMany) relationships.
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`)
+ *
+ * ## Features
+ * - Multiple entity selection with chip display
+ * - Supports custom option rendering and creation of new entities
+ * - Maintains selection order based on user interaction
+ * - Query-based option filtering with initial sorting
+ * - Integrated error state handling from parent form
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <MultiSelectField
+ *   field="categories"
+ *   label="Article Categories"
+ * >
+ *   <Field field="name" />
+ * </MultiSelectField>
+ * ```
+ *
+ * ## Example: With creation form and sorting
+ * ```tsx
+ * <MultiSelectField
+ *   field="tags"
+ *   label="Article Tags"
+ *   initialSorting={{ name: 'asc' }}
+ *   createNewForm={<TagCreateForm />}
+ * >
+ *   <Field field="name" />
+ * </MultiSelectField>
+ * ```
+ */
 export const MultiSelectField = Component<MultiSelectFieldProps>(
 	({ field, label, description, children, options, queryField, placeholder, createNewForm, errors, initialSorting }) => {
 		return (
@@ -81,6 +161,32 @@ export type SortableMultiSelectFieldProps =
 	& SortableMultiSelectInputProps
 	& Omit<FormContainerProps, 'children' | 'required'>
 
+/**
+ * SortableMultiSelectField component for ordered multi-entity relationships with drag-and-drop.
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`)
+ * - Requires sort field configuration via `sortableBy` prop
+ *
+ * ## Features
+ * - Drag-and-drop reordering of selected items
+ * - Visual sorting indicators during drag operations
+ * - Customizable sort field storage
+ * - Connection point management for complex relationships
+ * - Inherits all MultiSelectField features
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <SortableMultiSelectField
+ *   field="chapterPages"
+ *   label="Page Order"
+ *   sortableBy="pageNumber"
+ *   connectAt="bookChapter"
+ * >
+ *   <Field field="content" />
+ * </SortableMultiSelectField>
+ * ```
+ */
 export const SortableMultiSelectField = Component<SortableMultiSelectFieldProps>(
 	({ field, label, description, children, options, queryField, placeholder, sortableBy, connectAt, createNewForm, errors, initialSorting }) => {
 		return (
@@ -114,6 +220,57 @@ export type SelectEnumFieldProps =
 		required?: boolean
 	}
 
+/**
+ * SelectEnumField component for enum value selection with auto-option detection.
+ *
+ * ## Requirements
+ * - Field must be an enum type when using auto-detection
+ * - Manual options must be provided if enum not detected
+ *
+ * ## Features
+ * - Auto-detects enum options from schema definition
+ * - Supports mixed value types (string, number, boolean, null)
+ * - Two option formats: object map or array of {value/label}
+ * - Required field validation with error feedback
+ * - Custom placeholder support
+ * - Pre-persist validation for required fields
+ *
+ * ## Example: Auto-detected enum usage
+ * ```tsx
+ * <SelectEnumField
+ *   field="articleStatus"
+ *   label="Publication Status"
+ *   required
+ * />
+ * ```
+ *
+ * ## Example: Manual options with mixed types
+ * ```tsx
+ * <SelectEnumField
+ *   field="notificationSettings"
+ *   label="Alert Preferences"
+ *   options={[
+ *     { value: 'email', label: 'Email Notifications' },
+ *     { value: 1, label: 'SMS Alerts' },
+ *     { value: null, label: 'No Notifications' }
+ *   ]}
+ *   placeholder="Select preference..."
+ * />
+ * ```
+ *
+ * ## Example: Object-based options
+ * ```tsx
+ * <SelectEnumField
+ *   field="userRole"
+ *   label="Account Type"
+ *   options={{
+ *     admin: 'Administrator',
+ *     user: 'Standard User',
+ *     guest: 'Temporary Access'
+ *   }}
+ * />
+ * ```
+ */
 export const SelectEnumField = Component<SelectEnumFieldProps>(
 	({ field, label, description, options, placeholder, required }) => {
 		return (

--- a/packages/react-ui-lib/src/form/upload-repeaters.tsx
+++ b/packages/react-ui-lib/src/form/upload-repeaters.tsx
@@ -60,6 +60,47 @@ export type ImageRepeaterFieldProps =
 	& BaseFileRepeaterFieldProps
 	& ImageFileTypeProps
 
+/**
+ * ImageRepeaterField component - Multiple image upload with sorting capabilities
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Handles multiple image uploads in a list format
+ * - Drag-and-drop reordering of images
+ * - Auto-generated image previews
+ * - Progress indicators during upload
+ * - Integrated removal controls
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <ImageRepeaterField
+ *   label="Gallery Images"
+ *   field="images"
+ *   urlField="image.url"
+ *   orderBy="createdAt"
+ * />
+ * ```
+ *
+ * ## Example: With custom dropzone and actions
+ * ```tsx
+ * <ImageRepeaterField
+ *   field="imageList.items"
+ *   baseField="image"
+ *   sortableBy="order"
+ *   urlField="url"
+ *   widthField="width"
+ *   heightField="height"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   label="Image file"
+ *   description="Some description of the image file."
+ * />
+ * ```
+ */
 export const ImageRepeaterField = Component<ImageRepeaterFieldProps>(props => (
 	<>
 		<FileRepeaterFieldInner
@@ -82,6 +123,44 @@ export type AudioRepeaterFieldProps =
 	& BaseFileRepeaterFieldProps
 	& AudioFileTypeProps
 
+/**
+ * AudioRepeaterField component - Multiple audio file upload manager
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Handles ordered lists of audio files
+ * - Audio player preview for uploaded files
+ * - Supports common audio formats
+ * - File size validation
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <AudioRepeaterField
+ *   label="Podcast Episodes"
+ *   field="episodes"
+ *   urlField="audio.url"
+ *   orderBy="createdAt"
+ * />
+ * ```
+ *
+ * ## Example: Sortable with baseField and some optional props
+ * ```tsx
+ * <AudioRepeaterField
+ *   field="episodes"
+ *   baseField="audio"
+ *   urlField="url"
+ *   sortableBy="order"
+ *   durationField="duration"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   label="Audio file"
+ * />
+ * ```
+ */
 export const AudioRepeaterField = Component<AudioRepeaterFieldProps>(props => (
 	<>
 		<FileRepeaterFieldInner {...props} fileType={createAudioFileType(props)}>
@@ -94,6 +173,44 @@ export type VideoRepeaterFieldProps =
 	& BaseFileRepeaterFieldProps
 	& VideoFileTypeProps
 
+/**
+ * VideoRepeaterField component - Ordered video upload collection
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Manages multiple video uploads
+ * - Video preview thumbnails
+ * - Drag-and-drop sequence control
+ * - Upload progress tracking
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <VideoRepeaterField
+ *   label="Course Videos"
+ *   field="courses"
+ *   urlField="video.url"
+ *   orderBy="createdAt"
+ * />
+ * ```
+ *
+ * ## Example: Sortable with baseField and some optional props
+ * ```tsx
+ * <VideoRepeaterField
+ *   field="courses"
+ *   baseField="video"
+ *   urlField="url"
+ *   sortableBy="order"
+ *   durationField="duration"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   label="Course Videos"
+ * />
+ * ```
+ */
 export const VideoRepeaterField = Component<VideoRepeaterFieldProps>(props => (
 	<>
 		<FileRepeaterFieldInner {...props} fileType={createVideoFileType(props)}>
@@ -106,6 +223,43 @@ export type FileRepeaterFieldProps =
 	& BaseFileRepeaterFieldProps
 	& AnyFileTypeProps
 
+/**
+ * FileRepeaterField component - Generic multi-file upload repeater
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Handles any file type in a list format
+ * - File type icon display
+ * - Customizable preview components
+ * - Sortable document lists
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <FileRepeaterField
+ *   label="Attachments"
+ *   field="attachments"
+ *   urlField="file.url"
+ *   orderBy="createdAt"
+ * />
+ * ```
+ *
+ * ## Example: Sortable with baseField and some optional props
+ * ```tsx
+ * <FileRepeaterField
+ *   field="attachments"
+ *   baseField="file"
+ *   urlField="url"
+ *   sortableBy="order"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   label="File"
+ * />
+ * ```
+ */
 export const FileRepeaterField = Component<FileRepeaterFieldProps>(props => (
 	<>
 		<FileRepeaterFieldInner {...props} fileType={createAnyFileType(props)}>

--- a/packages/react-ui-lib/src/form/upload.tsx
+++ b/packages/react-ui-lib/src/form/upload.tsx
@@ -39,6 +39,44 @@ export type ImageFieldProps =
 	& BaseUploadFieldProps
 	& ImageFileTypeProps
 
+/**
+ * ImageField component - Specialized file upload for images
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Features
+ * - Handles image file uploads with preview
+ * - Supports common image formats (from ImageFileTypeProps)
+ * - Integrated drag-and-drop zone
+ * - Auto-generated preview using UploadedImageView
+ * - Optional custom destruction control
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <ImageField
+ *   label="Profile Picture"
+ *   urlField="avatar.url"
+ *   dropzonePlaceholder="Drag image here"
+ * />
+ * ```
+ *
+ * ## Example: With baseField and metadata fields
+ * ```tsx
+ * <ImageField
+ *   baseField="image"
+ *   urlField="url"
+ *   widthField="width"
+ *   heightField="height"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   label="Image file"
+ *   description="Some description of the image file."
+ * />
+ * ```
+ */
 export const ImageField = Component<ImageFieldProps>(props => (
 	<UploadFieldInner {...props} fileType={createImageFileType(props)}>
 		{props.children ?? <UploadedImageView {...props} DestroyAction={DisconnectEntityTrigger} />}
@@ -49,6 +87,32 @@ export type AudioFieldProps =
 	& BaseUploadFieldProps
 	& AudioFileTypeProps
 
+/**
+ * `AudioField` is a specialized upload component for handling audio files. It provides built-in file validation, an audio preview, and metadata tracking.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <AudioField
+ *   label="Podcast File"
+ *   urlField="audio.url"
+ * />
+ * ```
+ *
+ * ## Example: With metadata fields
+ * ```tsx
+ * <AudioField
+ *   label="Podcast File"
+ *   baseField="audio"
+ *   urlField="url"
+ *   durationField="duration"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   accept={{ 'audio/*': ['.mp3', '.wav', '.ogg'] }}
+ * />
+ * ```
+ */
 export const AudioField = Component<AudioFieldProps>(props => (
 	<UploadFieldInner {...props} fileType={createAudioFileType(props)}>
 		{props.children ?? <UploadedAudioView {...props} DestroyAction={DisconnectEntityTrigger} />}
@@ -59,6 +123,32 @@ export type VideoFieldProps =
 	& BaseUploadFieldProps
 	& VideoFileTypeProps
 
+/**
+ * `VideoField` is a specialized upload component for handling video files with built-in preview capabilities.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <VideoField
+ *   label="Demo Video"
+ *   urlField="video.url"
+ * />
+ * ```
+ *
+ * ## Example: With metadata fields
+ * ```tsx
+ * <VideoField
+ *   label="Demo Video"
+ *   baseField="video"
+ *   urlField="url"
+ *   durationField="duration"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   accept={{ 'video/*': ['.mp4', '.webm', '.ogg'] }}
+ * />
+ * ```
+ */
 export const VideoField = Component<VideoFieldProps>(props => (
 	<UploadFieldInner {...props} fileType={createVideoFileType(props)}>
 		{props.children ?? <UploadedVideoView {...props} DestroyAction={DisconnectEntityTrigger} />}
@@ -69,6 +159,29 @@ export type FileFieldProps =
 	& BaseUploadFieldProps
 	& AnyFileTypeProps
 
+/**
+ * `FileField` is a generic file upload component that supports any file type.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <FileField label="Document" urlField="file.url" />
+ * ```
+ *
+ * ## Example: With metadata fields and custom dropzone placeholder
+ * ```tsx
+ * <FileField
+ *   label="Document"
+ *   baseField="document"
+ *   urlField="file.url"
+ *   fileNameField="fileName"
+ *   fileSizeField="fileSize"
+ *   fileTypeField="fileType"
+ *   lastModifiedField="lastModified"
+ *   dropzonePlaceholder="Drag PDF here"
+ *   accept={{ 'application/*': ['.pdf'] }}
+ * />
+ * ```
+ */
 export const FileField = Component<FileFieldProps>(props => (
 	<UploadFieldInner {...props} fileType={createAnyFileType(props)}>
 		{props.children ?? <UploadedAnyView {...props} DestroyAction={DisconnectEntityTrigger} />}

--- a/packages/react-ui-lib/src/formatting/formatting.ts
+++ b/packages/react-ui-lib/src/formatting/formatting.ts
@@ -1,6 +1,17 @@
 import { SchemaColumn } from '@contember/interface'
 import { dict } from '@contember/react-ui-lib-base'
 
+/**
+ * Formats a date string into a localized date format.
+ *
+ * Converts ISO date strings to human-readable date format using browser locale settings.
+ * Handles null values gracefully.
+ *
+ * ## Example
+ * ```ts
+ * formatDate('2023-10-05') // '10/5/2023' (en-US locale)
+ * ```
+ */
 export const formatDate = (date: string | null) => {
 	if (date === null) {
 		return null
@@ -9,6 +20,16 @@ export const formatDate = (date: string | null) => {
 	return d.toLocaleDateString()
 }
 
+/**
+ * Formats a date string with a time component in a localized format.
+ *
+ * Shows both date and time including hours, minutes, and seconds. Respects system timezone.
+ *
+ * ## Example
+ * ```ts
+ * formatDateTime('2023-10-05T14:30:00') // '10/5/2023, 2:30:00 PM'
+ * ```
+ */
 export const formatDateTime = (date: string | null) => {
 	if (date === null) {
 		return null
@@ -17,6 +38,16 @@ export const formatDateTime = (date: string | null) => {
 	return d.toLocaleString()
 }
 
+/**
+ * Converts boolean values to localized strings using the application dictionary.
+ *
+ * Returns null for null input.
+ *
+ * ## Example
+ * ```ts
+ * formatBoolean(true) // 'Yes' (depending on dict)
+ * ```
+ */
 export const formatBoolean = (value: boolean | null) => {
 	if (value === null) {
 		return null
@@ -24,6 +55,17 @@ export const formatBoolean = (value: boolean | null) => {
 	return value ? dict.boolean.true : dict.boolean.false
 }
 
+/**
+ * Factory function that creates an enum value to label converter.
+ *
+ * Maps enum keys to human-readable labels. Handles null values and is case-sensitive.
+ *
+ * ## Example
+ * ```ts
+ * const formatStatus = createEnumFormatter({ DRAFT: 'Draft', PUBLISHED: 'Published' })
+ * formatStatus('DRAFT') // 'Draft'
+ * ```
+ */
 export const createEnumFormatter = (enumValues: Record<string, string>) => (value: string | null) => {
 	if (value === null) {
 		return null
@@ -31,6 +73,15 @@ export const createEnumFormatter = (enumValues: Record<string, string>) => (valu
 	return enumValues[value]
 }
 
+/**
+ * Wraps a formatter to provide a fallback value for null inputs.
+ *
+ * ## Example
+ * ```ts
+ * const safeFormat = withFallback(formatDate, 'Unknown date')
+ * safeFormat(null) // 'Unknown date'
+ * ```
+ */
 export const withFallback = <T>(formatter: (value: T) => string, fallback: string) => (value: T | null) => {
 	if (value === null) {
 		return fallback
@@ -38,6 +89,16 @@ export const withFallback = <T>(formatter: (value: T) => string, fallback: strin
 	return formatter(value)
 }
 
+/**
+ * Formats numbers with locale-aware thousand separators.
+ *
+ * Handles integers and floats. Respects browser locale.
+ *
+ * ## Example
+ * ```ts
+ * formatNumber(1234.5) // '1,234.5' (en-US)
+ * ```
+ */
 export const formatNumber = (value: number | null) => {
 	if (value === null) {
 		return null
@@ -45,6 +106,16 @@ export const formatNumber = (value: number | null) => {
 	return value.toLocaleString()
 }
 
+/**
+ * Converts raw byte counts to human-readable file sizes.
+ *
+ * Automatically selects the appropriate unit (KB, MB, GB, etc.) and supports configurable decimal precision.
+ *
+ * ## Example
+ * ```ts
+ * formatBytes(2048) // '2.0 KB'
+ * ```
+ */
 export const formatBytes = (bytes: number, decimals = 1) => {
 	if (bytes === 0) return '0 Bytes'
 	const k = 1024
@@ -54,16 +125,50 @@ export const formatBytes = (bytes: number, decimals = 1) => {
 	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 }
 
+/**
+ * Converts a duration in seconds to `mm:ss` format.
+ *
+ * Pads seconds with a leading zero. Handles durations over 60 minutes correctly.
+ *
+ * ## Example
+ * ```ts
+ * formatDuration(125) // '2:05'
+ * ```
+ */
 export const formatDuration = (duration: number) => {
 	const minutes = Math.floor(duration / 60)
 	const seconds = duration % 60
 	return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
+/**
+ * Pretty-prints a JSON value with 2-space indentation.
+ *
+ * ## Example
+ * ```ts
+ * formatJson({ key: 'value' }) // '{\n  "key": "value"\n}'
+ * ```
+ */
 export const formatJson = (value: any) => {
 	return JSON.stringify(value, null, 2)
 }
 
+/**
+ * Selects the appropriate formatter based on a schema column type.
+ *
+ * Mapping:
+ * - `Date` → {@link formatDate}
+ * - `DateTime` → {@link formatDateTime}
+ * - `Bool` → {@link formatBoolean}
+ * - `Integer` / `Float` → {@link formatNumber}
+ * - `Json` → {@link formatJson}
+ * - Other → identity formatter
+ *
+ * ## Example
+ * ```ts
+ * getFormatter({ type: 'Date' })('2023-10-05') // formatted date string
+ * ```
+ */
 export const getFormatter = (schema: SchemaColumn) => {
 	switch (schema.type) {
 		case 'Date':

--- a/packages/react-ui-lib/src/images/formatImageResizeUrl.ts
+++ b/packages/react-ui-lib/src/images/formatImageResizeUrl.ts
@@ -1,12 +1,31 @@
 export interface ImageResizeOptions {
+	/** Target width in pixels */
 	width?: number
+	/** Target height in pixels */
 	height?: number
+	/** Gaussian blur radius (0-100) */
 	blur?: number
+	/** Output quality (1-100) */
 	quality?: number
+	/** Resize behavior */
 	fit?: 'scale-down' | 'contain' | 'cover' | 'crop' | 'pad'
+	/** Output format */
 	format?: 'auto' | 'avif' | 'webp' | 'jpeg' | 'baseline-jpeg' | 'json'
 }
 
+/**
+ * Generates an optimized image URL using on-demand image processing.
+ *
+ * Only processes Contember-hosted images (URLs containing `cntmbr.com`).
+ * For external images the original URL is returned unchanged.
+ * Defaults to `contain` fit and `auto` format when not specified.
+ *
+ * ## Example
+ * ```ts
+ * formatImageResizeUrl('https://cdn.cntmbr.com/image.jpg', { width: 300 })
+ * // 'https://cdn.cntmbr.com/cdn-cgi/image/width=300,fit=contain,f=auto/image.jpg'
+ * ```
+ */
 export const formatImageResizeUrl = (src: string, options?: ImageResizeOptions) => {
 	const url = new URL(src)
 

--- a/packages/react-ui-lib/src/repeater/repeater.tsx
+++ b/packages/react-ui-lib/src/repeater/repeater.tsx
@@ -41,6 +41,10 @@ const RepeaterEmptyUI = uic('div', {
 	baseClass: 'italic text-sm text-gray-600',
 })
 
+/**
+ * A visual indicator for sortable repeater items,
+ * showing where an item will be dropped. It adapts its placement based on the `position` prop.
+ */
 export const RepeaterDropIndicator = ({ position }: { position: 'before' | 'after' }) => (
 	<div className={'relative'}>
 		<RepeaterSortableDropIndicator position={position}>
@@ -49,6 +53,11 @@ export const RepeaterDropIndicator = ({ position }: { position: 'before' | 'afte
 	</div>
 )
 
+/**
+ * A button that adds a new item to a repeater at a specified index.
+ * It wraps the `RepeaterAddItemTrigger` and displays customizable content.
+ * By default, it shows a plus icon alongside a localized label.
+ */
 export const RepeaterAddItemButton = ({ children, index }: { children?: React.ReactNode; index?: RepeaterAddItemIndex }) => (
 	<RepeaterAddItemTrigger index={index}>
 		<div>
@@ -65,7 +74,9 @@ export const RepeaterAddItemButton = ({ children, index }: { children?: React.Re
 )
 
 /**
- * A button that removes the item from the repeater.
+ * A button that removes an item from a repeater.
+ * It wraps the `RepeaterRemoveItemTrigger` and displays a customizable child element.
+ * By default, it shows a trash icon that turns red on hover.
  */
 export const RepeaterRemoveItemButton = ({ children }: { children?: React.ReactNode }) => (
 	<RepeaterRemoveItemTrigger>
@@ -86,22 +97,28 @@ export const RepeaterItemActions = uic('div', {
 	baseClass: 'absolute top-1 right-2 flex gap-2',
 })
 
+/**
+ * Props for the {@link DefaultRepeater} component.
+ */
 export type DefaultRepeaterProps =
 	& {
+		/**
+		 * Optional repeater title.
+		 */
 		title?: ReactNode
 		/**
-		 * Position of the add button.
+		 * Optional position of the add button.
 		 */
 		addButtonPosition?: 'none' | 'after' | 'before' | 'around'
+		/**
+		 * Optional label of the add button.
+		 */
 		addButtonLabel?: ReactNode
 	}
 	& RepeaterProps
 
 /**
  * DefaultRepeater is a wrapper around Repeater that provides a default UI for a list of items.
- *
- * ## Props {@link DefaultRepeaterProps}
- * - field or entities, sortableBy or orderBy, addButtonPosition, title
  *
  * ## Example
  * ```tsx

--- a/packages/react-ui-lib/src/select/create-new.tsx
+++ b/packages/react-ui-lib/src/select/create-new.tsx
@@ -5,6 +5,22 @@ import { SelectItemTrigger, SelectNewItem } from '@contember/react-select'
 import { dict } from '@contember/react-ui-lib-base'
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogTrigger } from '@contember/react-ui-lib-base'
 
+/**
+ * `CreateEntityDialog` is a modal component that facilitates the creation of a new entity.
+ * It integrates entity selection functionality with confirmation and cancellation actions.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <CreateEntityDialog
+ *   trigger={<Button>Create New Entity</Button>}
+ * >
+ *   <EntityForm />
+ * </CreateEntityDialog>
+ * ```
+ *
+ * @group SelectInput
+ * @group MultiSelectInput
+ */
 export const CreateEntityDialog = ({ trigger, children }: { trigger: ReactElement; children: ReactNode }) => {
 	return (
 		<Dialog>

--- a/packages/react-ui-lib/src/select/filter.tsx
+++ b/packages/react-ui-lib/src/select/filter.tsx
@@ -4,6 +4,12 @@ import { DataViewHasFilterType, DataViewQueryFilterName, DataViewTextFilterInput
 import { dict } from '@contember/react-ui-lib-base'
 import { memo } from 'react'
 
+/**
+ * `SelectDefaultFilter` is component for filtering data in a `SelectDataView`.
+ * It checks if a specific filter type exists and, if so, renders a text input for filtering.
+ *
+ * @group SelectInput
+ */
 export const SelectDefaultFilter = memo(() => (
 	<DataViewHasFilterType name={DataViewQueryFilterName}>
 		<DataViewTextFilterInput name={DataViewQueryFilterName}>

--- a/packages/react-ui-lib/src/select/highlight.tsx
+++ b/packages/react-ui-lib/src/select/highlight.tsx
@@ -1,6 +1,22 @@
 import { useCallback } from 'react'
 import { DataViewHighlightEvent } from '@contember/react-dataview'
 
+/**
+ * `useOnHighlight` is a hook that returns a callback function to handle the highlight event of a data view.
+ *
+ * ## Requirements
+ * - Must be used within an Entity context (`<EntitySubTree />` or `<EntityListSubTree />`).
+ *
+ * ## Usage
+ * ```tsx
+ * const onHighlight = useOnHighlight()
+ * ...
+ * <DataView onHighlight={onHighlight} />
+ * ```
+ *
+ * @group SelectInput
+ * @group MultiSelectInput
+ */
 export const useOnHighlight = () => {
 	return useCallback((event: DataViewHighlightEvent) => {
 		const scrollArea = event.element.closest('[data-radix-scroll-area-viewport]')

--- a/packages/react-ui-lib/src/select/list.tsx
+++ b/packages/react-ui-lib/src/select/list.tsx
@@ -21,12 +21,36 @@ import { SelectDefaultFilter } from './filter.js'
 import { SelectListItemUI } from './ui.js'
 import { SelectDataView, SelectItemTrigger, SelectOption } from '@contember/react-select'
 
+/**
+ * Props for {@link DefaultSelectDataView}.
+ */
 export interface DefaultSelectDataViewProps {
+	/**
+	 * Optional field used for querying the data view.
+	 */
 	queryField?: DataViewUnionFilterFields
+	/**
+	 * Optional initial sorting direction for the data view.
+	 */
 	initialSorting?: DataViewSortingDirections
+	/**
+	 * Children elements to be rendered inside the default data view renderer.
+	 */
 	children: ReactNode
 }
 
+/**
+ * `DefaultSelectDataView` provides a wrapper around `SelectDataView` with a default renderer. It simplifies setting up a data view selection with initial sorting and query field options.
+ *
+ * Must be used inside a context where `SelectDataView` is valid.
+ *
+ * ## Example: Basic usage
+ * ```tsx
+ * <DefaultSelectDataView queryField="status" initialSorting="asc">
+ *   <ItemRenderer />
+ * </DefaultSelectDataView>
+ * ```
+ */
 export const DefaultSelectDataView = Component<DefaultSelectDataViewProps>(({ children, initialSorting, queryField }) => {
 	return (
 		<>

--- a/packages/react-ui-lib/src/select/multi-select.tsx
+++ b/packages/react-ui-lib/src/select/multi-select.tsx
@@ -22,15 +22,52 @@ import {
 } from './ui.js'
 
 export type MultiSelectInputProps = {
+	/** Specifies the field to bind the selection to. */
 	field: SugaredRelativeEntityList['field']
+	/** An array of entities to populate the selection list. */
 	options?: SugaredQualifiedEntityList['entities']
+	/** React nodes for rendering the content of each selected item. */
 	children: ReactNode
+	/** Custom placeholder text when no items are selected. */
 	placeholder?: ReactNode
+	/** Content for creating a new entity. */
 	createNewForm?: ReactNode
+	/** Field used for querying and filtering options. */
 	queryField?: DataViewUnionFilterFields
+	/** Defines the initial sorting order for the options. */
 	initialSorting?: DataViewSortingDirections
 }
 
+/**
+ * MultiSelectInput is a component for selecting multiple values from a list of options,
+ * with support for inline entity creation, filtering, and sorting.
+ *
+ * ## Example: Basic usage with inline entity creation
+ * ```tsx
+ * <MultiSelectInput
+ *   field="tags"
+ *   placeholder="Select tags"
+ *   createNewForm={<div>Form to create a new tag</div>}
+ *   initialSorting="ASC"
+ * >
+ *   <Field field="name" />
+ * </MultiSelectInput>
+ * ```
+ *
+ * ## Sub-components
+ * - {@link SelectInputWrapperUI}
+ * - {@link SelectInputUI}
+ * - {@link SelectDefaultPlaceholderUI}
+ * - {@link MultiSelectItemWrapperUI}
+ * - {@link MultiSelectItemUI}
+ * - {@link MultiSelectItemContentUI}
+ * - {@link SelectItemTrigger}
+ * - {@link MultiSelectItemRemoveButtonUI}
+ * - {@link SelectInputActionsUI}
+ * - {@link SelectPopoverContent}
+ * - {@link Popover}
+ * - {@link PopoverTrigger}
+ */
 export const MultiSelectInput = Component<MultiSelectInputProps>(
 	({ field, queryField, options, children, placeholder, createNewForm, initialSorting }) => {
 		const id = useFormFieldId()

--- a/packages/react-ui-lib/src/select/select.tsx
+++ b/packages/react-ui-lib/src/select/select.tsx
@@ -27,16 +27,54 @@ import { useFormFieldId } from '@contember/react-form'
 import { dict } from '@contember/react-ui-lib-base'
 
 export type SelectInputProps = {
+	/** The field to bind the selection to (`SugaredRelativeSingleEntity['field']`) */
 	field: SugaredRelativeSingleEntity['field']
+	/** React nodes for rendering each value or additional content inside the selection UI. */
 	children: ReactNode
+	/** Defines the entity options to be displayed. */
 	options?: SugaredQualifiedEntityList['entities']
+	/** Custom placeholder content when no value is selected. */
 	placeholder?: ReactNode
+	/** Content for creating a new entity, displayed within a `CreateEntityDialog`. */
 	createNewForm?: ReactNode
+	/** Specifies the field to query for filtering or sorting. */
 	queryField?: DataViewUnionFilterFields
+	/** Defines the initial sorting order of the options. */
 	initialSorting?: DataViewSortingDirections
+	/** Boolean flag to enforce validation for the selection input. */
 	required?: boolean
 }
 
+/**
+ * `SelectInput` is a versatile component for rendering a selectable input field with advanced functionality.
+ * It supports optional entity creation, validation, and sorting within the context of Contember's interface.
+ *
+ * ## Example: Basic usage with entity creation
+ * ```tsx
+ * <SelectInput
+ *   field="category"
+ *   placeholder="Select a category"
+ *   createNewForm={<div>Form for creating a new category</div>}
+ *   required
+ * >
+ *   <Field field="label" />
+ * </SelectInput>
+ * ```
+ *
+ * ## Sub-components
+ * - {@link SelectInputWrapperUI}
+ * - {@link SelectInputUI}
+ * - {@link SelectDefaultPlaceholderUI}
+ * - {@link SelectPlaceholder}
+ * - {@link SelectInputActionsUI}
+ * - {@link SelectListItemUI}
+ * - {@link SelectEachValue}
+ * - {@link SelectItemTrigger}
+ * - {@link SelectPopoverContent}
+ * - {@link DefaultSelectDataView}
+ * - {@link Popover}
+ * - {@link PopoverTrigger}
+ */
 export const SelectInput = Component<SelectInputProps>(
 	({ field, queryField, options, children, placeholder, createNewForm, initialSorting, required }) => {
 		const [open, setOpen] = React.useState(false)

--- a/packages/react-ui-lib/src/select/sortable-select.tsx
+++ b/packages/react-ui-lib/src/select/sortable-select.tsx
@@ -48,7 +48,9 @@ const MultiSortableSelectDropIndicator = ({ position }: { position: 'before' | '
 
 export type SortableMultiSelectInputProps = {
 	field: SugaredRelativeEntityList['field']
+	/** Field name used to store sort order */
 	sortableBy: SugaredRelativeSingleField['field']
+	/** Field name used to connect the selected entity */
 	connectAt: SugaredRelativeSingleEntity['field']
 	children: ReactNode
 	options?: SugaredQualifiedEntityList['entities']
@@ -58,6 +60,13 @@ export type SortableMultiSelectInputProps = {
 	initialSorting?: DataViewSortingDirections
 }
 
+/**
+ * `SortableMultiSelectInput` is the UI for the sortable multi select input.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group SortableMultiSelectField
+ */
 export const SortableMultiSelectInput = Component<SortableMultiSelectInputProps>(
 	({ field, queryField, options, children, sortableBy, connectAt, placeholder, createNewForm, initialSorting }) => {
 		const id = useFormFieldId()

--- a/packages/react-ui-lib/src/select/ui.tsx
+++ b/packages/react-ui-lib/src/select/ui.tsx
@@ -6,10 +6,24 @@ import { CheckIcon, PlusIcon, XIcon } from 'lucide-react'
 import { PopoverContent } from '@contember/react-ui-lib-base'
 import { dict } from '@contember/react-ui-lib-base'
 
+/**
+ * `SelectInputWrapperUI` is the UI input wrapper for the select component.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ */
 export const SelectInputWrapperUI = uic('div', {
 	baseClass: 'w-full max-w-md relative',
 })
 
+/**
+ * `SelectInputUI` is the UI input wrapper for the select component.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ */
 export const SelectInputUI = uic('button', {
 	baseClass: [
 		'flex gap-2 justify-between items-center',
@@ -25,10 +39,25 @@ export const SelectInputUI = uic('button', {
 		'disabled:cursor-not-allowed disabled:opacity-50',
 	],
 })
+/**
+ * `SelectInputActionsUI` is the UI for the select action.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ * @group MultiSelectInput
+ */
 export const SelectInputActionsUI = uic('span', {
 	baseClass: 'flex gap-1 items-center',
 })
 
+/**
+ * `SelectListItemUI` is the UI for the select items list.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ */
 export const SelectListItemUI = uic(Button, {
 	baseClass: 'w-full text-left justify-start gap-1 data-[highlighted]:bg-gray-200 data-[selected]:bg-gray-100 group relative min-h-8 h-auto',
 	defaultProps: {
@@ -38,23 +67,76 @@ export const SelectListItemUI = uic(Button, {
 	afterChildren: <CheckIcon className="h-3 w-3 opacity-0 group-data-[selected]:opacity-100 ml-auto" />,
 })
 
+/**
+ * `SelectDefaultPlaceholderUI` is the UI for the select default placeholder.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ * @group MultiSelectInput
+ */
 export const SelectDefaultPlaceholderUI = () => <span className={'text-gray-400'}>{dict.select.placeholder}</span>
+
+/**
+ * `MultiSelectItemWrapperUI` is the UI for the multi-select item wrapper.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group MultiSelectInput
+ */
 export const MultiSelectItemWrapperUI = uic('div', {
 	baseClass: 'flex flex-wrap gap-1 items-center justify-start',
 })
+/**
+ * `MultiSelectItemUI` is the UI for the multi-select item.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group MultiSelectInput
+ */
 export const MultiSelectItemUI = uic('span', {
 	baseClass: 'flex items-stretch border border-gray-200 rounded-sm hover:shadow-sm transition-all',
 })
+
+/**
+ * `MultiSelectItemContentUI` is the UI for the multi-select item content.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group MultiSelectInput
+ */
 export const MultiSelectItemContentUI = uic('span', {
 	baseClass: 'rounded-l px-2 py-1 bg-background  ',
 })
+/**
+ * `MultiSelectSortableItemContentUI` is the UI for the multi-select sortable item content.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group MultiSelectInput
+ */
 export const MultiSelectSortableItemContentUI = uic('span', {
 	baseClass: 'rounded-l px-2 py-1 bg-background hover:bg-gray-50 cursor-move transition-all',
 })
+
+/**
+ * `MultiSelectItemDragOverlayUI` is the UI for the multi-select item drag overlay.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group MultiSelectInput
+ */
 export const MultiSelectItemDragOverlayUI = uic('span', {
 	baseClass: 'rounded-sm px-2 py-1 bg-gray-100/20 inline-flex gap-2 items-center backdrop-blur-sm text-sm border border-gray-200 shadow-sm',
 })
 
+/**
+ * `MultiSelectItemRemoveButtonUI` is the UI for the multi-select item remove button.
+ *
+ * See more {@link MultiSelectInput}
+ *
+ * @group MultiSelectInput
+ */
 export const MultiSelectItemRemoveButtonUI = uic('span', {
 	baseClass: 'bg-gray-100 border-l border-gray-200 py-1 px-2 rounded-r text-black inline-flex items-center justify-center hover:bg-gray-300',
 	afterChildren: <XIcon className={'w-3 h-3'} />,
@@ -70,6 +152,13 @@ export const MultiSelectItemRemoveButtonUI = uic('span', {
 	},
 })
 
+/**
+ * `SelectPopoverContent` is the UI for the select popover content.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ */
 export const SelectPopoverContent = uic(PopoverContent, {
 	baseClass: 'group w-[max(16rem,var(--radix-popover-trigger-width))]',
 	defaultProps: {
@@ -77,6 +166,13 @@ export const SelectPopoverContent = uic(PopoverContent, {
 	},
 })
 
+/**
+ * `SelectCreateNewTrigger` is the UI for the select create new trigger.
+ *
+ * See more {@link SelectInput}
+ *
+ * @group SelectInput
+ */
 export const SelectCreateNewTrigger = forwardRef<HTMLButtonElement, {}>((props, ref) => (
 	<Button variant="outline" size="icon" ref={ref} {...props}>
 		<PlusIcon className="w-3 h-3" />

--- a/packages/react-ui-lib/src/upload/dropzone.tsx
+++ b/packages/react-ui-lib/src/upload/dropzone.tsx
@@ -7,6 +7,23 @@ import { UploadIcon } from 'lucide-react'
 import { dict } from '@contember/react-ui-lib-base'
 import { Button } from '@contember/react-ui-lib-base'
 
+/**
+ * `UploaderDropzone` renders a file drop area UI for uploading files, with optional
+ * placeholder customization and conditional display of a loader while uploads are in progress.
+ *
+ * Requires usage within an uploader context providing file upload state.
+ *
+ * - Displays a loader when uploads are active and `inactiveOnUpload` is `true`
+ * - Supports custom placeholder content via `dropzonePlaceholder`
+ *
+ * ## Example: Basic usage with custom placeholder
+ * ```tsx
+ * <UploaderDropzone
+ *   inactiveOnUpload
+ *   dropzonePlaceholder={<div>Drop files here or click to upload</div>}
+ * />
+ * ```
+ */
 export const UploaderDropzone = ({ inactiveOnUpload, dropzonePlaceholder }: { inactiveOnUpload?: boolean; dropzonePlaceholder?: ReactNode }) => {
 	const filesInProgress = useUploaderStateFiles({ state: ['uploading', 'initial', 'finalizing'] })
 	const showLoader = inactiveOnUpload && filesInProgress.length > 0

--- a/packages/react-ui-lib/src/upload/repeater.tsx
+++ b/packages/react-ui-lib/src/upload/repeater.tsx
@@ -2,6 +2,10 @@ import { DropIndicator } from '@contember/react-ui-lib-base'
 import * as React from 'react'
 import { RepeaterSortableDropIndicator } from '@contember/react-repeater-dnd-kit'
 
+/**
+ * UploaderRepeaterDropIndicator is a component that renders a drop indicator for a repeater.
+ * It is used to indicate where an item can be dropped in a repeater.
+ */
 export const UploaderRepeaterDropIndicator = ({ position }: { position: 'before' | 'after' }) => (
 	<div className={'relative'}>
 		<RepeaterSortableDropIndicator position={position}>

--- a/packages/react-utils/src/hooks/useStoredState.ts
+++ b/packages/react-utils/src/hooks/useStoredState.ts
@@ -12,6 +12,16 @@ export interface StateStorage {
 	setItem(key: StateStorageKey, value: Serializable): void
 }
 
+/**
+ * `urlStateStorage` is a `StateStorage` implementation that persists state in the URL query parameters.
+ * This allows state persistence across page reloads and enables sharing state via URL.
+ *
+ * ## Example: Storing state in the URL
+ * ```tsx
+ * urlStateStorage.setItem(['app', 'theme'], 'dark'); // URL updates to: `?theme="dark"`
+ * console.log(urlStateStorage.getItem(['app', 'theme'])); // Output: "dark"
+ * ```
+ */
 export const urlStateStorage: StateStorage = {
 	getItem(key) {
 		const searchParams = new URLSearchParams(window.location.search)
@@ -38,7 +48,31 @@ const createStateStorageFromNativeStorage = (getStorage: () => Storage): StateSt
 	}
 }
 
+/**
+ * A `StateStorage` instance that persists state using `sessionStorage`.
+ *
+ * This storage mechanism automatically serializes and deserializes stored values using JSON.
+ * It is useful for storing temporary state that should persist across page reloads but be cleared when the session ends.
+ *
+ * ## Example: Storing a theme preference in session storage
+ * ```tsx
+ * sessionStateStorage.setItem(['app', 'theme'], 'dark');
+ * console.log(sessionStateStorage.getItem(['app', 'theme'])); // Output: "dark"
+ * ```
+ */
 export const sessionStateStorage = createStateStorageFromNativeStorage(() => sessionStorage)
+/**
+ * A `StateStorage` instance that persists state using `localStorage`.
+ *
+ * This storage mechanism automatically serializes and deserializes stored values using JSON.
+ * It is useful for storing persistent state that remains available even after closing and reopening the browser.
+ *
+ * ## Example: Storing a username in local storage
+ * ```tsx
+ * localStateStorage.setItem(['user', 'name'], 'Alice');
+ * console.log(localStateStorage.getItem(['user', 'name'])); // Output: "Alice"
+ * ```
+ */
 export const localStateStorage = createStateStorageFromNativeStorage(() => localStorage)
 export const nullStorage: StateStorage = {
 	getItem() {
@@ -57,6 +91,24 @@ const builtInStorages = {
 
 export type StateStorageOrName = StateStorage | 'url' | 'session' | 'local' | 'null'
 
+/**
+ * `useStoredState` provides a persistent state using different storage options such as
+ * URL, `sessionStorage`, `localStorage`, or a custom storage mechanism.
+ *
+ * This hook initializes state from the selected storage and updates it whenever the state changes.
+ *
+ * ## Example: Using session storage
+ * ```tsx
+ * const [count, setCount] = useStoredState<number>('session', ['app', 'counter'], storedValue => storedValue ?? 0);
+ *
+ * return (
+ *   <div>
+ *     <p>Count: {count}</p>
+ *     <button onClick={() => setCount(prev => prev + 1)}>Increment</button>
+ *   </div>
+ * );
+ * ```
+ */
 export const useStoredState = <V extends Serializable>(
 	storageOrName: StateStorageOrName | StateStorageOrName[],
 	key: StateStorageKey,
@@ -82,14 +134,67 @@ export const useStoredState = <V extends Serializable>(
 	]
 }
 
+/**
+ * `useSessionStorageState` is a specialized hook for persisting state in `sessionStorage`.
+ * It initializes state from `sessionStorage` on first render and updates it whenever the state changes.
+ *
+ * ## Example: Persisting theme in session storage
+ * ```tsx
+ * const [theme, setTheme] = useSessionStorageState(['app', 'theme'], storedValue => storedValue ?? 'light');
+ *
+ * return (
+ *   <div>
+ *     <p>Current Theme: {theme}</p>
+ *     <button onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}>
+ *       Toggle Theme
+ *     </button>
+ *   </div>
+ * );
+ * ```
+ */
 export const useSessionStorageState = <V extends Serializable>(key: StateStorageKey, initializeValue: ValueInitializer<V>): [V, SetState<V>] => {
 	return useStoredState<V>(sessionStateStorage, key, initializeValue)
 }
 
+/**
+ * `useLocalStorageState` is a specialized hook for persisting state in `localStorage`.
+ * It initializes state from `localStorage` on first render and updates it whenever the state changes.
+ *
+ * ## Example: Persisting username in local storage
+ * ```tsx
+ * const [username, setUsername] = useLocalStorageState(['user', 'name'], storedValue => storedValue ?? 'Guest');
+ *
+ * return (
+ *   <div>
+ *     <p>Username: {username}</p>
+ *     <input
+ *       type="text"
+ *       value={username}
+ *       onChange={(e) => setUsername(e.target.value)}
+ *       placeholder="Enter your name"
+ *     />
+ *   </div>
+ * );
+ * ```
+ */
 export const useLocalStorageState = <V extends Serializable>(key: StateStorageKey, initializeValue: ValueInitializer<V>): [V, SetState<V>] => {
 	return useStoredState<V>(localStateStorage, key, initializeValue)
 }
 
+/**
+ * Retrieves the appropriate storage mechanism based on the provided storage type or custom storage instance.
+ * Supports fallback mechanisms when multiple storage options are provided as an array.
+ *
+ * ## Example: Using a single storage type
+ * ```tsx
+ * const storage = getStateStorage('local'); // Retrieves localStorage
+ * ```
+ *
+ * ## Example: Using fallback storages
+ * ```tsx
+ * const storage = getStateStorage(['session', 'local']); // Uses sessionStorage, falls back to localStorage
+ * ```
+ */
 export const getStateStorage = (storageOrName: StateStorageOrName | StateStorageOrName[]) => {
 	if (Array.isArray(storageOrName)) {
 		return createFallbackStorage(storageOrName.map(it => typeof it === 'string' ? builtInStorages[it] : it))


### PR DESCRIPTION
Adds prop-level JSDoc comments with usage examples across `react-ui-lib` and related `react-*` component packages (datagrid, select, editor, form, upload, repeater, binding, dataview helpers, …).

**Documentation only — no code changes.** Verified: the source diff is comment-only (0 code lines added/removed, no behavioral changes).

### Why a new PR (supersedes #697)
#697 was ~412 commits stale and built on the old **Docusaurus** docs system, which `main` has since replaced with **Pletivo** (hand-authored content collections). On top of that, its `packages/` diff mixed the JSDoc with unrelated stale code (an i18n refactor `main` never adopted, type extractions, reformatting), so a plain rebase would have dragged that in.

This PR keeps only the durable value — the JSDoc prose — re-applied onto **current `main`**:
- Dropped the obsolete Docusaurus docs system and AI-generation tooling from #697.
- Skipped files `main` already documents (e.g. all of `react-dataview`, already covered by the earlier `762fa9eea`) and thin UI primitives/utilities.
- Adapted every doc block to `main`'s current API (renamed/removed props, package split into `react-ui-lib-base`/`-tenant`); examples adjusted to compile against current exports.
- Example headings normalized to `main`'s `## Example` convention.

### API reports
`build/api/*.api.md` regenerated via `bun run ae:update`. The only change is clearing `@public (undocumented)` markers for the now-documented symbols — **no API signatures changed**.

Closes #697.