### PR TITLE
fix(react-slate-editor-legacy): fix behaviour with ios autocorrect

### DIFF
--- a/packages/react-slate-editor-legacy/src/blockEditor/editor/overrideInsertData.ts
+++ b/packages/react-slate-editor-legacy/src/blockEditor/editor/overrideInsertData.ts
@@ -1,5 +1,5 @@
 import type { FieldValue, RelativeSingleField } from '@contember/react-binding'
-import { Descendant, Element as SlateElement, Node as SlateNode, Text, Transforms } from 'slate'
+import { Descendant, Editor, Element as SlateElement, Node as SlateNode, Text, Transforms } from 'slate'
 import type { ResolvedDiscriminatedDatum } from '../../discrimination/index.js'
 import { ReferenceElement, referenceElementType } from '../elements/index.js'
 import type { EmbedHandler, NormalizedEmbedHandlers } from '../embed/index.js'
@@ -85,14 +85,33 @@ export const overrideInsertData = <E extends EditorWithBlocks>(editor: E, option
 		}
 
 		const url = parseUrl(text)
+
+		// The insert has to happen asynchronously because embed handlers may need to fetch, but slate-react
+		// restores the pre-event selection as soon as insertData returns synchronously. E.g. Safari delivers
+		// autocorrections as an `insertReplacementText` beforeinput whose DataTransfer payload slate-react
+		// routes through insertData with the word being replaced selected — without tracking that selection
+		// through the restore, the correction would be inserted next to the original word instead of
+		// replacing it.
+		const selectionRef = editor.selection ? Editor.rangeRef(editor, editor.selection) : null
 		;(async () => {
-			for (const [, handler] of options.embedHandlers!) {
-				const result = await handler.datum.handleSource(text, url)
-				if (result !== undefined) {
-					return insertEmbed(handler, result, text)
+			try {
+				const restoreSelection = () => {
+					if (selectionRef?.current) {
+						Transforms.select(editor, selectionRef.current)
+					}
 				}
+				for (const [, handler] of options.embedHandlers!) {
+					const result = await handler.datum.handleSource(text, url)
+					if (result !== undefined) {
+						restoreSelection()
+						return insertEmbed(handler, result, text)
+					}
+				}
+				restoreSelection()
+				insertDataEmbed(data)
+			} finally {
+				selectionRef?.unref()
 			}
-			insertDataEmbed(data)
 		})()
 	}
 }


### PR DESCRIPTION
internal reference: https://clientcare.eu.contember.cloud/app/task-detail?id=f4952a95-1668-46a6-89e8-6faba59c23a2