### PR TITLE
chore: replace the local minio object storage with seaweedfs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ bun run format:check      # Check formatting (dprint)
 bun run format            # Auto-format (dprint)
 
 # Local dev environment
-docker-compose up --detach       # Start postgres, redis, mailhog, minio, adminer
+docker-compose up --detach       # Start postgres, redis, mailhog, object-storage, adminer
 docker-compose up engine         # Run engine server (port 4000)
 
 # Fill the local engine with data for every management panel page (idempotent)

--- a/docker-compose.override.dist.yaml
+++ b/docker-compose.override.dist.yaml
@@ -7,7 +7,7 @@
 #        COMPOSE_PROJECT_NAME=contember-oss-myworktree
 #        CONTEMBER_ENGINE_PORT=3101
 #        CONTEMBER_ADMINER_PORT=3102
-#        CONTEMBER_MINIO_PORT=3103
+#        CONTEMBER_OBJECT_STORAGE_PORT=3103
 #        CONTEMBER_POSTGRES_PORT=3105
 #        CONTEMBER_MAILHOG_PORT=3106
 #      (COMPOSE_PROJECT_NAME is required — otherwise two worktrees both default to their
@@ -25,8 +25,8 @@ services:
   adminer:
     ports: [ '${CONTEMBER_ADMINER_PORT:-3002}:8080' ]
 
