### PR TITLE
feat(actions): observability for the dispatch loop (Prometheus metrics + self-healing idle wait)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -255,6 +255,7 @@
         "@contember/typesafe": "workspace:*",
         "@graphql-tools/schema": "catalog:",
         "graphql-tag": "catalog:",
+        "prom-client": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",

--- a/packages/engine-actions/CLAUDE.md
+++ b/packages/engine-actions/CLAUDE.md
@@ -39,6 +39,24 @@ Mutations: `processBatch`, `retryEvent`, `stopEvent`, `setVariables` (MERGE/SET/
 
 Queries: `failedEvents`, `eventsToProcess`, `eventsInProcessing`, `event`, `variables`
 
+## Observability (`ActionsMetrics`)
+
+Cheap in-memory Prometheus metrics (no table polling), registered onto the engine's shared registry
+via `getMasterContainerHook`, labelled by `contember_project`:
+
+- `contember_actions_events_enqueued_total` — inflow (from `TriggerPayloadPersister`, pre-commit)
+- `contember_actions_events_succeeded_total` — terminal success
+- `contember_actions_delivery_attempts_failed_total` — failed webhook attempts (incl. retries)
+- `contember_actions_events_failed_total` — terminal failures (retries exhausted or unknown target)
+- `contember_actions_worker_heartbeat_timestamp_seconds` — gauge set each loop iteration; staleness ⇒ stuck/dead worker
+- `contember_actions_worker_crashed_total` — dispatch-loop crashes (each auto-restarted by the supervisor)
+
+Backlog is *estimated* as a trend: `enqueued − succeeded − failed` (rate comparison; the absolute value
+drifts across restarts and ignores manual retry/stop — query `actions_event` for an exact depth).
+
+The `ProjectDispatcher` idle wait is capped at `MAX_IDLE_SLEEP_MS` (30s) even when the queue is empty,
+so a lost `pg_notify` self-heals and the heartbeat keeps refreshing while idle.
+
 ## Plugin Integration
 
 Implements `Plugin` interface with:

--- a/packages/engine-actions/package.json
+++ b/packages/engine-actions/package.json
@@ -37,7 +37,8 @@
     "@contember/schema-utils": "workspace:*",
     "@contember/typesafe": "workspace:*",
     "@graphql-tools/schema": "catalog:",
-    "graphql-tag": "catalog:"
+    "graphql-tag": "catalog:",
+    "prom-client": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/engine-actions/src/ActionsExecutionContainerHookFactory.ts
+++ b/packages/engine-actions/src/ActionsExecutionContainerHookFactory.ts
@@ -3,10 +3,14 @@ import { ListenerStoreProvider } from './ListenerStoreProvider.js'
 import { TriggerPayloadBuilder } from './triggers/TriggerPayloadBuilder.js'
 import { TriggerPayloadPersister } from './triggers/TriggerPayloadPersister.js'
 import { ExecutionContainerHook } from '@contember/engine-content-api'
+import { ActionsMetrics } from './ActionsMetrics.js'
 
 export class ActionsExecutionContainerHookFactory {
 	constructor(
 		private readonly listenerStoreProvider: ListenerStoreProvider,
+		// Resolved lazily: the metrics singleton lives in the master container and is wired up when the
+		// dispatch worker boots, which precedes any content request that could enqueue an event.
+		private readonly metricsProvider: () => ActionsMetrics | undefined,
 	) {
 	}
 
@@ -18,6 +22,7 @@ export class ActionsExecutionContainerHookFactory {
 					mapperFactory,
 					{ whereBuilder, schema, pathFactory, systemSchema, providers, stage, project, schemaMeta, joinBuilder, userInfo, triggeredActionsCollector },
 				) => {
+					const projectMetrics = this.metricsProvider()?.forProject(project.slug)
 					mapperFactory.hooks.push(mapper => {
 						const triggerPayloadPersister = new TriggerPayloadPersister(
 							mapper,
@@ -29,6 +34,7 @@ export class ActionsExecutionContainerHookFactory {
 							mapper.identityId,
 							userInfo,
 							triggeredActionsCollector,
+							projectMetrics,
 						)
 						const triggerPayloadBuilder = new TriggerPayloadBuilder(mapper)
 						const payloadManager = new TriggerPayloadManager(triggerPayloadBuilder, triggerPayloadPersister)

--- a/packages/engine-actions/src/ActionsMetrics.ts
+++ b/packages/engine-actions/src/ActionsMetrics.ts
@@ -1,0 +1,135 @@
+import prom, { Registry } from 'prom-client'
+
+const LABEL_PROJECT = 'contember_project'
+type Label = typeof LABEL_PROJECT
+
+/**
+ * Prometheus metrics for the Actions dispatch subsystem.
+ *
+ * Two audiences, deliberately kept as cheap in-memory counters/gauges (no table polling):
+ *  - system / operator — is the dispatch loop alive and flowing, or stuck?
+ *      `workerHeartbeat` (liveness; works even when the queue is empty) + `workerCrashed`.
+ *  - userland — are webhook deliveries failing?
+ *      `eventsSucceeded` / `deliveryAttemptsFailed` / `eventsFailed`.
+ *
+ * Counting units matter: a *delivery attempt* and an *event* are different. A success is always
+ * terminal (one event = one successful attempt), but a failure splits — a failed attempt may be
+ * retried many times, while a terminally failed event gives up once. Hence the asymmetric set:
+ * one success counter, but both a per-attempt failure counter and a terminal-event failure counter.
+ *
+ * Queue backlog is *estimated* as a trend from the counters:
+ *   enqueued − succeeded − failed   (compare rates; the absolute value drifts across restarts and
+ *   ignores manual retry/stop, so for an exact depth query the `actions_event` table instead).
+ *
+ * Labelled only by `contember_project` to keep cardinality bounded; per-target / per-trigger
+ * detail belongs in the table-backed userland view, not in Prometheus.
+ */
+export class ActionsMetrics {
+	/** Events written to the queue (inflow). Unit: event. */
+	public readonly eventsEnqueued: prom.Counter<Label>
+	/** Events delivered successfully (terminal). Unit: event (= successful attempt). */
+	public readonly eventsSucceeded: prom.Counter<Label>
+	/** Failed webhook delivery attempts, including ones that will be retried. Unit: attempt. */
+	public readonly deliveryAttemptsFailed: prom.Counter<Label>
+	/** Events that reached a terminal failed state (retries exhausted or unknown target). Unit: event. */
+	public readonly eventsFailed: prom.Counter<Label>
+	/** Unix timestamp (seconds) of the last dispatch-loop iteration; staleness ⇒ stuck/dead worker. */
+	public readonly workerHeartbeat: prom.Gauge<Label>
+	/** Dispatch-loop crashes (each is auto-restarted by the supervisor). */
+	public readonly workerCrashed: prom.Counter<Label>
+
+	constructor(registry: Registry) {
+		const labelNames: Label[] = [LABEL_PROJECT]
+		this.eventsEnqueued = new prom.Counter({
+			registers: [registry],
+			name: 'contember_actions_events_enqueued_total',
+			help: 'Total number of action events written to the queue (inflow), by contember_project.',
+			labelNames,
+		})
+		this.eventsSucceeded = new prom.Counter({
+			registers: [registry],
+			name: 'contember_actions_events_succeeded_total',
+			help: 'Total number of action events delivered successfully, by contember_project.',
+			labelNames,
+		})
+		this.deliveryAttemptsFailed = new prom.Counter({
+			registers: [registry],
+			name: 'contember_actions_delivery_attempts_failed_total',
+			help: 'Total number of failed webhook delivery attempts (including attempts that will be retried), by contember_project.',
+			labelNames,
+		})
+		this.eventsFailed = new prom.Counter({
+			registers: [registry],
+			name: 'contember_actions_events_failed_total',
+			help: 'Total number of action events that reached a terminal failed state (retries exhausted or unknown target), by contember_project.',
+			labelNames,
+		})
+		this.workerHeartbeat = new prom.Gauge({
+			registers: [registry],
+			name: 'contember_actions_worker_heartbeat_timestamp_seconds',
+			help: 'Unix timestamp of the last dispatch-loop iteration per contember_project; staleness indicates a stuck or dead worker.',
+			labelNames,
+		})
+		this.workerCrashed = new prom.Counter({
+			registers: [registry],
+			name: 'contember_actions_worker_crashed_total',
+			help: 'Total number of dispatch-loop crashes per contember_project (each is auto-restarted by the supervisor).',
+			labelNames,
+		})
+	}
+
+	public forProject(projectSlug: string): ProjectActionsMetrics {
+		return new ProjectActionsMetrics(this, projectSlug)
+	}
+}
+
+/**
+ * A view of {@link ActionsMetrics} bound to a single project, so call sites don't repeat the label.
+ */
+export class ProjectActionsMetrics {
+	private readonly labels: { [LABEL_PROJECT]: string }
+
+	constructor(
+		private readonly metrics: ActionsMetrics,
+		private readonly projectSlug: string,
+	) {
+		this.labels = { [LABEL_PROJECT]: projectSlug }
+	}
+
+	public enqueued(count: number): void {
+		if (count > 0) {
+			this.metrics.eventsEnqueued.inc(this.labels, count)
+		}
+	}
+
+	public succeeded(count: number): void {
+		if (count > 0) {
+			this.metrics.eventsSucceeded.inc(this.labels, count)
+		}
+	}
+
+	public deliveryAttemptFailed(count: number): void {
+		if (count > 0) {
+			this.metrics.deliveryAttemptsFailed.inc(this.labels, count)
+		}
+	}
+
+	public failed(count: number): void {
+		if (count > 0) {
+			this.metrics.eventsFailed.inc(this.labels, count)
+		}
+	}
+
+	public heartbeat(): void {
+		this.metrics.workerHeartbeat.set(this.labels, Date.now() / 1000)
+	}
+
+	public crashed(): void {
+		this.metrics.workerCrashed.inc(this.labels, 1)
+	}
+
+	/** Drop the per-project heartbeat series when the worker stops, so a removed project doesn't look stuck. */
+	public dispose(): void {
+		this.metrics.workerHeartbeat.remove(this.projectSlug)
+	}
+}

--- a/packages/engine-actions/src/dispatch/EventDispatcher.ts
+++ b/packages/engine-actions/src/dispatch/EventDispatcher.ts
@@ -13,8 +13,14 @@ type ProcessBatchArgs = {
 }
 
 type ProcessBatchResult = {
-	succeed: number
-	failed: number
+	/** Events delivered successfully (terminal). */
+	succeeded: number
+	/** Failed delivery attempts that will be retried. */
+	retried: number
+	/** Events terminally failed after a delivery attempt (retries exhausted). */
+	failedAfterAttempt: number
+	/** Events terminally failed without a delivery attempt (target missing from schema). */
+	failedUnknownTarget: number
 	backoffMs: number | undefined
 }
 
@@ -35,7 +41,13 @@ export class EventDispatcher {
 			batchLogger.debug('Nothing to process', {
 				backoffMs: batch.backoffMs ?? 'undefined',
 			})
-			return { failed: 0, succeed: 0, backoffMs: batch.backoffMs }
+			return {
+				succeeded: 0,
+				retried: 0,
+				failedAfterAttempt: 0,
+				failedUnknownTarget: batch.unknownTargetFailed,
+				backoffMs: batch.backoffMs,
+			}
 		}
 		const { target, events } = batch
 		try {
@@ -45,18 +57,30 @@ export class EventDispatcher {
 			})
 			const variables = await this.variablesManager.fetchVariables(db)
 			const handledEvents = await handler.handle({ target, events, logger: batchLogger, variables })
-			const [succeed, failed] = await this.eventsRepository.persistProcessed(db.client, handledEvents)
-			batchLogger.debug('Processing done', { succeed, failed })
-			return { succeed, failed, backoffMs: 0 }
+			const { succeeded, retried, failed } = await this.eventsRepository.persistProcessed(db.client, handledEvents)
+			batchLogger.debug('Processing done', { succeed: succeeded, failed })
+			return {
+				succeeded,
+				retried,
+				failedAfterAttempt: failed,
+				failedUnknownTarget: batch.unknownTargetFailed,
+				backoffMs: 0,
+			}
 		} catch (e) {
 			logger.error(e, { loc: 'EventDispatcher', batchId })
 			const failedEvents = events.map((it): HandledEvent => ({
 				row: it,
 				result: { ok: false, errorMessage: `Internal error` },
 			}))
-			await this.eventsRepository.persistProcessed(db.client, failedEvents)
+			const { succeeded, retried, failed } = await this.eventsRepository.persistProcessed(db.client, failedEvents)
 
-			return { succeed: 0, failed: batch.events.length, backoffMs: 0 }
+			return {
+				succeeded,
+				retried,
+				failedAfterAttempt: failed,
+				failedUnknownTarget: batch.unknownTargetFailed,
+				backoffMs: 0,
+			}
 		}
 	}
 }

--- a/packages/engine-actions/src/dispatch/EventsRepository.ts
+++ b/packages/engine-actions/src/dispatch/EventsRepository.ts
@@ -11,18 +11,25 @@ const DEFAULT_BATCH_SIZE = 1
 
 export class EventsRepository {
 	public async fetchBatch(actions: Actions.Schema, db: Client): Promise<FetchBatchResult> {
-		const primaryEvent = (await this.fetchInternal(db, 1))[0]
-		if (!primaryEvent) {
-			return { ok: false, backoffMs: await this.fetchBackOff(db) }
+		// Events referencing a target that no longer exists in the schema are terminally failed and
+		// skipped over; count them so the caller can report them as terminal failures.
+		let unknownTargetFailed = 0
+		while (true) {
+			const primaryEvent = (await this.fetchInternal(db, 1))[0]
+			if (!primaryEvent) {
+				return { ok: false, backoffMs: await this.fetchBackOff(db), unknownTargetFailed }
+			}
+			const target = actions.targets[primaryEvent.target]
+			if (!target) {
+				if (await this.markFailedOnUnknownTarget(db, primaryEvent.target, primaryEvent.id)) {
+					unknownTargetFailed++
+				}
+				continue
+			}
+			const batchSize = (target.batchSize ?? DEFAULT_BATCH_SIZE) - 1
+			const batch = batchSize > 0 ? await this.fetchInternal(db, batchSize) : []
+			return { ok: true, events: [primaryEvent, ...batch], target, unknownTargetFailed }
 		}
-		const target = actions.targets[primaryEvent.target]
-		if (!target) {
-			await this.markFailedOnUnknownTarget(db, primaryEvent.target, primaryEvent.id)
-			return await this.fetchBatch(actions, db)
-		}
-		const batchSize = (target.batchSize ?? DEFAULT_BATCH_SIZE) - 1
-		const batch = batchSize > 0 ? await this.fetchInternal(db, batchSize) : []
-		return { ok: true, events: [primaryEvent, ...batch], target }
 	}
 
 	private async fetchBackOff(db: Client): Promise<number | undefined> {
@@ -60,18 +67,25 @@ export class EventsRepository {
 			.execute(db)
 	}
 
-	public async persistProcessed(db: Client, events: HandledEvent[]): Promise<[number, number]> {
+	public async persistProcessed(db: Client, events: HandledEvent[]): Promise<PersistProcessedResult> {
 		return await db.transaction(async trx => {
 			await trx.query(Connection.REPEATABLE_READ)
 			const succeed = events.filter(it => it.result.ok)
 			await this.markSucceed(trx, succeed.map(it => it.row))
 
+			let retried = 0
+			let failed = 0
 			for (const event of events) {
 				if (!event.result.ok) {
-					await this.markFailed(trx, event)
+					const terminal = await this.markFailed(trx, event)
+					if (terminal) {
+						failed++
+					} else {
+						retried++
+					}
 				}
 			}
-			return [succeed.length, events.length - succeed.length]
+			return { succeeded: succeed.length, retried, failed }
 		})
 	}
 
@@ -124,42 +138,44 @@ export class EventsRepository {
 			.execute(db)
 	}
 
-	private async markFailed(db: Client, event: HandledEvent): Promise<void> {
+	/** Returns `true` when the event reached a terminal `failed` state, `false` when it will be retried. */
+	private async markFailed(db: Client, event: HandledEvent): Promise<boolean> {
 		const numRetries = event.row.num_retries + 1
 		const now = new Date()
 		const nextAttempt = new Date()
 		nextAttempt.setTime(
 			nextAttempt.getTime() + (event.target?.initialRepeatIntervalMs ?? DEFAULT_REPEAT_INTERVAL_MS) * Math.pow(2, event.row.num_retries),
 		)
+		const terminal = numRetries >= (event.target?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)
 		await UpdateBuilder.create()
 			.table('actions_event')
 			.values<EventRow>({
 				last_state_change: now,
 				num_retries: numRetries,
 				log: JSON.stringify([...event.row.log, event.result]) as any,
-				...(numRetries < (event.target?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)
+				...(terminal
 					? {
-						state: 'retrying',
-						visible_at: nextAttempt,
+						state: 'failed',
 					}
 					: {
-						state: 'failed',
+						state: 'retrying',
+						visible_at: nextAttempt,
 					}),
 			})
 			.where({ id: event.row.id })
 			.execute(db)
+		return terminal
 	}
 
-	private async markFailedOnUnknownTarget(db: Client, targetName: string, primaryEventId: string) {
-		await UpdateBuilder.create()
+	private async markFailedOnUnknownTarget(db: Client, targetName: string, primaryEventId: string): Promise<boolean> {
+		const affectedRows = await UpdateBuilder.create()
 			.table('actions_event')
 			.where(it =>
 				it.or(it =>
 					it
 						.and(it =>
 							it
-								.in('state', ['retrying', 'created', 'processing'])
-								.compare('visible_at', Operator.lte, 'now')
+								.in('state', ['processing'])
 								.compare('target', Operator.eq, targetName)
 						)
 						.and(it =>
@@ -177,9 +193,19 @@ export class EventsRepository {
 				resolved_at: new Date(),
 			})
 			.execute(db)
+		return affectedRows > 0
 	}
 }
 
 export type FetchBatchResult =
-	| { ok: true; events: EventRow[]; target: Actions.AnyTarget }
-	| { ok: false; backoffMs?: number }
+	| { ok: true; events: EventRow[]; target: Actions.AnyTarget; unknownTargetFailed: number }
+	| { ok: false; backoffMs?: number; unknownTargetFailed: number }
+
+export type PersistProcessedResult = {
+	/** Events delivered successfully (terminal). */
+	succeeded: number
+	/** Events whose delivery attempt failed and that will be retried later. */
+	retried: number
+	/** Events whose delivery attempt failed and that reached a terminal `failed` state. */
+	failed: number
+}

--- a/packages/engine-actions/src/dispatch/ProjectDispatcher.ts
+++ b/packages/engine-actions/src/dispatch/ProjectDispatcher.ts
@@ -4,17 +4,26 @@ import { ContentSchemaResolver } from '@contember/engine-http'
 import { Runnable, RunnableArgs, Running } from '@contember/engine-common'
 import { Listener } from '@contember/database'
 import { NOTIFY_CHANNEL_NAME } from '../utils/notifyChannel.js'
+import { ActionsMetrics, ProjectActionsMetrics } from '../ActionsMetrics.js'
+
+/**
+ * Upper bound on how long the loop parks while idle. Even when the queue is empty (and we'd
+ * otherwise wait indefinitely on a `pg_notify`), we re-check at least this often, so a lost
+ * notification self-heals and the heartbeat keeps refreshing while the worker is genuinely idle.
+ */
+const MAX_IDLE_SLEEP_MS = 30_000
 
 export class ProjectDispatcherFactory {
 	constructor(
 		private readonly dispatcher: EventDispatcher,
+		private readonly metrics: ActionsMetrics,
 	) {
 	}
 
 	public create(
 		{ db, contentSchemaResolver, projectSlug }: { db: DatabaseContext; contentSchemaResolver: ContentSchemaResolver; projectSlug: string },
 	): ProjectDispatcher {
-		return new ProjectDispatcher(this.dispatcher, db, contentSchemaResolver, projectSlug)
+		return new ProjectDispatcher(this.dispatcher, db, contentSchemaResolver, projectSlug, this.metrics.forProject(projectSlug))
 	}
 }
 
@@ -24,6 +33,7 @@ export class ProjectDispatcher implements Runnable {
 		private readonly db: DatabaseContext,
 		private readonly contentSchemaResolver: ContentSchemaResolver,
 		private readonly projectSlug: string,
+		private readonly metrics: ProjectActionsMetrics,
 	) {
 	}
 
@@ -58,6 +68,7 @@ export class ProjectDispatcher implements Runnable {
 						end: async () => {
 							aborted = true
 							await listener.end()
+							this.metrics.dispose()
 							logger.info('Worker terminated', {
 								succeed: succeedTotal,
 								failed: failedTotal,
@@ -67,28 +78,31 @@ export class ProjectDispatcher implements Runnable {
 
 					try {
 						while (!aborted) {
-							const { succeed, failed, backoffMs } = await this.dispatcher.processBatch({
+							this.metrics.heartbeat()
+							const { succeeded, retried, failedAfterAttempt, failedUnknownTarget, backoffMs } = await this.dispatcher.processBatch({
 								db,
 								contentSchemaResolver: this.contentSchemaResolver,
 								logger,
 							})
-							succeedTotal += succeed
-							failedTotal += failed
+							const terminalFailed = failedAfterAttempt + failedUnknownTarget
+							this.metrics.succeeded(succeeded)
+							this.metrics.deliveryAttemptFailed(retried + failedAfterAttempt)
+							this.metrics.failed(terminalFailed)
+							succeedTotal += succeeded
+							failedTotal += terminalFailed
 
 							// listener error occurred during batch processing, rethrow
 							if (pendingError) {
 								throw pendingError
 							}
 
-							// queue is empty, wait
+							// queue is empty (or next retry is in the future), wait — but never longer than
+							// MAX_IDLE_SLEEP_MS, so a lost notification self-heals and the heartbeat stays fresh.
 							if (backoffMs !== 0) {
+								const waitMs = Math.min(backoffMs ?? MAX_IDLE_SLEEP_MS, MAX_IDLE_SLEEP_MS)
 								await new Promise<void>((resolve, reject) => {
-									let cleanup = () => {
-									}
-									if (backoffMs !== undefined) {
-										const timeoutHandle = setTimeout(resolve, backoffMs)
-										cleanup = () => clearTimeout(timeoutHandle)
-									}
+									const timeoutHandle = setTimeout(resolve, waitMs)
+									const cleanup = () => clearTimeout(timeoutHandle)
 									resolvePending = () => {
 										resolve()
 										cleanup()
@@ -103,6 +117,7 @@ export class ProjectDispatcher implements Runnable {
 						onClose?.()
 					} catch (e) {
 						await listener.end()
+						this.metrics.crashed()
 						onError(e)
 					}
 				})

--- a/packages/engine-actions/src/index.ts
+++ b/packages/engine-actions/src/index.ts
@@ -28,6 +28,7 @@ import { VariablesManager } from './model/VariablesManager.js'
 import { AccessEvaluator, Authorizator } from '@contember/authorization'
 import { ActionsPermissionsFactory } from './authorization/index.js'
 import { WebhookFetcherNative } from './dispatch/WebhookFetcher.js'
+import { ActionsMetrics } from './ActionsMetrics.js'
 
 export {
 	TriggerHandler,
@@ -42,18 +43,31 @@ export { ListenerStoreProvider } from './ListenerStoreProvider.js'
 export default class ActionsPlugin implements Plugin {
 	name = 'contember/actions'
 
+	/**
+	 * Metrics singleton, created in {@link getMasterContainerHook} (where the Prometheus registry is
+	 * available) and read back here in {@link getExecutionContainerHook}, which runs in the per-request
+	 * content container with no access to master-level services.
+	 */
+	private actionsMetrics: ActionsMetrics | undefined
+
 	getSystemMigrations(): MigrationGroup {
 		return migrationsGroup
 	}
 
 	getExecutionContainerHook() {
-		const hookFactory = new ActionsExecutionContainerHookFactory(new ListenerStoreProvider())
+		const hookFactory = new ActionsExecutionContainerHookFactory(new ListenerStoreProvider(), () => this.actionsMetrics)
 		return hookFactory.create()
 	}
 
 	getMasterContainerHook() {
 		const hook: MasterContainerHook = (builder: MasterContainerBuilder) => {
 			return builder
+				.addService('actions_metrics', ({ promRegistry }) => {
+					const metrics = new ActionsMetrics(promRegistry)
+					// expose to getExecutionContainerHook (runs in a different container scope)
+					this.actionsMetrics = metrics
+					return metrics
+				})
 				.addService('actions_variableManager', () => {
 					return new VariablesManager()
 				})
@@ -65,8 +79,8 @@ export default class ActionsPlugin implements Plugin {
 					const targetHandlerResolver = new TargetHandlerResolver(webhookTargetHandler)
 					return new EventDispatcher(actions_eventRepository, actions_variableManager, targetHandlerResolver)
 				})
-				.addService('actions_dispatchWorkerSupervisorFactory', ({ actions_eventDispatcher }) => {
-					const projectDispatcherFactory = new ProjectDispatcherFactory(actions_eventDispatcher)
+				.addService('actions_dispatchWorkerSupervisorFactory', ({ actions_eventDispatcher, actions_metrics }) => {
+					const projectDispatcherFactory = new ProjectDispatcherFactory(actions_eventDispatcher, actions_metrics)
 					return new DispatchWorkerSupervisorFactory(projectDispatcherFactory)
 				})
 				.addService('actions_authorizator', () => {

--- a/packages/engine-actions/src/triggers/TriggerPayloadPersister.ts
+++ b/packages/engine-actions/src/triggers/TriggerPayloadPersister.ts
@@ -3,6 +3,7 @@ import { Mapper, TriggeredActionEvent, TriggeredActionsCollector } from '@contem
 import { Actions, ActionsPayload } from '@contember/schema'
 import { EventRow } from '../model/types.js'
 import { notify } from '../utils/notifyChannel.js'
+import { ProjectActionsMetrics } from '../ActionsMetrics.js'
 
 type EventRowToInsert = Omit<EventRow, 'created_at' | 'visible_at' | 'last_state_change' | 'log'> & {
 	created_at: string | Date
@@ -21,6 +22,7 @@ export class TriggerPayloadPersister {
 		private readonly identityId: string,
 		private readonly userInfo: { ipAddress: string | null; userAgent: string | null },
 		private readonly triggeredActionsCollector: TriggeredActionsCollector | undefined,
+		private readonly metrics: ProjectActionsMetrics | undefined,
 	) {
 	}
 
@@ -61,6 +63,10 @@ export class TriggerPayloadPersister {
 				.into('actions_event')
 				.values(rows)
 				.execute(this.client)
+
+			// Counted before commit (events are written in the mutation's transaction); a rollback
+			// would over-count enqueued. Acceptable for a backlog *trend*, which is the intended use.
+			this.metrics?.enqueued(rows.length)
 
 			if (collected && collected.length > 0) {
 				collector!.add(collected)

--- a/packages/engine-actions/tests/cases/unit/actionsMetrics.test.ts
+++ b/packages/engine-actions/tests/cases/unit/actionsMetrics.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { Registry } from 'prom-client'
+import { ActionsMetrics } from '../../../src/ActionsMetrics.js'
+
+// Parse the Prometheus text exposition (the actual /metrics output) rather than getMetricsAsJSON,
+// whose return type doesn't expose sample values.
+const valueFor = async (registry: Registry, name: string, project: string): Promise<number | undefined> => {
+	const text = await registry.metrics()
+	const line = text
+		.split('\n')
+		.find(it => it.startsWith(`${name}{`) && it.includes(`contember_project="${project}"`))
+	if (!line) {
+		return undefined
+	}
+	return Number(line.slice(line.lastIndexOf(' ') + 1))
+}
+
+describe('ActionsMetrics', () => {
+	let registry: Registry
+	let metrics: ActionsMetrics
+
+	beforeEach(() => {
+		registry = new Registry()
+		metrics = new ActionsMetrics(registry)
+	})
+
+	test('counts are labelled by project via forProject', async () => {
+		metrics.forProject('blog').enqueued(3)
+		metrics.forProject('shop').enqueued(5)
+
+		expect(await valueFor(registry, 'contember_actions_events_enqueued_total', 'blog')).toBe(3)
+		expect(await valueFor(registry, 'contember_actions_events_enqueued_total', 'shop')).toBe(5)
+	})
+
+	test('accumulates across calls', async () => {
+		const project = metrics.forProject('blog')
+		project.succeeded(2)
+		project.succeeded(4)
+		project.deliveryAttemptFailed(1)
+		project.failed(1)
+
+		expect(await valueFor(registry, 'contember_actions_events_succeeded_total', 'blog')).toBe(6)
+		expect(await valueFor(registry, 'contember_actions_delivery_attempts_failed_total', 'blog')).toBe(1)
+		expect(await valueFor(registry, 'contember_actions_events_failed_total', 'blog')).toBe(1)
+	})
+
+	test('zero counts are a no-op (no series created)', async () => {
+		metrics.forProject('blog').enqueued(0)
+
+		expect(await valueFor(registry, 'contember_actions_events_enqueued_total', 'blog')).toBeUndefined()
+	})
+
+	test('heartbeat sets a recent timestamp, dispose removes only the heartbeat series', async () => {
+		const project = metrics.forProject('blog')
+		project.succeeded(1)
+		project.heartbeat()
+
+		const beat = await valueFor(registry, 'contember_actions_worker_heartbeat_timestamp_seconds', 'blog')
+		expect(beat).toBeGreaterThan(1_700_000_000)
+
+		project.dispose()
+
+		// heartbeat series gone (a removed project must not look perpetually stuck)...
+		expect(await valueFor(registry, 'contember_actions_worker_heartbeat_timestamp_seconds', 'blog')).toBeUndefined()
+		// ...but the counter is untouched
+		expect(await valueFor(registry, 'contember_actions_events_succeeded_total', 'blog')).toBe(1)
+	})
+
+	test('crash counter increments per crash', async () => {
+		const project = metrics.forProject('blog')
+		project.crashed()
+		project.crashed()
+
+		expect(await valueFor(registry, 'contember_actions_worker_crashed_total', 'blog')).toBe(2)
+	})
+})


### PR DESCRIPTION
## Why

The Actions dispatch subsystem had no observability. Two distinct failure modes were invisible:

1. **System / operator** — the dispatch loop gets *stuck*: events hang in a pending state and nothing flows. Crucially, **counters alone can't detect this** — a stalled loop emits *zero*, which looks identical to "nothing to do".
2. **Userland** — webhook *delivery* fails. Today this is invisible on **both** sides: a webhook returning 500 is an expected `result.ok=false` → retry, so it never reaches Sentry either.

## What

Cheap **in-memory** Prometheus metrics (deliberately *no* table polling), registered onto the engine's shared registry via the plugin's master-container hook, labelled only by `contember_project`:

| Metric | Unit | Answers |
|---|---|---|
| `contember_actions_events_enqueued_total` | event | inflow |
| `contember_actions_events_succeeded_total` | event | delivered |
| `contember_actions_delivery_attempts_failed_total` | attempt | transient health (incl. retries) |
| `contember_actions_events_failed_total` | event | **terminal failures** (userland-actionable) |
| `contember_actions_worker_heartbeat_timestamp_seconds` | gauge | **stuck/dead worker** (works when queue is empty) |
| `contember_actions_worker_crashed_total` | counter | crash-loops |

**Counting units are kept distinct.** A success is always terminal (event = attempt), but a failure splits — a *failed attempt* may retry many times, while a *terminally failed event* gives up once. Hence one success counter but both a per-attempt and a terminal-event failure counter. (The previous `persistProcessed` returned a `[succeed, failed]` tuple that conflated these.)

**Backlog estimate** comes as a *trend* from the counters: `enqueued − succeeded − failed`. Rate comparison survives the in-memory counters' drift across restarts; for an exact depth, query `actions_event`.

### Robustness fix (also enables the stuck-loop signal)

`ProjectDispatcher` previously parked **indefinitely** on `pg_notify` when the queue was empty (no timeout when `backoffMs === undefined`). A lost notification → the worker sleeps forever with pending work, never crashes, so the supervisor never kicks in.

The idle wait is now **capped at 30s**. A lost notify self-heals within 30s, and the heartbeat keeps refreshing while idle — which is exactly what makes heartbeat staleness a *reliable* stuck-loop alarm rather than a false positive during legitimate idle.

## Design notes

- **No table-polling gauge** (queue depth / oldest-pending-age) — a per-project query per scrape is real cost at Cloud scale. Can be added later as a low-frequency *cached* collector if exact backlog visibility is needed; the scrape interval would be decoupled from query frequency.
- **Cardinality**: operator metrics are project-level only; per-target/per-trigger detail belongs in the table-backed userland view (`failedEvents`), a likely phase 2.
- **Known limitation**: `enqueued` is counted pre-commit (events are written in the mutation's transaction), so a rollback over-counts. Acceptable for a backlog *trend*; documented in code.

## Tests

New `actionsMetrics.test.ts` (names, labels, accumulation, zero no-op, crash counter, and `dispose()` removing only the heartbeat series). Full `engine-actions` suite green (34 pass); typecheck, biome, dprint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)