### PR TITLE
fix(tenant): survive the 40001 race between disablePerson and session tracking

### DIFF
--- a/e2e/cases/tenant/disablePerson.test.ts
+++ b/e2e/cases/tenant/disablePerson.test.ts
@@ -14,6 +14,25 @@ const signInMutation = `mutation($email: String!, $password: String!) {
 	signIn(email: $email, password: $password) { ok error { code } }
 }`
 
+/**
+ * Looked up as the admin rather than through `me`, on purpose. Authenticating as the person schedules a background
+ * write to their `api_key` row (`ApiKeyManager.verifyAndProlong` fires it from `setImmediate` and does not await
+ * it), and `disablePerson` updates that very row inside a repeatable-read transaction. The two race, and the
+ * mutation is the one that loses — it aborts with `could not serialize access due to concurrent update`, which the
+ * caller sees as `Internal server error` and this test used to see as a bare `null`. The root token has no
+ * `api_key` row, so asking as the admin leaves the person's row alone.
+ */
+const personsQuery = `query($email: String!) {
+	persons(filter: { email: $email }) { id disabledAt }
+}`
+
+const findPerson = async (email: string): Promise<{ id: string; disabledAt: string | null }> => {
+	const resp = await executeGraphql('/tenant', personsQuery, { variables: { email } })
+	const persons = resp.body.data.persons
+	expect(persons).toHaveLength(1)
+	return persons[0]
+}
+
 test('disablePerson blocks future signIn with PERSON_DISABLED', async () => {
 	const tester = await createTester(emptySchema)
 	const email = `john-${rand()}@doe.com`
@@ -21,9 +40,8 @@ test('disablePerson blocks future signIn with PERSON_DISABLED', async () => {
 	await tester.tenant.signUp(email, password)
 
 	// initial signIn works
-	const token = await tester.tenant.signIn(email, password)
-	const personResp = await executeGraphql('/tenant', `query { me { person { id } } }`, { authorizationToken: token })
-	const personId: string = personResp.body.data.me.person.id
+	await tester.tenant.signIn(email, password)
+	const personId = (await findPerson(email)).id
 
 	const disableResp = await executeGraphql('/tenant', disableMutation, { variables: { id: personId } })
 	expect(disableResp.body.data.disablePerson).toEqual({ ok: true, error: null })
@@ -46,10 +64,10 @@ test('enablePerson restores signIn and reports the disabled state', async () => 
 	const password = 'HWGA51KKpJ4lSW'
 	await tester.tenant.signUp(email, password)
 
-	const token = await tester.tenant.signIn(email, password)
-	const personResp = await executeGraphql('/tenant', `query { me { person { id disabledAt } } }`, { authorizationToken: token })
-	const personId: string = personResp.body.data.me.person.id
-	expect(personResp.body.data.me.person.disabledAt).toBe(null)
+	await tester.tenant.signIn(email, password)
+	const person = await findPerson(email)
+	const personId = person.id
+	expect(person.disabledAt).toBe(null)
 
 	// Asserted rather than fired and forgotten: a silent failure here surfaces one step later as
 	// enablePerson reporting PERSON_ALREADY_ENABLED, which blames the wrong mutation.

--- a/packages/engine-tenant-api/src/model/service/PersonAccessManager.ts
+++ b/packages/engine-tenant-api/src/model/service/PersonAccessManager.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@contember/logger'
 import { PersonQuery, PersonRow } from '../queries/index.js'
 import { DatabaseContext } from '../utils/index.js'
 import { DisablePersonCommand } from '../commands/person/DisablePersonCommand.js'
@@ -9,7 +10,9 @@ import { DisablePersonErrorCode, EnablePersonErrorCode } from '../../schema/inde
 class PersonAccessManager {
 	constructor(private readonly apiKeyManager: ApiKeyManager) {}
 
-	async disablePerson(dbContext: DatabaseContext, person: PersonRow): Promise<PersonDisableAccessResponse> {
+	async disablePerson(dbContext: DatabaseContext, person: PersonRow, logger: Logger): Promise<PersonDisableAccessResponse> {
+		// Retried: the api_key update races the target's own background session tracking and loses with a 40001,
+		// which would otherwise leave the person enabled behind an internal error. Nothing here escapes the transaction.
 		return await dbContext.transaction(async trx => {
 			if (person.disabled_at !== null) {
 				return new ResponseError('PERSON_ALREADY_DISABLED', 'Person is already disabled')
@@ -20,7 +23,7 @@ class PersonAccessManager {
 			await this.disableIdentityApiKeys(trx, person.identity_id)
 
 			return new ResponseOk(null)
-		})
+		}, { retry: { logger } })
 	}
 
 	async enablePerson(dbContext: DatabaseContext, person: PersonRow): Promise<PersonEnableAccessResponse> {

--- a/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts
+++ b/packages/engine-tenant-api/src/model/service/apiKey/ApiKeyManager.ts
@@ -127,8 +127,10 @@ export class ApiKeyManager {
 			}
 		}
 
-		setImmediate(async () => {
-			await dbContext.commandBus.execute(
+		// Detached (runs after the response), so a rejection here would be an unhandledRejection and can take the
+		// worker down. Tracking is best-effort — the next request writes it again.
+		setImmediate(() => {
+			dbContext.commandBus.execute(
 				new ProlongApiKeyCommand(
 					apiKeyRow.id,
 					apiKeyRow.type,
@@ -142,7 +144,7 @@ export class ApiKeyManager {
 					},
 					apiKeyRow.max_expires_at,
 				),
-			)
+			).catch(() => {})
 		})
 
 		return new ResponseOk(

--- a/packages/engine-tenant-api/src/model/utils/DatabaseContext.ts
+++ b/packages/engine-tenant-api/src/model/utils/DatabaseContext.ts
@@ -1,7 +1,19 @@
-import { Client, Connection } from '@contember/database'
+import { Client, Connection, retryTransaction } from '@contember/database'
+import { Logger } from '@contember/logger'
 import { Providers } from '../providers.js'
 import { CommandBus } from '../commands/index.js'
 import { BatchLoaderArgs, initBatchLoader, ItemLoader } from '../../utils/batchQuery.js'
+
+export interface TransactionOptions {
+	/**
+	 * Repeat the transaction when postgres aborts it with a serialization failure (40001) — the standing cost of the
+	 * repeatable-read level every transaction here runs at.
+	 *
+	 * Opt in only when the callback has no effect outside the transaction: several managers send a mail from inside
+	 * one (InviteManager, EmailChangeManager, PasswordlessSignInManager) and a retry would send it twice.
+	 */
+	retry?: { logger: Logger }
+}
 
 export class DatabaseContext<Conn extends Connection.ConnectionLike = Connection.ConnectionLike> {
 	private loaders = new Map<BatchLoaderArgs<any, any, any>, ItemLoader<any, any>>()
@@ -20,11 +32,20 @@ export class DatabaseContext<Conn extends Connection.ConnectionLike = Connection
 		return this.client.createQueryHandler()
 	}
 
-	public async transaction<T>(cb: (dbContext: DatabaseContext<Connection.TransactionLike>) => Promise<T>): Promise<T> {
-		return await this.client.transaction(async db => {
-			await db.query(Connection.REPEATABLE_READ)
-			return await cb(new DatabaseContext(db, this.providers))
-		})
+	public async transaction<T>(
+		cb: (dbContext: DatabaseContext<Connection.TransactionLike>) => Promise<T>,
+		options: TransactionOptions = {},
+	): Promise<T> {
+		const run = async () =>
+			await this.client.transaction(async db => {
+				await db.query(Connection.REPEATABLE_READ)
+				return await cb(new DatabaseContext(db, this.providers))
+			})
+		const retry = options.retry
+		if (!retry) {
+			return await run()
+		}
+		return await retryTransaction(run, message => retry.logger.warn(message))
 	}
 
 	public async scope<T>(cb: (dbContext: DatabaseContext<Connection.AcquiredConnectionLike>) => Promise<T>): Promise<T> {

--- a/packages/engine-tenant-api/src/resolvers/mutation/person/DisablePersonMutationResolver.ts
+++ b/packages/engine-tenant-api/src/resolvers/mutation/person/DisablePersonMutationResolver.ts
@@ -32,7 +32,7 @@ export class DisablePersonMutationResolver implements MutationResolvers {
 			message: 'You are not allowed to disable person account',
 		})
 
-		const result = await this.personAccessManager.disablePerson(context.db, targetPerson)
+		const result = await this.personAccessManager.disablePerson(context.db, targetPerson, context.logger)
 		await context.logAuthAction({
 			type: 'person_disable',
 			response: result,

--- a/packages/engine-tenant-api/tests/cases/integration/mocked/disablePersonMutation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/integration/mocked/disablePersonMutation.test.ts
@@ -1,0 +1,89 @@
+import { executeTenantTest } from '../../../src/testTenant.js'
+import { GQL, SQL } from '../../../src/tags.js'
+import { testUuid } from '../../../src/testUuid.js'
+import { getPersonByIdSql } from './sql/getPersonByIdSql.js'
+import { sqlTransaction } from './sql/sqlTransaction.js'
+import { expect, test } from 'bun:test'
+
+const disablePersonQuery = GQL`mutation($id: String!) {
+	disablePerson(personId: $id) {
+		ok
+		error { code }
+	}
+}`
+
+test('disablePerson revokes the account and its api keys', async () => {
+	const personId = testUuid(1)
+	const identityId = testUuid(2)
+
+	await executeTenantTest({
+		query: {
+			query: disablePersonQuery,
+			variables: { id: personId },
+		},
+		executes: [
+			getPersonByIdSql({
+				personId,
+				response: { personId, identityId, password: '123', roles: [], email: 'jane@doe.com', disabledAt: null },
+			}),
+			...sqlTransaction(
+				{
+					sql: SQL`update "tenant"."person" set "disabled_at" = ? where "id" = ?`,
+					parameters: [(value: unknown) => value instanceof Date, personId],
+					response: { rowCount: 1 },
+				},
+				{
+					sql: SQL`update "tenant"."api_key" set "disabled_at" = ? where "identity_id" = ?`,
+					parameters: [(value: unknown) => value instanceof Date, identityId],
+					response: { rowCount: 1 },
+				},
+			),
+		],
+		return: {
+			data: {
+				disablePerson: { ok: true, error: null },
+			},
+		},
+		expectedAuthLog: {
+			type: 'person_disable',
+			targetPersonId: personId,
+			response: expect.objectContaining({ ok: true }),
+		},
+	})
+})
+
+test('disablePerson returns PERSON_ALREADY_DISABLED', async () => {
+	const personId = testUuid(1)
+	const identityId = testUuid(2)
+
+	await executeTenantTest({
+		query: {
+			query: disablePersonQuery,
+			variables: { id: personId },
+		},
+		executes: [
+			getPersonByIdSql({
+				personId,
+				response: {
+					personId,
+					identityId,
+					password: '123',
+					roles: [],
+					email: 'jane@doe.com',
+					disabledAt: new Date('2019-09-04 12:00'),
+				},
+			}),
+			...sqlTransaction(),
+		],
+		return: {
+			data: {
+				disablePerson: { ok: false, error: { code: 'PERSON_ALREADY_DISABLED' } },
+			},
+		},
+		expectedAuthLog: {
+			type: 'person_disable',
+			targetPersonId: personId,
+			response: expect.objectContaining({ ok: false }),
+		},
+	})
+})

--- a/packages/engine-tenant-api/tests/cases/unit/databaseContextRetry.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/databaseContextRetry.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from 'bun:test'
+import { createConnectionMock, ExpectedQuery } from '@contember/database-tester'
+import { SerializationFailureError } from '@contember/database'
+import { createLogger, TestLoggerHandler } from '@contember/logger'
+import { DatabaseContext } from '../../../src/index.js'
+import { Providers } from '../../../src/model/providers.js'
+
+// Every tenant transaction runs at repeatable read, so postgres aborts it with a 40001 as soon as another
+// transaction commits to a row it wants — the api_key row disablePerson touches is written by that very
+// person's background session tracking. Repeating is the only correct answer, but it is opt-in: several
+// managers send a mail from inside their transaction and would send it twice.
+
+const providers: Providers = {
+	uuid: () => '11111111-1111-1111-1111-111111111111',
+	now: () => new Date('2026-01-01T00:00:00Z'),
+	randomBytes: length => Promise.resolve(Buffer.alloc(length)),
+	bcrypt: value => Promise.resolve(value),
+	bcryptCompare: (data, encrypted) => Promise.resolve(data === encrypted),
+	hash: value => Buffer.from(String(value)),
+	encrypt: () => {
+		throw new Error('not supported')
+	},
+	decrypt: () => {
+		throw new Error('not supported')
+	},
+	encryptionEnabled: false,
+}
+
+const serializationFailure = () =>
+	new SerializationFailureError('update "tenant"."api_key" set "disabled_at" = $1 where "identity_id" = $2', [], {
+		code: '40001',
+		message: 'could not serialize access due to concurrent update',
+	})
+
+const begin: ExpectedQuery[] = [
+	{ sql: 'BEGIN;', response: { rowCount: 1 } },
+	{ sql: 'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ', response: { rowCount: 1 } },
+]
+const commit: ExpectedQuery = { sql: 'COMMIT;', response: { rowCount: 1 } }
+
+const createDbContext = (queries: ExpectedQuery[]) => {
+	const connection = createConnectionMock(queries)
+	return new DatabaseContext(connection.createClient('tenant', { module: 'tenant' }), providers)
+}
+
+test('transaction with retry repeats the whole transaction after a serialization failure', async () => {
+	const queries = [...begin, ...begin, commit]
+	const dbContext = createDbContext(queries)
+	const handler = new TestLoggerHandler()
+	let attempts = 0
+
+	const result = await dbContext.transaction(async () => {
+		attempts++
+		if (attempts === 1) {
+			throw serializationFailure()
+		}
+		return 'done'
+	}, { retry: { logger: createLogger(handler) } })
+
+	expect(result).toBe('done')
+	expect(attempts).toBe(2)
+	// The second attempt opens its own transaction, so it gets a fresh snapshot — a retry on the same one
+	// would abort again forever.
+	expect(queries).toHaveLength(0)
+	// Logged through the injected logger, not an ambient one — a retry must not depend on request-scoped state.
+	expect(handler.messages).toHaveLength(1)
+	expect(handler.messages[0].message).toMatch(/^RETRY: Serialization failure \(attempt #1/)
+})
+
+test('transaction without retry lets the serialization failure through', async () => {
+	const dbContext = createDbContext([...begin])
+	let attempts = 0
+
+	const run = dbContext.transaction(async () => {
+		attempts++
+		throw serializationFailure()
+	})
+
+	await expect(run).rejects.toBeInstanceOf(SerializationFailureError)
+	expect(attempts).toBe(1)
+})


### PR DESCRIPTION
## The failure

`e2e/cases/tenant/disablePerson.test.ts` has been failing intermittently across postgres versions — most recently on PG 12 and PG 14, in whichever of its tests got unlucky. `disablePerson` came back as a bare `null`:

```
- { "error": null, "ok": true }
+ null
```

The error logging added in #933 named the cause on its first run:

```
GraphQL errors from POST /tenant: [{"message":"Internal server error"}]
```

and the postgres log, at the same millisecond:

```
ERROR:  could not serialize access due to concurrent update
STATEMENT:  update "tenant"."api_key" set "disabled_at" = $1 where "identity_id" = $2
```

## The race

Two writers, same `api_key` row — the session created by `signIn`.

**A — background session tracking**, autocommit, read committed. Every authenticated request schedules one: `ApiKeyManager.verifyAndProlong` fires `ProlongApiKeyCommand` from `setImmediate` and never awaits it, so the write outlives the request. On a token's *first* use it always writes, because `last_used_at IS NULL` makes `shouldUpdateTracking` true.

```sql
update "tenant"."api_key" set "last_ip"=$1, "last_user_agent"=$2, "last_used_at"=$3 where "id"=$4
```

**B — `disablePerson`**, in the transaction `DatabaseContext` opens at repeatable read:

```sql
BEGIN;
SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
update "tenant"."person"  set "disabled_at"=$1 where "id"=$2            -- (1)
update "tenant"."api_key" set "disabled_at"=$1 where "identity_id"=$2   -- (2)
COMMIT;
```

Postgres takes the repeatable-read snapshot lazily, at the first statement that needs one — not at `BEGIN`, and not at `SET TRANSACTION ISOLATION LEVEL`. So the snapshot is taken at (1), and B is only blind to concurrent writers from that point on.

B then fails **iff** A takes the row lock before (2) *and* commits after that snapshot: on repeatable read an `UPDATE` that meets a row whose newest version was written by a transaction committed after the snapshot can neither overwrite it nor skip it, so it aborts with `40001`. B always loses — it is the one holding a snapshot. The error lands on (2), which rolls back (1) with it: **the person stays enabled** and the caller gets `Internal server error`.

The other interleavings are harmless. A committing before the snapshot is simply visible to B. A taking the lock after (2) just waits, then rewrites `last_used_at` on an already-disabled key.

The control case confirms it: `forceSignOutPerson` issues the *same* `update api_key where identity_id`, after the same authenticated request, and does not flake — because it runs outside a transaction (`ForceSignOutMutationResolver` → `disableIdentityApiKeys` → `commandBus`), so read-committed just waits for the lock and rewrites. The only difference between the flaking path and the stable one is the repeatable-read snapshot.

## What this does

**1. Retries the transaction (`3de2896`).** Nothing in the tenant API handled `40001`, although every one of its transactions runs at repeatable read — that is the defect, and `disablePerson` is only where it surfaced first. `retryTransaction` already exists in `@contember/database` and is what content-api uses (`MutationResolver`), so this wires it into `DatabaseContext.transaction`.

It is **opt-in**, not automatic: `InviteManager`, `EmailChangeManager` and `PasswordlessSignInManager` each send a mail from inside their transaction, and a blanket retry would send it twice. Those three are named in the doc comment. The logger is passed explicitly rather than read from the ambient `@contember/logger` proxy — `getLogger()` throws when no scope is set, and a shared helper should not acquire a hidden dependency on request-scoped state that only bites during a retry.

Only `disablePerson` opts in here. The remaining call sites can follow once each is checked for effects that escape its transaction.

**2. Guards the detached write (`f27334f`).** The `setImmediate` in `verifyAndProlong` was an unguarded async function: any rejection from the tracking update — a transient connection error, a pool timeout — became an unhandledRejection and can take the worker down. `IdpSessionRevalidator` already documents and handles exactly this for its own detached work. Tracking is best-effort, so the rejection is swallowed and the next request writes it again.

**3. Stops the e2e from creating the race (`58b0896`).** Reads the person through the admin `persons` query instead of `me`. The root token belongs to a different identity, so nothing writes to the person's `api_key` row while the mutation runs. (The root token itself *is* persisted — `migrations/tenantCredentials.ts` inserts an `api_key` row for `CONTEMBER_ROOT_TOKEN`; the unpersisted variant is `CONTEMBER_ROOT_TOKENS`. It is the identity that differs, not the persistence.)

## Tests

- `tests/cases/unit/databaseContextRetry.test.ts` — new. Pins both directions: with `retry` the whole transaction is repeated on a `SerializationFailureError` (a fresh `BEGIN`, so a fresh snapshot — retrying inside the aborted one would fail forever) and the warning goes through the injected logger; without it the error propagates untouched.
- `tests/cases/integration/mocked/disablePersonMutation.test.ts` — new. The mutation had no mocked-SQL coverage at all; asserts the full statement sequence, repeatable-read transaction included.
