### PR TITLE
fix(react-slate-editor): keep reference elements bound across persist

### DIFF
--- a/packages/react-slate-editor-legacy/src/blockEditor/references/ReferenceElementWrapper.tsx
+++ b/packages/react-slate-editor-legacy/src/blockEditor/references/ReferenceElementWrapper.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react'
 import { ElementWithReference } from '../elements/index.js'
-import { AccessorProvider } from '@contember/react-binding'
+import { EntityKeyProvider, EnvironmentContext } from '@contember/react-binding'
 import { useReferencedEntity } from './useReferencedEntity.js'
 import { ReactEditor, useSlateStatic } from 'slate-react'
 
@@ -13,5 +13,14 @@ export const ReferenceElementWrapper: FC<ReferenceElementWrapperProps> = ({ chil
 	const editor = useSlateStatic()
 	const path = ReactEditor.findPath(editor, element)
 	const ref = useReferencedEntity(path, element.referenceId)
-	return <AccessorProvider accessor={ref}>{children}</AccessorProvider>
+	// The entity is provided through its stable accessor getter rather than the realm key.
+	// Realm keys change when a successful persist assigns server identities (`changeRealmId`),
+	// but Slate does not re-render its cached element trees, so consumers below would keep
+	// resolving the captured stale key and crash with "Trying to retrieve a non-existent entity".
+	// The getter keeps resolving correctly because the realm state is re-keyed in place.
+	return (
+		<EntityKeyProvider entityKey={ref.getAccessor}>
+			<EnvironmentContext.Provider value={ref.environment}>{children}</EnvironmentContext.Provider>
+		</EntityKeyProvider>
+	)
 }

--- a/packages/react-slate-editor-legacy/src/components/EditorInlineReferencePortal.tsx
+++ b/packages/react-slate-editor-legacy/src/components/EditorInlineReferencePortal.tsx
@@ -1,4 +1,4 @@
-import { Entity, useEnvironment, VariableInputTransformer } from '@contember/react-binding'
+import { EntityKeyProvider, EnvironmentContext, useEnvironment, VariableInputTransformer } from '@contember/react-binding'
 import { Element as SlateElement, type Range as SlateRange } from 'slate'
 import { ReactNode, useEffect, useState } from 'react'
 import { EntityAccessor, EntityId, OptionallyVariableFieldValue } from '@contember/react-binding'
@@ -45,8 +45,10 @@ export const EditorInlineReferencePortal = (props: EditorInlineReferenceTriggerP
 		return null
 	}
 	return (
-		<Entity accessor={entity}>
-			{props.children}
-		</Entity>
+		// Same reasoning as in ReferenceElementWrapper: the accessor is held in state across persists,
+		// so we provide the stable accessor getter instead of a realm key that a persist may migrate.
+		<EntityKeyProvider entityKey={entity.getAccessor}>
+			<EnvironmentContext.Provider value={entity.environment}>{props.children}</EnvironmentContext.Provider>
+		</EntityKeyProvider>
 	)
 }

--- a/packages/react-slate-editor/src/components/EditorInlineReferencePortal.tsx
+++ b/packages/react-slate-editor/src/components/EditorInlineReferencePortal.tsx
@@ -1,4 +1,4 @@
-import { Entity, useEnvironment } from '@contember/react-binding'
+import { EntityKeyProvider, EnvironmentContext, useEnvironment } from '@contember/react-binding'
 import { Editor, Element as SlateElement, type Range as SlateRange } from 'slate'
 import { ReactNode, useEffect, useState } from 'react'
 import { EntityAccessor, EntityId } from '@contember/react-binding'
@@ -45,8 +45,10 @@ export const EditorInlineReferencePortal = (props: EditorInlineReferenceTriggerP
 		return null
 	}
 	return (
-		<Entity accessor={entity}>
-			{props.children}
-		</Entity>
+		// Same reasoning as in ReferenceElementWrapper: the accessor is held in state across persists,
+		// so we provide the stable accessor getter instead of a realm key that a persist may migrate.
+		<EntityKeyProvider entityKey={entity.getAccessor}>
+			<EnvironmentContext.Provider value={entity.environment}>{props.children}</EnvironmentContext.Provider>
+		</EntityKeyProvider>
 	)
 }