-  minio:
-    ports: [ '${CONTEMBER_MINIO_PORT:-3003}:9000' ]
+  object-storage:
+    ports: [ '${CONTEMBER_OBJECT_STORAGE_PORT:-3003}:9000' ]
 
   postgres:
     ports: [ '${CONTEMBER_POSTGRES_PORT:-3005}:5432' ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,12 +65,16 @@ services:
       TENANT_MAILER_HOST: 'mailhog'
       TENANT_MAILER_PORT: '1025'
       TENANT_MAILER_FROM: 'contember@localhost'
+      # A Contember provider name, not the image behind `object-storage`: it selects path-style
+      # addressing and no object ACL (public read comes from the store's own config instead).
       DEFAULT_S3_PROVIDER: 'minio'
       DEFAULT_S3_REGION: ''
       DEFAULT_S3_BUCKET: 'contember'
       DEFAULT_S3_PREFIX: 'data'
       DEFAULT_S3_KEY: 'contember'
       DEFAULT_S3_SECRET: 'contember'
+      # The host port from docker-compose.override.dist.yaml, not the service name: the engine only
+      # signs URLs here and hands them to the browser, which resolves them itself.
       DEFAULT_S3_ENDPOINT: 'http://localhost:3003'
       CONTEMBER_PACKAGE_JSON: /src/packages/engine-server/package.json
     volumes:
@@ -115,16 +119,37 @@ services:
 #        condition: service_healthy
 
 
-  minio:
-    image: bitnamilegacy/minio:2025.7.23-debian-12-r5
+  # S3-compatible storage for the engine's asset bucket. SeaweedFS rather than MinIO: minio/minio
+  # and minio/mc are archived upstream, the newest published MinIO image predates the fix for
+  # MinIO's own CVE-2025-62506, and the Bitnami catalog the old image came from is frozen.
+  object-storage:
+    image: chrislusf/seaweedfs:4.42
+
+    # `mini` runs master + volume + filer + S3 in a single process. Both flags override a default
+    # that would bite us: `autoCreateBucket` is on by default and silently creates a bucket on the
+    # first write, so a typo would look like a working upload, and telemetry is on by default and
+    # reports to telemetry.seaweedfs.com every 24 h.
+    command: >
+      mini -dir=/data -s3.port=9000 -s3.config=/etc/seaweedfs/identities.json
+      -s3.autoCreateBucket=false -master.telemetry=false
 
     environment:
-      MINIO_ROOT_USER: 'contember'
-      MINIO_ROOT_PASSWORD: 'contember'
-      MINIO_DEFAULT_BUCKETS: 'contember:download'
+      # Created on start, an existing one left alone. Public read and the signing credentials live
+      # in the identities file — see its README.
+      S3_BUCKET: 'contember'
 
     volumes:
-      - minio-data:/data:cached
+      - object-storage-data:/data
+      - ./docker/object-storage/identities.json:/etc/seaweedfs/identities.json:ro
+
+    # The S3 port starts answering ~0.5 s before the bucket exists, so probing it (or `/healthz`)
+    # would report ready while an upload still fails with `NoSuchBucket`. The filer 404s on a bucket
+    # that isn't there yet, so ask it instead.
+    healthcheck:
+      test: [ 'CMD-SHELL', 'curl -fsS -o /dev/null "http://127.0.0.1:8888/buckets/contember/?limit=1"' ]
+      interval: 2s
+      timeout: 3s
+      retries: 30
 
 
   adminer:
@@ -171,4 +196,4 @@ services:
       MH_CORS_ORIGIN: '*'
 volumes:
   pgsql-data: ~
-  minio-data: ~
+  object-storage-data: ~

--- a/docker/object-storage/README.md
+++ b/docker/object-storage/README.md
@@ -1,0 +1,13 @@
+# Local object storage (SeaweedFS)
+
+`identities.json` is the `-s3.config` file for the `object-storage` compose service. JSON carries no
+comments, so the two identities are explained here.
+
+- **`anonymous`** — the unauthenticated caller. `Read:contember` makes exactly one bucket publicly
+  readable, which is what the engine's asset bucket needs: `generateUploadUrl` hands the browser a
+  `publicUrl` with no credentials on it. Any other bucket added to `S3_BUCKET` stays private until
+  it is listed here as well.
+- **`contember`** — the credentials the engine signs upload and read URLs with
+  (`DEFAULT_S3_KEY` / `DEFAULT_S3_SECRET`). Local dev only.
+
+Buckets are not declared here; the service creates them from `S3_BUCKET` on start.

--- a/docker/object-storage/identities.json
+++ b/docker/object-storage/identities.json
@@ -1,0 +1,13 @@
+{
+	"identities": [
+		{
+			"name": "anonymous",
+			"actions": ["Read:contember"]
+		},
+		{
+			"name": "contember",
+			"credentials": [{ "accessKey": "contember", "secretKey": "contember" }],
+			"actions": ["Admin", "Read", "Write", "List", "Tagging"]
+		}
+	]
+}

--- a/docs/src/content/docs/guides/self-hosted-contember.mdx
+++ b/docs/src/content/docs/guides/self-hosted-contember.mdx
@@ -10,7 +10,7 @@ This is an advanced guide. You don't need this - skip the hassle and [deploy to 
 ## What you'll need
 
 1. PostgreSQL database (e.g. [AWS RDS for PostgreSQL](https://aws.amazon.com/rds/postgresql/), [DigitalOcean Managed Database](https://www.digitalocean.com/products/managed-databases/))
-1. S3-compatible storage for file uploads (optional if you don't need file upload capability; e.g. [AWS S3](https://aws.amazon.com/s3/), [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/), [MinIO](https://min.io/), [CEPH](https://ceph.io/), [Zenko CloudServer](https://www.zenko.io/cloudserver/))
+1. S3-compatible storage for file uploads (optional if you don't need file upload capability; e.g. [AWS S3](https://aws.amazon.com/s3/), [DigitalOcean Spaces](https://www.digitalocean.com/products/spaces/), [SeaweedFS](https://seaweedfs.com/), [CEPH](https://ceph.io/), [Zenko CloudServer](https://www.zenko.io/cloudserver/))
 1. SMTP server to send emails from (optional)
 1. Some way to run Docker image.
 

--- a/docs/src/content/docs/intro/installation.mdx
+++ b/docs/src/content/docs/intro/installation.mdx
@@ -68,7 +68,7 @@ To stop your Contember project, just press ctrl+c to exit the process. This will
 **For advanced use-cases, there are also:**
 
 - Adminer database management tool at [http://localhost:1485](http://localhost:1485) to access database created by Contember.
-- Minio local S3 provider at [http://localhost:1483](http://localhost:1483) (you can sign in with contember / contember credentials). Contember uses object storage to store files and images uploaded by your users.
+- Local S3 provider (SeaweedFS) at [http://localhost:1483](http://localhost:1483) — an S3 API endpoint, so reach it with an S3 client using the `contember` / `contember` credentials. Contember uses object storage to store files and images uploaded by your users.
 - Mailhog - tool for testing emails at [http://localhost:1484](http://localhost:1484).
 - And of course PostgreSQL database at [localhost:1482](localhost:1482) (you can sign in with `contember` / `contember` credentials).
 

--- a/docs/src/content/docs/intro/studio-quickstart.mdx
+++ b/docs/src/content/docs/intro/studio-quickstart.mdx
@@ -71,7 +71,7 @@ Services that are now running on your local machine:
 For advanced use-cases there is also:
 
 - Adminer database management tool at [http://localhost:1485](http://localhost:1485).
-- Minio local S3 provider at [http://localhost:1483](http://localhost:1483) (you can sign in with contember / contember credentials).
+- Local S3 provider (SeaweedFS) at [http://localhost:1483](http://localhost:1483) — an S3 API endpoint, so reach it with an S3 client using the `contember` / `contember` credentials.
 - Mailhog testing SMTP at [http://localhost:1484](http://localhost:1484).
 - PostgreSQL database at [localhost:1482](localhost:1482) (you can sign in with contember / contember credentials).
 

--- a/docs/src/content/docs/reference/engine/content/s3.mdx
+++ b/docs/src/content/docs/reference/engine/content/s3.mdx
@@ -6,7 +6,7 @@ Beside operations for your data, there are mutations related to S3 compatible st
 
 ## S3 server
 
-In Contember development stack, there is bundled Minio server, which is S3 compatible storage server, therefore you don't have to setup anything on localhost as it is running out of box. For production [see our guide](/guides/self-hosted-contember#s3)
+In Contember development stack, there is a bundled SeaweedFS server, which is an S3 compatible storage server, therefore you don't have to setup anything on localhost as it is running out of box. Set `DEFAULT_S3_PROVIDER` to `minio` for it — the provider name selects path-style addressing without object ACL, which is what SeaweedFS and other MinIO-compatible servers need. For production [see our guide](/guides/self-hosted-contember#s3)
 
 ## Signing upload URL
 

--- a/packages/create/resources/templates/default/README.md
+++ b/packages/create/resources/templates/default/README.md
@@ -67,7 +67,9 @@ Follow these steps to set up and run your project locally:
 | S3               | 1483 | [http://localhost:1483](http://localhost:1483) |
 | MailPit          | 1484 | [http://localhost:1484](http://localhost:1484) |
 | Adminer          | 1485 | [http://localhost:1485](http://localhost:1485) |
-| S3 Dashboard     | 1486 | [http://localhost:1486](http://localhost:1486) |
+
+The S3 endpoint on 1483 is an API, not a web UI — reach it with an S3 client (`contember` /
+`contember`).
 
 When you're done, stop the Docker containers with:
 

--- a/packages/create/resources/templates/default/docker-compose.yaml
+++ b/packages/create/resources/templates/default/docker-compose.yaml
@@ -18,11 +18,15 @@ services:
       DEFAULT_DB_USER: 'contember'
       DEFAULT_DB_PASSWORD: 'contember'
 
+      # The host port, not the service name: the engine only signs URLs here and hands them to the
+      # browser, which resolves them itself.
       DEFAULT_S3_ENDPOINT: 'http://localhost:1483'
       DEFAULT_S3_BUCKET: 'contember'
       DEFAULT_S3_REGION: ''
       DEFAULT_S3_KEY: 'contember'
       DEFAULT_S3_SECRET: 'contember'
+      # A Contember provider name, not the image behind `object-storage`: it selects path-style
+      # addressing and no object ACL (public read comes from the store's own config instead).
       DEFAULT_S3_PROVIDER: 'minio'
 
       TENANT_MAILER_HOST: 'mailhog'
@@ -81,19 +85,37 @@ services:
       timeout: 5s
       retries: 10
 
-  minio:
-    image: bitnami/minio
+  object-storage:
+    image: chrislusf/seaweedfs:4.42
+
+    # `mini` runs master + volume + filer + S3 in a single process. Both flags override a default
+    # that would bite you: `autoCreateBucket` is on by default and silently creates a bucket on the
+    # first write, so a typo would look like a working upload, and telemetry is on by default and
+    # reports to telemetry.seaweedfs.com every 24 h.
+    command: >
+      mini -dir=/data -s3.port=9000 -s3.config=/etc/seaweedfs/identities.json
+      -s3.autoCreateBucket=false -master.telemetry=false
 
     environment:
-      MINIO_ROOT_USER: 'contember'
-      MINIO_ROOT_PASSWORD: 'contember'
-      MINIO_DEFAULT_BUCKETS: 'contember:download'
+      # Created on start, an existing one left alone. Public read and the signing credentials live
+      # in the identities file — see docker/object-storage/README.md.
+      S3_BUCKET: 'contember'
 
     ports:
       - '1483:9000'
 
     volumes:
-      - minio-data:/bitnami/minio/data
+      - object-storage-data:/data
+      - ./docker/object-storage/identities.json:/etc/seaweedfs/identities.json:ro
+
+    # The S3 port starts answering ~0.5 s before the bucket exists, so probing it (or `/healthz`)
+    # would report ready while an upload still fails with `NoSuchBucket`. The filer 404s on a bucket
+    # that isn't there yet, so ask it instead.
+    healthcheck:
+      test: [ 'CMD-SHELL', 'curl -fsS -o /dev/null "http://127.0.0.1:8888/buckets/contember/?limit=1"' ]
+      interval: 2s
+      timeout: 3s
+      retries: 30
 
   mailhog:
     image: mailhog/mailhog
@@ -121,4 +143,4 @@ services:
 
 volumes:
   pgsql-data: ~
-  minio-data: ~
+  object-storage-data: ~

--- a/packages/create/resources/templates/default/docker/object-storage/README.md
+++ b/packages/create/resources/templates/default/docker/object-storage/README.md
@@ -1,0 +1,13 @@
+# Local object storage (SeaweedFS)
+
+`identities.json` is the `-s3.config` file for the `object-storage` service in
+`docker-compose.yaml`. JSON carries no comments, so the two identities are explained here.
+
+- **`anonymous`** — the unauthenticated caller. `Read:contember` makes exactly one bucket publicly
+  readable, which is what the Contember engine's asset bucket needs: `generateUploadUrl` hands the
+  browser a `publicUrl` with no credentials on it. Any other bucket added to `S3_BUCKET` stays
+  private until it is listed here as well.
+- **`contember`** — the credentials the engine signs upload and read URLs with
+  (`DEFAULT_S3_KEY` / `DEFAULT_S3_SECRET`). Local dev only; a deployed environment holds its own.
+
+Buckets are not declared here; the service creates them from `S3_BUCKET` on start.

--- a/packages/create/resources/templates/default/docker/object-storage/identities.json
+++ b/packages/create/resources/templates/default/docker/object-storage/identities.json
@@ -1,0 +1,13 @@
+{
+	"identities": [
+		{
+			"name": "anonymous",
+			"actions": ["Read:contember"]
+		},
+		{
+			"name": "contember",
+			"credentials": [{ "accessKey": "contember", "secretKey": "contember" }],
+			"actions": ["Admin", "Read", "Write", "List", "Tagging"]
+		}
+	]
+}

--- a/packages/create/src/commands/WorkspaceCreateCommand.ts
+++ b/packages/create/src/commands/WorkspaceCreateCommand.ts
@@ -95,10 +95,9 @@ ${chalk.bold('API & Backend')}
 
 ${chalk.bold('Development Tools')}
 - PostgreSQL database     ${chalk.blue('http://localhost:1482')}    ${chalk.grey('credentials: contember / contember')}
-- Minio S3 storage        ${chalk.blue('http://localhost:1483')}
+- S3 object storage       ${chalk.blue('http://localhost:1483')}    ${chalk.grey('credentials: contember / contember')}
 - Mailpit SMTP testing    ${chalk.blue('http://localhost:1484')}
 - Adminer DB manager      ${chalk.blue('http://localhost:1485')}
-- Minio Dashboard         ${chalk.blue('http://localhost:1486')}    ${chalk.grey('credentials: contember / contember')}
 
 ${chalk.bold('Need help?')} Ask the community: https://github.com/orgs/contember/discussions
 `

--- a/packages/engine-s3-plugin/src/Config.ts
+++ b/packages/engine-s3-plugin/src/Config.ts
@@ -2,6 +2,7 @@ import * as Typesafe from '@contember/typesafe'
 
 export enum S3Providers {
 	aws = 'aws',
+	// Path-style addressing with no object ACL — the right value for any MinIO-compatible server, SeaweedFS included.
 	minio = 'minio',
 	ceph = 'ceph',
 	localstack = 'localstack',


### PR DESCRIPTION
## Why

The dev stack's object storage runs on images nobody maintains any more, and the project template's one is already broken.

- **`minio/minio` and `minio/mc` are archived upstream** (GitHub `archived: true`, last push 2026-04-24). The last community release, `RELEASE.2025-10-15`, fixed MinIO's own **CVE-2025-62506** but **never shipped as an image** — the newest tag on Docker Hub and quay.io is `RELEASE.2025-09-07`. Anyone running MinIO today runs an image that is missing the fix for MinIO's last CVE.
- **Bitnami's catalog moved to `bitnamilegacy/*`** — no further updates or security patches ever — and `bitnamisecure/minio` is subscription-only.
- **`bitnami/minio` no longer resolves at all.** Verified: `docker manifest inspect docker.io/bitnami/minio:latest` → `no such manifest`. That image is what `packages/create/resources/templates/default/docker-compose.yaml` asks for, so **every project created from the template today fails to start its object storage.** This is a live breakage for new users, not just staleness.

Alternatives were ruled out by measurement, not by reading: **Garage** has no bucket policies (`Unimplemented action: GetBucketPolicy`, anonymous GET 403) and forces `GK`+24-hex access keys; **LocalStack**'s repo is archived and its free tier forbids commercial use; **Adobe S3Mock** validates neither signatures nor presigned URLs. `pgsty/silo` is a live AGPL MinIO fork and would be the lower-migration-risk option if a drop-in were wanted; **SeaweedFS** is the recommendation here — Apache-2.0, roughly four releases a month, 4.42 released 2026-08-17.

## What changed

Both compose stacks now run `chrislusf/seaweedfs:4.42` under `weed mini` (master + volume + filer + S3 in one process), as a service named `object-storage`:

- **`docker-compose.yaml`** — the repo's dev stack.
- **`packages/create/resources/templates/default/docker-compose.yaml`** — the template every new Contember project gets.
- **`docker/object-storage/identities.json`** (+ a sibling `README.md`, in both the repo and the template) — buckets come from `S3_BUCKET`, but public read and the signing credentials have no env equivalent, so they live in the `-s3.config` file. JSON has no comments, hence the README.
- **`docker-compose.override.dist.yaml`** — `minio` → `object-storage`, `CONTEMBER_MINIO_PORT` → `CONTEMBER_OBJECT_STORAGE_PORT`.
- **Docs** (`intro/installation`, `intro/studio-quickstart`, `reference/engine/content/s3`, `guides/self-hosted-contember`), `CLAUDE.md`, the template `README.md` and the `create` command's closing summary.

Three details that are easy to get wrong, all encoded in the compose files with a comment:

- `anonymous` scoped `Read:contember` in the identities file is what replaces MinIO's `:download` bucket-policy suffix. Without it, public asset reads 403.
- **`-s3.autoCreateBucket` defaults to `true`**, which silently creates a bucket on the first write by an admin identity — a typo would look like a successful upload instead of `NoSuchBucket`. Turned off.
- **`-master.telemetry` defaults to `true`** and reports to `telemetry.seaweedfs.com` every 24 h. Turned off. (The flag is `-master.telemetry`, not `-telemetry`; a wrong flag name exits the container with 2.)

The service also gains a **healthcheck**, so `up --wait` gates on it. Measured on a cold volume: the S3 port and `/healthz` answer at 1.26 s, the bucket exists at 1.78 s — a **515 ms window** in which an S3-port probe would report ready but every upload 404s. So the probe asks the **filer** (`:8888/buckets/contember/`), which 404s until the bucket is there.

## Judgement calls

- **Renamed the service `minio` → `object-storage`, and `CONTEMBER_MINIO_PORT` → `CONTEMBER_OBJECT_STORAGE_PORT`.** Keeping a service called `minio` that runs SeaweedFS would mislead the next reader, and a provider-neutral name survives the next swap. The cost: a checkout that already has a `docker-compose.override.yaml` copied from the dist file must re-copy it — otherwise compose sees an override-only `minio` service with no image and fails loudly, which is the failure mode you want. In the template it is a new-project-only change; generated projects own their compose file and are unaffected.
- **`S3Providers.minio` in `packages/engine-s3-plugin/src/Config.ts` is untouched** apart from one clarifying comment. It is public configuration API and it correctly means "path-style addressing, no object ACL" — which is exactly what SeaweedFS needs. The compose files say the same thing next to `DEFAULT_S3_PROVIDER` so nobody reads it as naming the image.
- **Dropped the "Minio Dashboard / S3 Dashboard on :1486" line** from the `create` summary and the template README. The template never published :1486 (nor MinIO's console port), so that entry pointed at nothing. SeaweedFS's filer UI on :8888 could have filled the slot, but its HTTP API accepts unauthenticated writes, so publishing it would be a worse default than the login-gated console it would replace. The remaining :1483 line now says it is an S3 API endpoint and names the credentials, instead of inviting you to "sign in" to what was always the API port.
- **Left `docker/object-storage/` as a new top-level directory** in both repos, rather than inlining the identities into the compose file, so the file can be bind-mounted read-only and explained in prose next to itself.
- **`serversWithoutAclSupport` behaviour is unchanged**, so `generateUploadUrl(acl: …)` still returns "ACL is not supported" for this provider. That is the existing contract, not a SeaweedFS gap.

## Verification (measured, in a worktree of this branch)

Cold volume in both cases (`docker compose down -v` first):

| Check | Result |
|---|---|
| `up -d --wait object-storage`, repo dev stack | **healthy in 2.95 s** |
| `up -d --wait object-storage`, project generated by `@contember/create` from this branch | **healthy in 2.88 s** |
| `up -d --wait engine postgres object-storage` | **all healthy in 11.6 s** |
| S3 port / `/healthz` ready vs. bucket ready | 1.26 s vs 1.78 s → **515 ms gap** (hence the filer probe) |

S3 behaviour, driven through the engine's own `S3Service` / `S3Signer` / `S3ObjectAuthorizator` with the exact config `docker-compose.yaml` gives the engine service — 12/12:

```
PASS  presigned PUT — 200 data/12c30a9e-….txt
PASS  anonymous GET of publicUrl — 200, body matches: true
PASS  acl argument rejected (noAcl provider) — ACL is not supported
PASS  Content-Disposition round trip — PUT 200, GET 200, header: attachment; filename*=UTF-8''%C3%BA%C4%8Detn%C3%AD%20z%C3%A1v%C4%9Brka.pdf
PASS  presigned GET — 200
PASS  Range GET — 206 bytes 0-4/34
PASS  anonymous PUT denied — 403
PASS  private bucket: signed write ok — 200
PASS  private bucket: anonymous GET denied — 403
PASS  private bucket: signed GET allowed — 200
PASS  unknown bucket rejected — 404 NoSuchBucket
PASS  tampered signature rejected — 403
```

The "private bucket" rows use a second bucket added to `S3_BUCKET` but absent from the `anonymous` grant — that is what proves the public read on `contember` comes from `Read:contember` and is not a store-wide default.

Against a project generated from the template on this branch (its own store, its own volume): presigned PUT 200, anonymous GET 200 with matching body, unknown bucket 404 `NoSuchBucket`. The generated tree contains `docker/object-storage/identities.json`, so the template installer does ship it.

Repo checks, all green on this branch:

| Command | Result |
|---|---|
| `bun run lint` (biome) | 3503 files checked, no findings |
| `bun run format:check` (dprint) | clean |
| `bun run pre-build && bun run ts:build` | exit 0 |
| `bun run test` | **1912 pass / 0 fail**, 1915 tests across 367 files |
| `bun run test:legacy-decorators` | 33 pass / 0 fail |
| `bun test packages/engine-s3-plugin` | 8 pass / 0 fail |

Not verified, deliberately: the `generateUploadUrl` GraphQL mutation end to end. The playground project defines no `s3` ACL rules, so the S3 schema contributor exposes no mutation for it, and adding rules means a schema migration in a project unrelated to this change. Everything the resolver delegates to is exercised directly above, and the same end-to-end flow (mutation → CORS preflight → presigned PUT → anonymous GET, plus a 12 MiB upload and a browser uploader) was measured against a live Contember 2.2.0-alpha.3 engine on this exact SeaweedFS recipe in another repository before this PR. CI does not run `test:e2e`, and none of those cases touch S3, so they were not run here either.

## Operator note

**The data volume is new** (`minio-data` → `object-storage-data`), so a local stack comes up with an empty store — anything uploaded into the old volume has to be re-uploaded. The old volume is left in place rather than removed; drop it with `docker volume rm <project>_minio-data` once you are sure you do not want it.

If you have a `docker-compose.override.yaml` copied from `docker-compose.override.dist.yaml`, re-copy it: the service key and the port variable both changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o5Hv6c1NwqYnJTw3rUTKi
