### PR TITLE
fix(engine-content-api): recursively ACL-close nested read predicates and field guards

### DIFF
--- a/e2e/cases/content/acl-audit-gaps.test.ts
+++ b/e2e/cases/content/acl-audit-gaps.test.ts
@@ -1,0 +1,575 @@
+import { expect, test } from 'bun:test'
+import { createTester, gql, rootToken } from '../../src/tester.js'
+import { AclDefinition as acl, createSchema, SchemaDefinition as def } from '@contember/schema-definition'
+import type { Schema } from '@contember/schema'
+
+// ACL read-path GAP audit. Metamorphic oracle: "changing a value a restricted role cannot read must never
+// change what that role's query returns." For each shape we build two dataset states differing ONLY in
+// unreadable data and assert byte-identical restricted output; teeth (root) MUST differ. Shapes here target
+// gaps NOT covered by acl-leak-oracle / acl-isnull-relation-readable-view / acl-nested-predicate-closure.
+
+type Query = { query: string; variables?: Record<string, any> }
+type MembershipVar = { name: string; values: string[] }
+
+const run = async (tester: any, token: string | undefined, queries: Query[]): Promise<any[]> => {
+	const out: any[] = []
+	for (const q of queries) {
+		const res = await tester(q.query, { authorizationToken: token, variables: q.variables }).expect(200)
+		out.push(res.body.data)
+	}
+	return out
+}
+
+interface OracleConfig {
+	schema: Schema
+	role: string
+	setupA: (tester: any) => Promise<{ variables: MembershipVar[]; ctx: any }>
+	mutateToB: (tester: any, ctx: any) => Promise<void>
+	restrictedQueries: Query[]
+	teethQueries: Query[]
+}
+
+const assertLeakOracle = async (cfg: OracleConfig) => {
+	const tester = await createTester(cfg.schema)
+	const { variables, ctx } = await cfg.setupA(tester)
+
+	const email = `audit_${cfg.role}_${Date.now()}_${Math.random().toString(36).slice(2)}@doe.com`
+	const identityId = await tester.tenant.signUp(email)
+	const authKey = await tester.tenant.signIn(email)
+	await tester.tenant.addProjectMember(identityId, tester.projectSlug, { role: cfg.role, variables })
+
+	const restrictedA = await run(tester, authKey, cfg.restrictedQueries)
+	const teethA = await run(tester, rootToken, cfg.teethQueries)
+
+	await cfg.mutateToB(tester, ctx)
+
+	const restrictedB = await run(tester, authKey, cfg.restrictedQueries)
+	const teethB = await run(tester, rootToken, cfg.teethQueries)
+
+	return { tester, authKey, restrictedA, restrictedB, teethA, teethB }
+}
+
+const create = async (tester: any, entity: string, data: Record<string, any>): Promise<string> => {
+	const res = await tester(
+		`mutation ($data: ${entity}CreateInput!) { create${entity}(data: $data) { ok errorMessage node { id } } }`,
+		{ variables: { data } },
+	).expect(200)
+	const payload = res.body.data[`create${entity}`]
+	expect(payload.ok, `create${entity} failed: ${payload.errorMessage}`).toBe(true)
+	return payload.node.id
+}
+
+const update = async (tester: any, entity: string, id: string, data: Record<string, any>): Promise<void> => {
+	const res = await tester(
+		`mutation ($by: ${entity}UniqueWhere!, $data: ${entity}UpdateInput!) { update${entity}(by: $by, data: $data) { ok errorMessage } }`,
+		{ variables: { by: { id }, data } },
+	).expect(200)
+	expect(res.body.data[`update${entity}`].ok, `update${entity} failed`).toBe(true)
+}
+
+const connect = (id: string) => ({ connect: { id } })
+
+// =============================================================================================
+// SHAPE 1: to-many `some` FILTER on an unreadable CELL of a readable target row.
+// Post.comments is oneHasMany; Comment ROW is readable (in company) but `secret` is cell-guarded
+// (readable only when visible=yes). Filter `{ comments: { secret: { eq: PROBE } } }` must operate on
+// the role's MASKED view of `secret` — a masked (visible=no) comment must never match the probe.
+// =============================================================================================
+namespace S1 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		posts = def.oneHasMany(Post, 'company')
+		comments = def.oneHasMany(Comment, 'company')
+	}
+
+	@acl.allow(reader, { read: ['id', 'title', 'company', 'comments'], when: { company: { id: companyVar } } })
+	export class Post {
+		title = def.stringColumn()
+		company = def.manyHasOne(Company, 'posts').notNull()
+		comments = def.oneHasMany(Comment, 'post')
+	}
+
+	// Comment row readable in company; `secret` masked unless visible=yes → cell-level guard.
+	@acl.allow(reader, { read: ['id', 'label', 'company', 'post'], when: { company: { id: companyVar } } })
+	@acl.allow(reader, { read: ['secret'], when: { company: { id: companyVar }, visible: { eq: 'yes' } } })
+	export class Comment {
+		label = def.stringColumn()
+		secret = def.stringColumn()
+		visible = def.stringColumn()
+		company = def.manyHasOne(Company, 'comments').notNull()
+		post = def.manyHasOne(Post, 'comments').notNull()
+	}
+}
+
+test('SHAPE 1 — to-many some-filter on a masked cell of a readable row cannot leak', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S1),
+		role: 'reader',
+		setupA: async t => {
+			const company = await create(t, 'Company', { name: 'Acme' })
+			const post = await create(t, 'Post', { title: 'p', company: connect(company) })
+			// readable-row comment whose `secret` cell is masked (visible=no)
+			const c = await create(t, 'Comment', { label: 'c', secret: 'none', visible: 'no', company: connect(company), post: connect(post) })
+			return { variables: [{ name: 'company', values: [company] }], ctx: { c } }
+		},
+		// flip the masked cell to the probe value (row stays readable, cell stays masked)
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Comment', ctx.c, { secret: 'PROBE' })
+		},
+		restrictedQueries: [
+			{ query: gql`query { listPost(filter: { comments: { secret: { eq: "PROBE" } } }, orderBy: [{ title: asc }]) { title } }` },
+			{ query: gql`query { listPost(filter: { not: { comments: { secret: { eq: "PROBE" } } } }, orderBy: [{ title: asc }]) { title } }` },
+		],
+		teethQueries: [{ query: gql`query { listPost(filter: { comments: { secret: { eq: "PROBE" } } }) { title } }` }],
+	})
+	expect(restrictedB, 'LEAK S1: masked-cell to-many filter changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S1').not.toStrictEqual(teethA)
+	console.log('SHAPE1 restrictedA some=', JSON.stringify(restrictedA[0]), ' none=', JSON.stringify(restrictedA[1]))
+	console.log('SHAPE1 restrictedB some=', JSON.stringify(restrictedB[0]), ' none=', JSON.stringify(restrictedB[1]))
+	console.log('SHAPE1 teethA=', JSON.stringify(teethA[0]), ' teethB=', JSON.stringify(teethB[0]))
+})
+
+// =============================================================================================
+// SHAPE 2: M:N `some` FILTER on an unreadable CELL of a readable target row (junction lowering).
+// Post.tags is manyHasMany; Tag ROW readable, `secret` cell-guarded. Same oracle as S1 but through the
+// junction path.
+// =============================================================================================
+namespace S2 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		posts = def.oneHasMany(Post, 'company')
+		tags = def.oneHasMany(Tag, 'company')
+	}
+
+	@acl.allow(reader, { read: ['id', 'title', 'company', 'tags'], when: { company: { id: companyVar } } })
+	export class Post {
+		title = def.stringColumn()
+		company = def.manyHasOne(Company, 'posts').notNull()
+		tags = def.manyHasMany(Tag)
+	}
+
+	@acl.allow(reader, { read: ['id', 'label', 'company'], when: { company: { id: companyVar } } })
+	@acl.allow(reader, { read: ['secret'], when: { company: { id: companyVar }, visible: { eq: 'yes' } } })
+	export class Tag {
+		label = def.stringColumn()
+		secret = def.stringColumn()
+		visible = def.stringColumn()
+		company = def.manyHasOne(Company, 'tags').notNull()
+	}
+}
+
+test('SHAPE 2 — M:N some-filter on a masked cell of a readable row cannot leak', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S2),
+		role: 'reader',
+		setupA: async t => {
+			const company = await create(t, 'Company', { name: 'Acme' })
+			const tag = await create(t, 'Tag', { label: 't', secret: 'none', visible: 'no', company: connect(company) })
+			await create(t, 'Post', { title: 'p', company: connect(company), tags: [connect(tag)] })
+			return { variables: [{ name: 'company', values: [company] }], ctx: { tag } }
+		},
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Tag', ctx.tag, { secret: 'PROBE' })
+		},
+		restrictedQueries: [
+			{ query: gql`query { listPost(filter: { tags: { secret: { eq: "PROBE" } } }, orderBy: [{ title: asc }]) { title } }` },
+			{ query: gql`query { listPost(filter: { not: { tags: { secret: { eq: "PROBE" } } } }, orderBy: [{ title: asc }]) { title } }` },
+		],
+		teethQueries: [{ query: gql`query { listPost(filter: { tags: { secret: { eq: "PROBE" } } }) { title } }` }],
+	})
+	expect(restrictedB, 'LEAK S2: masked-cell M:N filter changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S2').not.toStrictEqual(teethA)
+	console.log('SHAPE2 restrictedA some=', JSON.stringify(restrictedA[0]), ' none=', JSON.stringify(restrictedA[1]))
+	console.log('SHAPE2 restrictedB some=', JSON.stringify(restrictedB[0]), ' none=', JSON.stringify(restrictedB[1]))
+})
+
+// =============================================================================================
+// SHAPE 3: nested paginate totalCount + edges must count ONLY readable rows within a relation, and be
+// invariant to unreadable-sibling changes. Post.locales: some readable (visible=yes), some unreadable
+// rows (visible=no). paginateLocales.totalCount / edges must not see the unreadable sibling.
+// =============================================================================================
+namespace S3 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		posts = def.oneHasMany(Post, 'company')
+	}
+
+	@acl.allow(reader, { read: ['id', 'title', 'company', 'locales'], when: { company: { id: companyVar } } })
+	export class Post {
+		title = def.stringColumn()
+		company = def.manyHasOne(Company, 'posts').notNull()
+		locales = def.oneHasMany(PostLocale, 'post')
+	}
+
+	// Row readable only when visible=yes → a visible=no locale is an unreadable sibling row.
+	@acl.allow(reader, { read: ['id', 'value', 'post'], when: { post: { company: { id: companyVar } }, visible: { eq: 'yes' } } })
+	export class PostLocale {
+		value = def.stringColumn()
+		visible = def.stringColumn()
+		post = def.manyHasOne(Post, 'locales').notNull()
+	}
+}
+
+test('SHAPE 3 — nested paginate totalCount/edges count only readable rows, invariant to unreadable siblings', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S3),
+		role: 'reader',
+		setupA: async t => {
+			const company = await create(t, 'Company', { name: 'Acme' })
+			const post = await create(t, 'Post', { title: 'p', company: connect(company) })
+			await create(t, 'PostLocale', { value: 'r1', visible: 'yes', post: connect(post) })
+			const hidden = await create(t, 'PostLocale', { value: 'h1', visible: 'no', post: connect(post) })
+			return { variables: [{ name: 'company', values: [company] }], ctx: { post, hidden } }
+		},
+		// add ANOTHER unreadable sibling + mutate the existing one — role must not observe any of it
+		mutateToB: async (t, ctx) => {
+			await update(t, 'PostLocale', ctx.hidden, { value: 'h1-mut' })
+			await create(t, 'PostLocale', { value: 'h2', visible: 'no', post: connect(ctx.post) })
+		},
+		restrictedQueries: [
+			{ query: gql`query { listPost { title paginateLocales { pageInfo { totalCount } edges { node { value } } } } }` },
+			{ query: gql`query { listPost { title localesMeta: paginateLocales(filter: { value: { isNull: false } }) { pageInfo { totalCount } } } }` },
+		],
+		teethQueries: [{ query: gql`query { listPost { title paginateLocales { pageInfo { totalCount } } } }` }],
+	})
+	expect(restrictedB, 'LEAK S3: nested totalCount/edges changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S3').not.toStrictEqual(teethA)
+	console.log('SHAPE3 restrictedA=', JSON.stringify(restrictedA[0]))
+	console.log('SHAPE3 teethA=', JSON.stringify(teethA[0]), ' teethB=', JSON.stringify(teethB[0]))
+	expect(restrictedA[0].listPost[0].paginateLocales.pageInfo.totalCount, 'nested totalCount = readable only').toBe(1)
+})
+
+// =============================================================================================
+// SHAPE 4: order-by on a MASKED cell with pagination (limit/offset) as the ONLY sort key — page
+// boundaries must not leak the unreadable order (bisection oracle). Masked sortKey is NULL for the role,
+// so order falls to a stable tie-break; permuting the real (unreadable) sortKey must not move rows across
+// page boundaries.
+// =============================================================================================
+namespace S4 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		items = def.oneHasMany(Item, 'company')
+	}
+
+	@acl.allow(reader, { read: ['id', 'name', 'company'], when: { company: { id: companyVar } } })
+	@acl.allow(reader, { read: ['sortKey'], when: { company: { id: companyVar }, elevated: { eq: 'yes' } } })
+	export class Item {
+		name = def.stringColumn()
+		sortKey = def.intColumn()
+		elevated = def.stringColumn()
+		company = def.manyHasOne(Company, 'items').notNull()
+	}
+}
+
+test('SHAPE 4 — order-by on masked cell as sole sort key with pagination cannot leak via page boundaries', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S4),
+		role: 'reader',
+		setupA: async t => {
+			const company = await create(t, 'Company', { name: 'Acme' })
+			const a = await create(t, 'Item', { name: 'a', elevated: 'no', sortKey: 1, company: connect(company) })
+			const b = await create(t, 'Item', { name: 'b', elevated: 'no', sortKey: 2, company: connect(company) })
+			const c = await create(t, 'Item', { name: 'c', elevated: 'no', sortKey: 3, company: connect(company) })
+			const d = await create(t, 'Item', { name: 'd', elevated: 'no', sortKey: 4, company: connect(company) })
+			return { variables: [{ name: 'company', values: [company] }], ctx: { a, b, c, d } }
+		},
+		// reverse the masked sortKeys
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Item', ctx.a, { sortKey: 4 })
+			await update(t, 'Item', ctx.b, { sortKey: 3 })
+			await update(t, 'Item', ctx.c, { sortKey: 2 })
+			await update(t, 'Item', ctx.d, { sortKey: 1 })
+		},
+		restrictedQueries: [
+			// order ONLY by the masked cell, paginate page-by-page
+			{ query: gql`query { listItem(orderBy: [{ sortKey: asc }], limit: 2, offset: 0) { name } }` },
+			{ query: gql`query { listItem(orderBy: [{ sortKey: asc }], limit: 2, offset: 2) { name } }` },
+			{ query: gql`query { listItem(orderBy: [{ sortKey: desc }], limit: 1, offset: 0) { name } }` },
+		],
+		teethQueries: [{ query: gql`query { listItem(orderBy: [{ sortKey: asc }]) { name } }` }],
+	})
+	expect(restrictedB, 'LEAK S4: masked sort-key page boundaries changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S4').not.toStrictEqual(teethA)
+	console.log(
+		'SHAPE4 restrictedA page0=',
+		JSON.stringify(restrictedA[0]),
+		' page1=',
+		JSON.stringify(restrictedA[1]),
+		' desc1=',
+		JSON.stringify(restrictedA[2]),
+	)
+	console.log(
+		'SHAPE4 restrictedB page0=',
+		JSON.stringify(restrictedB[0]),
+		' page1=',
+		JSON.stringify(restrictedB[1]),
+		' desc1=',
+		JSON.stringify(restrictedB[2]),
+	)
+})
+
+// =============================================================================================
+// SHAPE 5: order-by THROUGH a to-many/M:N relation on a masked target cell combined with limit — the
+// nested relation page order must not leak the unreadable ordering of siblings. (CLASS 3 covered m2m
+// order-by top-2; here we add offset paging + a to-many oneHasMany variant.)
+// =============================================================================================
+namespace S5 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		posts = def.oneHasMany(Post, 'company')
+		comments = def.oneHasMany(Comment, 'company')
+	}
+
+	@acl.allow(reader, { read: ['id', 'title', 'company', 'comments'], when: { company: { id: companyVar } } })
+	export class Post {
+		title = def.stringColumn()
+		company = def.manyHasOne(Company, 'posts').notNull()
+		comments = def.oneHasMany(Comment, 'post')
+	}
+
+	@acl.allow(reader, { read: ['id', 'label', 'company', 'post'], when: { company: { id: companyVar } } })
+	@acl.allow(reader, { read: ['rank'], when: { company: { id: companyVar }, visible: { eq: 'yes' } } })
+	export class Comment {
+		label = def.stringColumn()
+		rank = def.intColumn()
+		visible = def.stringColumn()
+		company = def.manyHasOne(Company, 'comments').notNull()
+		post = def.manyHasOne(Post, 'comments').notNull()
+	}
+}
+
+test('SHAPE 5 — order-by through to-many on masked cell + paging cannot leak sibling order', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S5),
+		role: 'reader',
+		setupA: async t => {
+			const company = await create(t, 'Company', { name: 'Acme' })
+			const post = await create(t, 'Post', { title: 'p', company: connect(company) })
+			const c1 = await create(t, 'Comment', { label: 'l1', rank: 1, visible: 'no', company: connect(company), post: connect(post) })
+			await create(t, 'Comment', { label: 'l2', rank: 2, visible: 'no', company: connect(company), post: connect(post) })
+			const c3 = await create(t, 'Comment', { label: 'l3', rank: 3, visible: 'no', company: connect(company), post: connect(post) })
+			return { variables: [{ name: 'company', values: [company] }], ctx: { c1, c3 } }
+		},
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Comment', ctx.c1, { rank: 3 })
+			await update(t, 'Comment', ctx.c3, { rank: 1 })
+		},
+		restrictedQueries: [
+			{ query: gql`query { listPost { title comments(orderBy: [{ rank: asc }], limit: 2, offset: 0) { label } } }` },
+			{ query: gql`query { listPost { title comments(orderBy: [{ rank: asc }], limit: 2, offset: 1) { label } } }` },
+			{ query: gql`query { listPost { title paginateComments(orderBy: [{ rank: asc }], first: 2) { edges { node { label } } } } }` },
+		],
+		teethQueries: [{ query: gql`query { listPost { title comments(orderBy: [{ rank: asc }]) { label } } }` }],
+	})
+	expect(restrictedB, 'LEAK S5: to-many masked order-by paging changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S5').not.toStrictEqual(teethA)
+	console.log('SHAPE5 restrictedA=', JSON.stringify(restrictedA))
+	console.log('SHAPE5 restrictedB=', JSON.stringify(restrictedB))
+})
+
+// =============================================================================================
+// SHAPE 6: relation-traversing CELL guard — a field whose read guard traverses a relation
+// (Employee.salary readable when { dept: { open: eq true } }). The traversed Dept has its OWN read
+// predicate (company scope). If salary's guard does not enforce Dept readability, an unreadable Dept
+// (other company) with open=true leaks salary; and mutating that unreadable dept's `open` would move
+// salary in/out → leak.
+// =============================================================================================
+namespace S6 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		employees = def.oneHasMany(Employee, 'company')
+		depts = def.oneHasMany(Dept, 'company')
+	}
+
+	// Employee row readable in company; `salary` readable only when its dept is open — guard TRAVERSES dept.
+	@acl.allow(reader, { read: ['id', 'name', 'company', 'dept'], when: { company: { id: companyVar } } })
+	@acl.allow(reader, { read: ['salary'], when: { company: { id: companyVar }, dept: { open: { eq: true } } } })
+	export class Employee {
+		name = def.stringColumn()
+		salary = def.intColumn()
+		company = def.manyHasOne(Company, 'employees').notNull()
+		dept = def.manyHasOne(Dept).notNull()
+	}
+
+	// Dept readable only within company scope (a dept in another company is unreadable to the role).
+	@acl.allow(reader, { read: ['id', 'title', 'open', 'company'], when: { company: { id: companyVar } } })
+	export class Dept {
+		title = def.stringColumn()
+		open = def.boolColumn()
+		company = def.manyHasOne(Company, 'depts').notNull()
+	}
+}
+
+test('SHAPE 6 — relation-traversing cell guard: unreadable traversed relation must not leak the cell', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S6),
+		role: 'reader',
+		setupA: async t => {
+			const mine = await create(t, 'Company', { name: 'Mine' })
+			const other = await create(t, 'Company', { name: 'Other' }) // NOT in role scope
+			// dept in the OTHER (unreadable) company, open=true
+			const otherDept = await create(t, 'Dept', { title: 'od', open: true, company: connect(other) })
+			// employee is in MY company (row readable) but its dept is the unreadable other-company dept
+			await create(t, 'Employee', { name: 'e', salary: 100, company: connect(mine), dept: connect(otherDept) })
+			return { variables: [{ name: 'company', values: [mine] }], ctx: { otherDept } }
+		},
+		// mutate the UNREADABLE dept's `open` true->false. If salary readability tracks it, the guard leaked
+		// dept.open (unreadable data).
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Dept', ctx.otherDept, { open: false })
+		},
+		restrictedQueries: [
+			{ query: gql`query { listEmployee(orderBy: [{ name: asc }]) { name salary dept { title } } }` },
+			// filter by salary (masked): does the guard leak via filter?
+			{ query: gql`query { listEmployee(filter: { salary: { eq: 100 } }, orderBy: [{ name: asc }]) { name } }` },
+		],
+		teethQueries: [{ query: gql`query { listEmployee { name salary dept { title open } } }` }],
+	})
+	console.log('SHAPE6 restrictedA=', JSON.stringify(restrictedA))
+	console.log('SHAPE6 restrictedB=', JSON.stringify(restrictedB))
+	console.log('SHAPE6 teethA=', JSON.stringify(teethA), ' teethB=', JSON.stringify(teethB))
+	// LEAK (RED): the salary cell-read guard `{ dept: { open: eq true } }` is evaluated against the RAW
+	// dept row, NOT the role's readable view of Dept. The employee's dept is in another company (unreadable:
+	// note dept projection is null), yet:
+	//   • state A (unreadable dept.open=true)  → salary = 100 is revealed
+	//   • state B (unreadable dept.open=false) → salary = null
+	// so flipping an UNREADABLE dept's `open` moves an otherwise-masked cell in/out of the response — the role
+	// can read the unreadable dept.open through the salary mask. Same class as acl-nested-predicate-closure
+	// (recursive-ACL-closure), but for a FIELD (cell) read guard rather than a ROW read predicate.
+	expect(restrictedB, 'LEAK S6: cell guard traversing an unreadable relation changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S6').not.toStrictEqual(teethA)
+})
+
+// =============================================================================================
+// SHAPE 7: deep mixed composition — nested NOT/AND/OR mixing a scalar cell guard + relation presence +
+// to-many across 2 levels, over only-unreadable data.
+// =============================================================================================
+namespace S7 {
+	export const reader = acl.createRole('reader')
+	export const companyVar = acl.createEntityVariable('company', 'Company', reader)
+
+	@acl.allow(reader, { read: ['id', 'name'], when: { id: companyVar } })
+	export class Company {
+		name = def.stringColumn()
+		posts = def.oneHasMany(Post, 'company')
+		comments = def.oneHasMany(Comment, 'company')
+	}
+
+	@acl.allow(reader, { read: ['id', 'title', 'company', 'comments'], when: { company: { id: companyVar } } })
+	@acl.allow(reader, { read: ['secret'], when: { company: { id: companyVar }, flag: { eq: 'yes' } } })
+	export class Post {
+		title = def.stringColumn()
+		secret = def.stringColumn()
+		flag = def.stringColumn()
+		company = def.manyHasOne(Company, 'posts').notNull()
+		comments = def.oneHasMany(Comment, 'post')
+	}
+
+	// Comment row readable only when visible=yes → unreadable rows; `note` cell readable at row level.
+	@acl.allow(reader, { read: ['id', 'note', 'company', 'post'], when: { company: { id: companyVar }, visible: { eq: 'yes' } } })
+	export class Comment {
+		note = def.stringColumn()
+		visible = def.stringColumn()
+		company = def.manyHasOne(Company, 'comments').notNull()
+		post = def.manyHasOne(Post, 'comments').notNull()
+	}
+}
+
+test('SHAPE 7 — deep mixed NOT/AND/OR (scalar cell guard + to-many presence) cannot leak', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S7),
+		role: 'reader',
+		setupA: async t => {
+			const company = await create(t, 'Company', { name: 'Acme' })
+			// p1: masked secret (flag=no), one unreadable comment (visible=no)
+			const p1 = await create(t, 'Post', { title: 'p1', secret: 'none', flag: 'no', company: connect(company) })
+			const hc = await create(t, 'Comment', { note: 'n', visible: 'no', company: connect(company), post: connect(p1) })
+			// p2: masked secret, one readable comment (visible=yes)
+			const p2 = await create(t, 'Post', { title: 'p2', secret: 'none', flag: 'no', company: connect(company) })
+			await create(t, 'Comment', { note: 'n', visible: 'yes', company: connect(company), post: connect(p2) })
+			return { variables: [{ name: 'company', values: [company] }], ctx: { hc } }
+		},
+		// mutate only unreadable data: masked secret + the unreadable comment's note
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Comment', ctx.hc, { note: 'PROBE' })
+		},
+		restrictedQueries: [
+			{
+				query:
+					gql`query { listPost(filter: { not: { or: [ { secret: { eq: "PROBE" } }, { comments: { note: { eq: "PROBE" } } } ] } }, orderBy: [{ title: asc }]) { title } }`,
+			},
+			{
+				query:
+					gql`query { listPost(filter: { and: [ { not: { secret: { eq: "PROBE" } } }, { comments: { id: { isNull: false } } } ] }, orderBy: [{ title: asc }]) { title } }`,
+			},
+			{ query: gql`query { listPost(filter: { comments: { note: { eq: "PROBE" } } }, orderBy: [{ title: asc }]) { title } }` },
+		],
+		teethQueries: [{ query: gql`query { listPost(filter: { comments: { note: { eq: "PROBE" } } }) { title } }` }],
+	})
+	expect(restrictedB, 'LEAK S7: deep mixed composition changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S7').not.toStrictEqual(teethA)
+	console.log('SHAPE7 restrictedA=', JSON.stringify(restrictedA))
+	console.log('SHAPE7 restrictedB=', JSON.stringify(restrictedB))
+})
+
+// =============================================================================================
+// SHAPE 8: _meta.updatable / _meta.readable reachable via read — must reflect the role's masked view and
+// be invariant to unreadable data. secretA cell-guarded; _meta.secretA.{readable,updatable}.
+// =============================================================================================
+namespace S8 {
+	export const reader = acl.createRole('reader')
+
+	@acl.allow(reader, { read: ['id', 'name', 'visibleA'] })
+	@acl.allow(reader, { read: ['secretA'], update: ['secretA'], when: { visibleA: { eq: 'yes' } } })
+	export class Doc {
+		name = def.stringColumn()
+		visibleA = def.stringColumn()
+		secretA = def.stringColumn()
+	}
+}
+
+test('SHAPE 8 — _meta.readable/_meta.updatable reflect masked view, invariant to unreadable data', async () => {
+	const { restrictedA, restrictedB, teethA, teethB } = await assertLeakOracle({
+		schema: createSchema(S8),
+		role: 'reader',
+		setupA: async t => {
+			const pub = await create(t, 'Doc', { name: 'pub', visibleA: 'yes', secretA: 'pubA' })
+			const hid = await create(t, 'Doc', { name: 'hid', visibleA: 'no', secretA: 'hidA' })
+			return { variables: [], ctx: { hid, pub } }
+		},
+		mutateToB: async (t, ctx) => {
+			await update(t, 'Doc', ctx.hid, { secretA: 'PROBE' })
+		},
+		restrictedQueries: [
+			{ query: gql`query { listDoc(orderBy: [{ name: asc }]) { name secretA _meta { secretA { readable updatable } } } }` },
+		],
+		teethQueries: [{ query: gql`query { listDoc(filter: { name: { eq: "hid" } }) { secretA } }` }],
+	})
+	expect(restrictedB, 'LEAK S8: _meta changed with only-unreadable data').toStrictEqual(restrictedA)
+	expect(teethB, 'VACUOUS S8').not.toStrictEqual(teethA)
+	console.log('SHAPE8 restrictedA=', JSON.stringify(restrictedA[0]))
+})