--- a/packages/react-slate-editor/src/plugins/references/ReferenceElementWrapper.tsx
+++ b/packages/react-slate-editor/src/plugins/references/ReferenceElementWrapper.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from 'react'
-import { AccessorProvider } from '@contember/react-binding'
+import { EntityKeyProvider, EnvironmentContext } from '@contember/react-binding'
 import { useReferencedEntity } from './useReferencedEntity.js'
 import { ReactEditor, useSlateStatic } from 'slate-react'
 import { ElementWithReference } from './elements/index.js'
@@ -13,5 +13,14 @@ export const ReferenceElementWrapper: FC<ReferenceElementWrapperProps> = ({ chil
 	const editor = useSlateStatic()
 	const path = ReactEditor.findPath(editor, element)
 	const ref = useReferencedEntity(path, element.referenceId)
-	return <AccessorProvider accessor={ref}>{children}</AccessorProvider>
+	// The entity is provided through its stable accessor getter rather than the realm key.
+	// Realm keys change when a successful persist assigns server identities (`changeRealmId`),
+	// but Slate does not re-render its cached element trees, so consumers below would keep
+	// resolving the captured stale key and crash with "Trying to retrieve a non-existent entity".
+	// The getter keeps resolving correctly because the realm state is re-keyed in place.
+	return (
+		<EntityKeyProvider entityKey={ref.getAccessor}>
+			<EnvironmentContext.Provider value={ref.environment}>{children}</EnvironmentContext.Provider>
+		</EntityKeyProvider>
+	)
 }


### PR DESCRIPTION
## Problem

When a persist runs while a rich text editor with reference elements stays mounted — a manual save without `refreshOnPersist`, or any autosave-style flow — the next interaction with the editor crashes:

```
BindingError: Trying to retrieve a non-existent entity: key 'C-…' was not found.
```

The usual workaround is `refreshOnPersist`, but that rebuilds the whole tree store and remounts the editor (full-screen loader, lost caret and scroll position), which makes silent/idle autosave impractical.

## Root cause

After a successful persist, `TreeAugmenter.updatePersistedData` → `OperationsHelpers.changeRealmId` migrates the realm keys of newly persisted entities (`ClientGeneratedUuid` → `ServerId`; the `C-` prefix is dropped).

Regular React trees don't notice: they re-render from binding updates, and `Entity` even remounts via its React `key`. Slate is different — element subtrees are cached and are **not** re-rendered by binding events. `ReferenceElementWrapper` provides the referenced entity through `AccessorProvider`, which puts the **realm key string** into `EntityKeyContext`. Consumers below (`useEntity` & friends) capture that string in their memoized subscription callbacks; once the migration runs, the captured key no longer exists in the realm store and `getEntityByKey` throws.

## Fix

Provide the referenced entity through its stable **accessor getter** instead of the realm key, scoped to the two Slate reference wrappers (`react-slate-editor`, `react-slate-editor-legacy`) — the only places where an `EntityKeyContext` provider lives inside a render tree that Slate may never re-render.

The getter form is already first-class in the binding:

- `EntityKeyProviderProps['entityKey']` is `string | (() => EntityAccessor)`,
- `getEntityByKey` explicitly resolves function values,
- `AccessorProvider` itself already falls back to `getAccessor` whenever `key` is `undefined`.

It survives the migration because `changeRealmId` re-keys the existing realm state in place, so a getter bound to that realm keeps resolving the current accessor.

`AccessorProvider`/`Entity` semantics everywhere else are deliberately left untouched — in regular trees the string key also serves as a React key / effect dependency and drives remount-on-migration, and there is no reason to change that behaviour.

## Testing

- `tsc --build packages/react-slate-editor packages/react-slate-editor-legacy` passes; `dprint` and `biome` are clean on the changed files.
- Verified against a production admin project (2.1.0-alpha.30, with this change applied at the application level): a 3-second-idle autosave persisting repeatedly while typing inside and next to reference blocks (images, galleries, quotes) — no crash, caret preserved, and repeated persists produce no duplicate creates. Previously this scenario required `refreshOnPersist`.
