### PR TITLE
test(react-client-tenant): unmount between TenantForm cases

### DIFF
--- a/packages/react-client-tenant/tests/TenantForm.test.tsx
+++ b/packages/react-client-tenant/tests/TenantForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'bun:test'
-import { fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { GraphQlClientError } from '@contember/graphql-client'
 import { TenantForm } from '../src/components/forms/TenantForm.js'
 import { useForm } from '../src/contexts.js'
@@ -29,6 +29,11 @@ const renderProbe = (execute: () => Promise<never>) => {
 	)
 	return result
 }
+
+// Unmount between the cases: without it the second render leaves two forms in the document and
+// getByText('submit') fails on the duplicate. Auto-cleanup only kicks in when the testing library
+// sees a global afterEach, which it doesn't reliably do here.
+afterEach(cleanup)
 
 describe('TenantForm error codes', () => {
 	it('reports a denied mutation as FORBIDDEN', async () => {


### PR DESCRIPTION
`main` has been red since #927 landed: `TenantForm error codes > reports a genuine failure as UNKNOWN_ERROR` fails with `Found multiple elements with the text: submit` ([run 32136505267](https://github.com/contember/contember/actions/runs/32136505267)).

The two cases in that file render into the same document and nothing unmounts the first one, so the second `getByText('submit')` matches both forms and throws. `@testing-library/react` registers its own cleanup only when it finds a global `afterEach` at import time, which doesn't reliably happen under `bun test` — locally the file passes, in CI it doesn't. Registering the cleanup explicitly makes it independent of that.

Blocks CI for everything else, including #933.