--- a/e2e/cases/content/acl-nested-predicate-closure.test.ts
+++ b/e2e/cases/content/acl-nested-predicate-closure.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from 'bun:test'
+import { createTester, gql } from '../../src/tester.js'
+import { AclDefinition as acl, createSchema, SchemaDefinition as def } from '@contember/schema-definition'
+
+// Regression for the recursive-ACL-closure gap (PredicatesInjector.injectPredicatesToPredicate):
+// a row-level read predicate whose OWN target entity's predicate traverses a further to-one relation used to
+// append that target predicate RAW, so the further entity's readability was never enforced — a readable-view
+// leak. Chain: Parent.read = {room:{name:"anchor"}}, Room.read = {building:{code:"B1"}}, and Building has an
+// INDEPENDENT scalar predicate {open: true}. A Parent whose room's building is code=B1 but open=FALSE must be
+// invisible (building unreadable ⇒ room unreadable ⇒ parent has no readable "anchor" room). Before the fix the
+// parent leaked as visible because Building.read ({open:true}) was not injected under Room.read.
+//
+// Metamorphic core: the reader's restricted view must be invariant to the CONTENTS of unreadable rows — two
+// dataset states that differ only in a hidden (open=false) building's fields must yield byte-identical reader
+// responses, and filter / projection / totalCount must all agree.
+
+namespace NestedClosure {
+	export const reader = acl.createRole('reader')
+
+	// Parent readable iff it has a READABLE room named "anchor".
+	@acl.allow(reader, { read: true, when: { room: { name: { eq: 'anchor' } } } })
+	export class Parent {
+		tag = def.stringColumn()
+		room = def.manyHasOne(Room).notNull()
+	}
+
+	// Room readable iff it has a READABLE building with code "B1".
+	@acl.allow(reader, { read: true, when: { building: { code: { eq: 'B1' } } } })
+	export class Room {
+		name = def.stringColumn()
+		building = def.manyHasOne(Building).notNull()
+	}
+
+	// Building has an INDEPENDENT scalar predicate: only open buildings are readable.
+	@acl.allow(reader, { read: true, when: { open: { eq: true } } })
+	export class Building {
+		code = def.stringColumn()
+		open = def.boolColumn()
+	}
+}
+
+const mk = async (t: any, q: string, variables: any = {}) => (await t(q, { variables }).expect(200)).body.data
+const tags = (rows: any[]) => rows.map(r => r.tag).sort()
+
+test('recursive ACL closure: nested target-entity predicate readability is enforced (readable view)', async () => {
+	const tester = await createTester(createSchema(NestedClosure))
+
+	const openB = (await mk(tester, gql`mutation { createBuilding(data: { code: "B1", open: true }) { node { id } } }`)).createBuilding.node.id
+	const hiddenB = (await mk(tester, gql`mutation { createBuilding(data: { code: "B1", open: false }) { node { id } } }`)).createBuilding.node.id
+
+	// visible: room's building is readable (open) with code B1.
+	await mk(
+		tester,
+		gql`mutation ($b: UUID!) { createParent(data: { tag: "visible", room: { create: { name: "anchor", building: { connect: { id: $b } } } } }) { ok } }`,
+		{ b: openB },
+	)
+	// hidden: room's building is UNREADABLE (open=false) — parent must be invisible to the reader.
+	await mk(
+		tester,
+		gql`mutation ($b: UUID!) { createParent(data: { tag: "hidden", room: { create: { name: "anchor", building: { connect: { id: $b } } } } }) { ok } }`,
+		{ b: hiddenB },
+	)
+
+	const email = `closure${Date.now()}@doe.com`
+	const identityId = await tester.tenant.signUp(email)
+	const authKey = await tester.tenant.signIn(email)
+	await tester.tenant.addProjectMember(identityId, tester.projectSlug, { role: 'reader', variables: [] })
+
+	const readAll = async () => {
+		const list =
+			(await tester(gql`query { listParent(orderBy: [{ tag: asc }]) { tag room { name } } }`, { authorizationToken: authKey }).expect(200)).body.data
+				.listParent
+		const meta =
+			(await tester(gql`query { paginateParent { pageInfo { totalCount } } }`, { authorizationToken: authKey }).expect(200)).body.data.paginateParent
+				.pageInfo.totalCount
+		return { list, meta }
+	}
+	const filterMatch = async (filter: any) => {
+		const q = gql`query ($filter: ParentWhere) { listParent(filter: $filter, orderBy: [{ tag: asc }]) { tag } }`
+		return tags((await tester(q, { variables: { filter }, authorizationToken: authKey }).expect(200)).body.data.listParent)
+	}
+
+	// State A: hidden building open=false.
+	const a = await readAll()
+	expect(tags(a.list), 'only the readable-building parent is visible').toEqual(['visible'])
+	expect(a.list.every((p: any) => p.room != null), 'every visible parent has a readable room').toBe(true)
+	expect(a.meta, 'totalCount agrees with the readable node set').toBe(1)
+
+	// Filter / projection agreement over the readable view.
+	expect(await filterMatch({ room: { name: { eq: 'anchor' } } }), 'positive room filter matches only readable').toEqual(['visible'])
+	expect(await filterMatch({ room: { id: { isNull: false } } }), 'isNull:false matches only readable room').toEqual(['visible'])
+	expect(await filterMatch({ not: { room: { id: { isNull: true } } } }), 'not(isNull) == readable').toEqual(['visible'])
+
+	// Metamorphic: mutate ONLY the hidden building's fields (still open=false). The reader view must not change.
+	await mk(tester, gql`mutation ($b: UUID!) { updateBuilding(by: { id: $b }, data: { code: "MUTATED" }) { ok } }`, { b: hiddenB })
+	const b = await readAll()
+	expect(tags(b.list), 'reader view invariant to hidden-building mutation').toEqual(tags(a.list))
+	expect(b.meta, 'totalCount invariant to hidden-building mutation').toBe(a.meta)
+	expect(await filterMatch({ room: { name: { eq: 'anchor' } } }), 'filter invariant to hidden-building mutation').toEqual(['visible'])
+})

--- a/packages/engine-content-api/src/ExecutionContainer.ts
+++ b/packages/engine-content-api/src/ExecutionContainer.ts
@@ -161,7 +161,8 @@ export class ExecutionContainerFactory {
 				))
 			.addService(
 				'orderByBuilder',
-				({ joinBuilder, predicateFactory, whereBuilder, schema }) => new OrderByBuilder(schema.model, joinBuilder, predicateFactory, whereBuilder),
+				({ joinBuilder, predicateFactory, predicatesInjector, whereBuilder, schema }) =>
+					new OrderByBuilder(schema.model, joinBuilder, predicateFactory, predicatesInjector, whereBuilder),
 			)
 			.addService(
 				'relationFetcher',
@@ -190,7 +191,9 @@ export class ExecutionContainerFactory {
 			}))
 			.addService(
 				'selectBuilderFactory',
-				({ whereBuilder, orderByBuilder, fieldsVisitorFactory, metaHandler, selectHandlers, pathFactory, predicateFactory, schema }) =>
+				(
+					{ whereBuilder, orderByBuilder, fieldsVisitorFactory, metaHandler, selectHandlers, pathFactory, predicateFactory, predicatesInjector, schema },
+				) =>
 					new (class implements SelectBuilderFactory {
 						create(qb: DbSelectBuilder, hydrator: SelectHydrator, relationPath: Model.AnyRelationContext[]): SelectBuilder {
 							return new SelectBuilder(
@@ -205,6 +208,7 @@ export class ExecutionContainerFactory {
 								pathFactory,
 								relationPath,
 								predicateFactory,
+								predicatesInjector,
 							)
 						}
 					})(),

--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -113,12 +113,14 @@ export class PredicatesInjector {
 			predicatesWhere = { [entity.primary]: { always: true } }
 		} else {
 			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, effectiveFieldNames, relationContext, effectiveIsRoot)
-			// Process the predicate to inject nested entity predicates
+			// Process the predicate to inject nested entity predicates. The closure stack starts with `entity`
+			// because `rawPredicate` IS this entity's own read predicate — re-entering its expansion is a cycle.
 			predicatesWhere = this.injectPredicatesToPredicate(
 				rawPredicate,
 				entity,
 				isBackReferenceContext ?? false,
 				ancestorPath ?? [],
+				new Set([entity.name]),
 			)
 		}
 
@@ -133,6 +135,25 @@ export class PredicatesInjector {
 	}
 
 	/**
+	 * Recursively ACL-close an already-resolved FIELD (cell) read guard, exactly as {@link createWhere}
+	 * closes a row predicate. The projection cell mask and the order-key guard build the raw field guard via
+	 * `PredicateFactory.buildReadPredicates` (a predicate reference → WHERE) and lower it straight to SQL; that
+	 * raw guard has NO target `read` injected, so a guard traversing a relation (e.g. `Employee.salary` readable
+	 * only `{dept:{open:true}}`) leaks the traversed row's value when that row is itself unreadable
+	 * (`Dept.read = {company:{id:companyVar}}`). Routing the guard through this closure injects `Dept.read` under
+	 * the traversal → `{dept:{open:true, company:{id:companyVar}}}`, masking the cell in every state. For a guard
+	 * with no relation hops the closure is a structural no-op (byte-identical SQL). `relationPath` is the path
+	 * that reached `entity`, used for back-reference detection inside the traversal (mirrors the row path).
+	 */
+	public closeReadPredicate(
+		entity: Model.Entity,
+		where: Input.OptionalWhere,
+		relationPath: readonly Model.AnyRelationContext[] = [],
+	): Input.OptionalWhere {
+		return this.injectPredicatesToPredicate(where, entity, false, relationPath, new Set([entity.name]))
+	}
+
+	/**
 	 * Processes a predicate and injects nested entity predicates for any relation traversals.
 	 * This ensures that when a predicate like { department: { company: { name: 'Acme' } } }
 	 * is used, the predicates of Department and Company are also applied.
@@ -142,21 +163,22 @@ export class PredicatesInjector {
 		entity: Model.Entity,
 		isBackReferenceContext: boolean,
 		ancestorPath: readonly Model.AnyRelationContext[],
+		targetClosure: ReadonlySet<string>,
 	): Input.OptionalWhere {
 		const resultWhere: Writable<Input.OptionalWhere> = {}
 
 		if (where.and) {
 			resultWhere.and = where.and
 				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath))
+				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, targetClosure))
 		}
 		if (where.or) {
 			resultWhere.or = where.or
 				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath))
+				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, targetClosure))
 		}
 		if (where.not) {
-			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath)
+			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath, targetClosure)
 		}
 
 		const fields = Object.keys(where).filter(it => !['and', 'or', 'not'].includes(it))
@@ -186,6 +208,7 @@ export class PredicatesInjector {
 						context.targetEntity,
 						nestedIsBackReferenceContext,
 						nestedAncestorPath,
+						targetClosure,
 					)
 
 					const primaryKey = context.targetEntity.primary
@@ -199,7 +222,7 @@ export class PredicatesInjector {
 					// within a predicate is always through-access, so it consults the `all` permission set (isRoot=false).
 					const targetPredicate = shouldSimplifyNested
 						? { [context.targetEntity.primary]: { always: true } }
-						: this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, false)
+						: this.closeTargetPredicate(context, nestedIsBackReferenceContext, nestedAncestorPath, targetClosure)
 
 					// Optimization: avoid duplicate { id: always } when both are simplified
 					const targetIsAlwaysTrue = this.isAlwaysTruePrimaryWhere(targetPredicate, primaryKey)
@@ -222,6 +245,35 @@ export class PredicatesInjector {
 		}
 
 		return resultWhere
+	}
+
+	/**
+	 * The target entity's own read predicate for a relation reached from WITHIN another predicate, recursively
+	 * ACL-closed. Historically this was appended RAW via `PredicateFactory.create`, so any relation inside the
+	 * target's predicate never had ITS target's predicate injected — a readable-view leak: e.g.
+	 * `Parent.read = {room:{name}}` with `Room.read = {building:{code}}` and an independent `Building.read` left
+	 * the building's readability unenforced (a parent whose room's building is unreadable stayed visible).
+	 *
+	 * Closing recurses only through TO-ONE hops (to-many stays legacy, deferred to the to-many slice). A to-one
+	 * back-hop that re-reaches a row-gated ancestor is already collapsed to `{primary: always}` by the caller's
+	 * `shouldSimplifyNested`, so it never reaches here. `targetClosure` tracks the entities whose predicate is
+	 * being expanded up this branch: re-entering one is a genuine ACL cycle (e.g. a to-many round-trip or a
+	 * missing-inverse loop), where we fall back to the raw predicate — terminating exactly at the boundary the
+	 * pre-existing code stopped at (no infinite recursion, no new error, strictly less leakage than before).
+	 */
+	private closeTargetPredicate(
+		context: Model.AnyRelationContext,
+		isBackReferenceContext: boolean,
+		ancestorPath: readonly Model.AnyRelationContext[],
+		targetClosure: ReadonlySet<string>,
+	): Input.OptionalWhere {
+		const rawTargetPredicate = this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, false)
+		const isToOne = PredicatesInjector.toOneBackReferenceTypes.has(context.type)
+		if (!isToOne || targetClosure.has(context.targetEntity.name) || Object.keys(rawTargetPredicate).length === 0) {
+			return rawTargetPredicate
+		}
+		const nestedClosure = new Set(targetClosure).add(context.targetEntity.name)
+		return this.injectPredicatesToPredicate(rawTargetPredicate, context.targetEntity, isBackReferenceContext, ancestorPath, nestedClosure)
 	}
 
 	private injectToWhere(

--- a/packages/engine-content-api/src/mapper/select/OrderByBuilder.ts
+++ b/packages/engine-content-api/src/mapper/select/OrderByBuilder.ts
@@ -4,7 +4,7 @@ import { JoinBuilder } from './JoinBuilder.js'
 import { CaseStatement, Literal, QueryBuilder, SelectBuilder, wrapIdentifier } from '@contember/database'
 import { acceptFieldVisitor, getColumnName, getTargetEntity } from '@contember/schema-utils'
 import { UserError } from '../../exception.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { PredicateFactory, PredicatesInjector } from '../../acl/index.js'
 import { WhereBuilder } from './WhereBuilder.js'
 
 const orderByMapping = {
@@ -29,6 +29,7 @@ export class OrderByBuilder {
 		private readonly schema: Model.Schema,
 		private readonly joinBuilder: JoinBuilder,
 		private readonly predicateFactory: PredicateFactory,
+		private readonly predicatesInjector: PredicatesInjector,
 		private readonly whereBuilder: WhereBuilder,
 	) {}
 
@@ -178,7 +179,14 @@ export class OrderByBuilder {
 		const columnLiteral = new Literal(`${wrapIdentifier(path.alias)}.${wrapIdentifier(columnName)}`)
 		const conditions: Literal[] = []
 		for (const guard of guards) {
-			const predicateWhere = this.predicateFactory.buildReadPredicates(guard.entity, [guard.predicate], guard.relationPath)
+			// Close the order-key guard the same way projection closes the cell mask: a guard traversing a
+			// relation gets the traversed target's `read` injected, so ordering can never leak an unreadable
+			// traversed row's value. No-op for guards without relation hops.
+			const predicateWhere = this.predicatesInjector.closeReadPredicate(
+				guard.entity,
+				this.predicateFactory.buildReadPredicates(guard.entity, [guard.predicate], guard.relationPath),
+				guard.relationPath,
+			)
 			// The row-level predicate is already guaranteed in the WHERE of the ACL-filtered entity, so let the
 			// optimizer simplify it out of the cell-level predicate (mirrors SelectBuilder's predicate column).
 			const evaluatedPredicates = guard.isAclFiltered

--- a/packages/engine-content-api/src/mapper/select/SelectBuilder.ts
+++ b/packages/engine-content-api/src/mapper/select/SelectBuilder.ts
@@ -11,7 +11,7 @@ import { MetaHandler } from './handlers/index.js'
 import { Mapper } from '../Mapper.js'
 import { FieldNode, ObjectNode } from '../../inputProcessing/index.js'
 import { assertNever } from '../../utils/index.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { PredicateFactory, PredicatesInjector } from '../../acl/index.js'
 
 export class SelectBuilder {
 	private resolver: (value: SelectRow[]) => void = () => {
@@ -33,6 +33,7 @@ export class SelectBuilder {
 		private readonly pathFactory: PathFactory,
 		private readonly relationPath: Model.AnyRelationContext[],
 		private readonly predicateFactory: PredicateFactory,
+		private readonly predicatesInjector: PredicatesInjector,
 	) {}
 
 	public async execute(db: Client): Promise<SelectRow[]> {
@@ -95,7 +96,14 @@ export class SelectBuilder {
 
 			if (!fetchedPredicates.has(predicate)) {
 				const primaryPredicate = this.predicateFactory.createReadPredicate(entity, undefined, this.relationPath)
-				const fieldPredicate = this.predicateFactory.buildReadPredicates(entity, [predicate], this.relationPath)
+				// Recursively ACL-close the field guard so a relation it traverses gets its target `read` injected
+				// (e.g. `salary` guard `{dept:{open:true}}` → `{dept:{open:true, company:{id:companyVar}}}`),
+				// masking the cell when the traversed row is unreadable. No-op for guards without relation hops.
+				const fieldPredicate = this.predicatesInjector.closeReadPredicate(
+					entity,
+					this.predicateFactory.buildReadPredicates(entity, [predicate], this.relationPath),
+					this.relationPath,
+				)
 
 				const { qb, condition } = this.whereBuilder.buildConditionLiteral(
 					this.qb,

--- a/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
@@ -707,10 +707,10 @@ describe('predicates injector - multi-level back-reference', () => {
 		// the predicate should NOT be simplified AND nested predicates should be applied
 		const injected = injector.inject(schema.model.entities.Employee, {})
 
-		// Full predicate with nested entity predicates applied:
-		// - Employee predicate: { department: { company: { isActive: true } } }
-		// - Department predicate: { company: { isActive: true } } is added
-		// - Company predicate: { isActive: true } is added inside company traversal
+		// Full predicate with nested entity predicates applied. Department's OWN predicate is now recursively
+		// ACL-closed too: its `company` hop gets Company's read predicate injected, exactly like the
+		// Employee-predicate branch — so a target entity's readability is enforced no matter which branch
+		// reaches it. Here Company.read == the authored condition, so the extra term is a (harmless) duplicate.
 		assert.deepStrictEqual(injected, {
 			department: {
 				and: [
@@ -722,7 +722,14 @@ describe('predicates injector - multi-level back-reference', () => {
 							],
 						},
 					},
-					{ company: { isActive: { eq: true } } }, // Department's predicate
+					{
+						company: {
+							and: [
+								{ isActive: { eq: true } }, // Department's predicate
+								{ isActive: { eq: true } }, // Company's own predicate, now closed under Department's predicate too
+							],
+						},
+					},
 				],
 			},
 		})
@@ -1063,9 +1070,9 @@ describe('predicates injector - SECURITY: inconsistent predicates must NOT be si
 
 		const injected = injector.inject(schema.model.entities.Employee, {})
 
-		// Employee's condition (name='Acme') is preserved
-		// Department's predicate { company: { isActive: true } } is applied
-		// Company's predicate { isActive: true } is applied inside the traversal
+		// Employee's condition (name='Acme') is preserved. Department's own predicate { company: { isActive } }
+		// is now recursively ACL-closed, so Company's read predicate is injected under it too — Company's
+		// readability is enforced regardless of which predicate branch reaches Company.
 		assert.deepStrictEqual(injected, {
 			department: {
 				and: [
@@ -1077,7 +1084,14 @@ describe('predicates injector - SECURITY: inconsistent predicates must NOT be si
 							],
 						},
 					},
-					{ company: { isActive: { eq: true } } }, // Department predicate
+					{
+						company: {
+							and: [
+								{ isActive: { eq: true } }, // Department predicate
+								{ isActive: { eq: true } }, // Company's own predicate, now closed under Department's predicate too
+							],
+						},
+					},
 				],
 			},
 		})


### PR DESCRIPTION
## Summary

Closes two ACL **read** leaks where a relation reached from *within* an ACL read predicate was evaluated
against the raw target row instead of its readable view. Both are the same class — missing recursive ACL
closure — one on **row** predicates and one on relation-traversing **field/cell** guards.

Found via an empirical metamorphic leak audit of the whole read path (see below): of 8 audited leak-shapes,
**7 were already safe** and **1 leaked** — plus a second, deeper leak surfaced while building the audit.

Stacks on #923 (read-path hardening). No behavior change for the common case — guards without relation hops
are byte-identical; only two `predicatesInjector` unit assertions change to the deeper (correct) closure.

## The two leaks

**1. Deep nested row predicate.** A read predicate two or more to-one hops deep didn't enforce the deepest
entity's readability. `PredicatesInjector.injectPredicatesToPredicate` appended a relation's target read
predicate *raw*. Example: `Parent.read = {room:{name:"anchor"}}`, `Room.read = {building:{code:"B1"}}`,
`Building.read = {open:true}` — a parent whose room's building was `open=false` (unreadable) still leaked as
visible, because `Building.read` was never injected under the room predicate.

**2. Relation-traversing field guard.** A projected or ordered field whose read guard traverses a relation was
evaluated against the raw target. Example: `Employee.salary` readable only when `{dept:{open:true}}`, with the
employee's `dept` in an unreadable other company — projecting `salary` revealed whether the unreadable
`dept.open` was true, even though `dept` itself projects as `null`.

## The fix

A single recursive closure applied to both consumers:
- `injectPredicatesToPredicate` threads a closure stack and recursively ACL-closes **to-one** hops
  (`closeTargetPredicate`); cyclic configs terminate by falling back to the previous raw append at the cycle
  boundary — strictly monotonic (never loops, never newly errors, only reduces leakage). To-many hops keep the
  raw append.
- The projection cell mask (`SelectBuilder`) and order-key guard (`OrderByBuilder`) route the field guard
  through the same closure (`closeReadPredicate`), so e.g. the salary guard becomes
  `{and:[{dept:{open:true}}, {dept:{company:{id:companyVar}}}]}` — the out-of-scope dept makes it false and the
  cell is masked in every state.

## The audit

A metamorphic oracle (two dataset states differing only in data a restricted role cannot read → identical
responses, with a root "teeth" check proving non-vacuity) was run across the read-path leak-shapes not already
covered by existing e2e tests: to-many/M:N masked-cell filters, `some`/`none`/`every`, projection-vs-filter
divergence, order-by bisection, nested `totalCount`, deep mixed NOT/AND/OR, `_meta`, and relation-traversing
field guards. **7/8 were already leak-free on the branch; the relation-traversing field guard (shape 6) leaked
and is fixed here.** Added as `e2e/cases/content/acl-audit-gaps.test.ts` (8 shapes) plus
`acl-nested-predicate-closure.test.ts` (the deep-chain regression).

## Verification

- `bun test packages/engine-content-api`: **476 pass / 0 fail** (only the 2 deeper-closure assertions changed).
- `tsc --build`: clean.
- e2e (live PostgreSQL): `acl-audit-gaps` (incl. the fixed shape 6), `acl-nested-predicate-closure`,
  `acl-leak-oracle`, `acl-isnull-relation-readable-view` — **all green**.
- `biome` + `dprint`: clean.

## Note on the readable-scope refactor

These areas were also explored by a larger "readable read-path scope" refactor (occurrence-owned two-valued
guard masking). The audit showed that refactor is **optional robustness** rather than leak-closing — the two
fixes here close the only live read-path leaks found — so it is parked as WIP; this PR ships just the fixes.
