### PR TITLE
feat(acl): compose `through` grants and enforce them on the write path

### DIFF
--- a/docs/src/content/docs/reference/engine/schema/acl.mdx
+++ b/docs/src/content/docs/reference/engine/schema/acl.mdx
@@ -186,9 +186,10 @@ Most of the time, you will declare ACL rules directly in your schema using the `
   - If omitted or `false`, the operation is disallowed by this rule (but can still be granted by another rule).
 - **`delete`**: A boolean. If `true`, allows deleting the entire row under the given `when` condition; if omitted or `false`, it does not allow deletion.
 - **`through`**:
-  - If `true`, means that *root-level* access for the operation is **disallowed**, but the operation is still allowed **through relations**.
-  - If you set `through: true`, you are effectively restricting direct queries (like listBook) or direct mutations (e..g updateBook) on the root. However, you can still access this entity if you traverse from a parent entity that *does* allow a root-level operation.
-  - You cannot mix "through" for the same operation in a conflicting way
+  - If `true`, this rule grants the operation **only when the entity is reached over a relation** — never at the root. It does not open a direct query (`listBook`) or a direct mutation (`updateBook`).
+  - `through` rules are **additive**. The permissions in effect under a relation are the root rules *plus* the `through` ones, so the same role, entity and operation can carry both: read `title` anywhere, read `secret` only through a relation.
+  - A root query or mutation is generated only when the **root** rules grant that operation. If every rule for an operation is `through: true`, the corresponding entry point disappears.
+  - Field-level `through` is enforced at execution time, not in the schema: a field granted only via `through` still appears on the entity type (types are shared between root and nested positions), and is denied when you read or write it at the root — the same way a field behind a row-level predicate behaves.
 
 #### Multiple `@c.Allow` Decorators
 
@@ -296,8 +297,9 @@ export class Product {
 ```
 
 - `read` of `id` is allowed at root level.
-- `update` of `name` is **not** allowed at the root query/mutation because `through: true` prevents direct updates.
+- `update` of `name` is **not** allowed at the root query/mutation, because the only rules granting it are `through: true`. No `updateProduct` mutation is generated.
 - If an upstream entity relation to `Product` is allowed to update it, then the user can update `name` **through** that relation—provided the `category` is `isActive: true` or `isActive: false`.
+- Adding a plain `@c.Allow(publicRole, { update: ['name'] })` alongside these would *also* allow the root update; the rules combine rather than conflict.
 
 
 ## `@c.AllowCustomPrimary`

--- a/packages/cli/src/commands/project/ProjectPrintSchemaCommand.ts
+++ b/packages/cli/src/commands/project/ProjectPrintSchemaCommand.ts
@@ -69,7 +69,8 @@ export class ProjectPrintSchemaCommand extends Command<Args, Options> {
 		const permissionFactory = new PermissionFactory()
 		const inputRoles = input.getOption('role')
 		const schemaNormalized = input.getOption('normalize') ? normalizeSchema(filteredSchema) : filteredSchema
-		const permissions = permissionFactory.create(schemaNormalized, inputRoles || ['admin'])
+		// Introspection renders types, so it needs the nested set - the same one the engine builds them from.
+		const { all: permissions } = permissionFactory.createContextual(schemaNormalized, inputRoles || ['admin'])
 		const schemaBuilderFactory = new GraphQlSchemaBuilderFactory()
 		const authorizator = new Authorizator(
 			permissions,

--- a/packages/engine-content-api/src/acl/AclScope.ts
+++ b/packages/engine-content-api/src/acl/AclScope.ts
@@ -1,0 +1,22 @@
+import { Model } from '@contember/schema'
+
+/**
+ * Where the entity being accessed sits relative to the query or mutation root.
+ *
+ * `root` resolves against the role's root grants only. `nested` additionally picks up the grants
+ * declared with `through: true`, which exist precisely to apply when an entity is reached over a
+ * relation and not directly.
+ *
+ * Every predicate lookup takes one of these explicitly - there is no default. The scope used to be
+ * an optional flag that silently fell back to `root`, which is how the whole write path ended up
+ * ignoring `through` grants.
+ */
+export type AclScope = 'root' | 'nested'
+
+/**
+ * Derives the scope from a relation path. Callers that already track how deep they are - the select
+ * builder, the predicate injector - should use this rather than deciding by hand, so the answer
+ * stays correct for every node instead of being computed once at the top and carried down.
+ */
+export const aclScopeFromPath = (path: readonly Model.AnyRelationContext[] | undefined): AclScope =>
+	path === undefined || path.length === 0 ? 'root' : 'nested'

--- a/packages/engine-content-api/src/acl/Authorizator.ts
+++ b/packages/engine-content-api/src/acl/Authorizator.ts
@@ -56,10 +56,6 @@ export class Authorizator {
 		return this.permissions?.[entity]?.operations?.customPrimary ?? this.defaultCustomPrimary
 	}
 
-	isRootOperationDisallowed(entity: string, operation: Acl.Operation): boolean {
-		return this.permissions?.[entity]?.operations?.noRoot?.includes(operation) ?? false
-	}
-
 	isRefreshMaterializedViewAllowed(entity: string): boolean {
 		return this.permissions?.[entity]?.operations?.refreshMaterializedView ?? this.allowRefreshMaterializedView
 	}

--- a/packages/engine-content-api/src/acl/PermissionFactory.ts
+++ b/packages/engine-content-api/src/acl/PermissionFactory.ts
@@ -1,5 +1,5 @@
 import { Acl, Model, Schema, Writable } from '@contember/schema'
-import { getEntity, PredicateDefinitionProcessor } from '@contember/schema-utils'
+import { getEntity, PredicateDefinitionProcessor, splitEntityPermissions } from '@contember/schema-utils'
 import { mapObject } from '../utils/index.js'
 import { prefixVariable } from './VariableUtils.js'
 
@@ -12,32 +12,57 @@ export interface ContextualPermissions {
 	all: Acl.Permissions
 }
 
+/**
+ * `root` covers what a role may do as the query or mutation root; `all` adds the grants that apply
+ * only when the entity is reached through a relation.
+ */
+export type PermissionScope = 'root' | 'all'
+
 export class PermissionFactory {
-	public create(schema: Schema, roles: readonly string[], prefix?: string): Acl.Permissions {
-		return this.createInternal(schema, roles, false, prefix)
+	public create(schema: Schema, roles: readonly string[], prefix?: string, scope: PermissionScope = 'root'): Acl.Permissions {
+		return this.createInternal(schema, roles, scope, prefix)
 	}
 
 	public createContextual(schema: Schema, roles: readonly string[]): ContextualPermissions {
 		return {
-			root: this.createInternal(schema, roles, false),
-			all: this.createInternal(schema, roles, true),
+			root: this.createInternal(schema, roles, 'root'),
+			all: this.createInternal(schema, roles, 'all'),
 		}
 	}
 
-	private createInternal(schema: Schema, roles: readonly string[], includeThrough: boolean, prefix?: string): Acl.Permissions {
+	private createInternal(schema: Schema, roles: readonly string[], scope: PermissionScope, prefix?: string): Acl.Permissions {
 		let result: Acl.Permissions = {}
 		for (let role of roles) {
 			const roleDefinition = schema.acl.roles[role] || { entities: {} }
-			let rolePermissions: Acl.Permissions = this.prefixPredicatesWithRole(schema.model, roleDefinition.entities, prefix || role)
+			let rolePermissions: Acl.Permissions = this.projectScope(
+				this.prefixPredicatesWithRole(schema.model, roleDefinition.entities, prefix || role),
+				scope,
+			)
 			if (roleDefinition.inherits) {
-				const inheritedPermissions = this.createInternal(schema, roleDefinition.inherits, includeThrough, prefix || role)
-				rolePermissions = this.mergePermissions(inheritedPermissions, rolePermissions, includeThrough)
+				const inheritedPermissions = this.createInternal(schema, roleDefinition.inherits, scope, prefix || role)
+				rolePermissions = this.mergePermissions(inheritedPermissions, rolePermissions)
 			}
-			result = this.mergePermissions(result, rolePermissions, includeThrough)
+			result = this.mergePermissions(result, rolePermissions)
 		}
 		result = this.makePrimaryPredicatesUnionOfAllFields(schema.model, result)
 
 		return result
+	}
+
+	/**
+	 * Flattens each entity to the grants effective in the requested scope, so everything downstream
+	 * merges plain permission sets and never has to reason about `through` again. The projection runs
+	 * per role, before any merging - which is what keeps a single role's root set free of its own
+	 * through-only grants.
+	 */
+	private projectScope(permissions: Acl.Permissions, scope: PermissionScope): Acl.Permissions {
+		return mapObject(permissions, (entityPermissions): Acl.EntityPermissions => {
+			const { root, through } = splitEntityPermissions(entityPermissions)
+			if (scope === 'root' || Object.keys(through.operations).length === 0) {
+				return root
+			}
+			return this.mergeEntityPermissions(root, through)
+		})
 	}
 
 	private prefixPredicatesWithRole(model: Model.Schema, permissions: Acl.Permissions, role: string): Acl.Permissions {
@@ -114,11 +139,11 @@ export class PermissionFactory {
 		})
 	}
 
-	private mergePermissions(left: Acl.Permissions, right: Acl.Permissions, includeThrough = false): Acl.Permissions {
+	private mergePermissions(left: Acl.Permissions, right: Acl.Permissions): Acl.Permissions {
 		const result = { ...left }
 		for (let entityName in right) {
 			if (result[entityName] !== undefined) {
-				result[entityName] = this.mergeEntityPermissions(result[entityName], right[entityName], includeThrough)
+				result[entityName] = this.mergeEntityPermissions(result[entityName], right[entityName])
 			} else {
 				result[entityName] = right[entityName]
 			}
@@ -126,13 +151,16 @@ export class PermissionFactory {
 		return result
 	}
 
-	private mergeEntityPermissions(left: Acl.EntityPermissions, right: Acl.EntityPermissions, includeThrough = false): Acl.EntityPermissions {
+	/**
+	 * Both sides are already scope-projected, so this is a plain union of grants - `through` and the
+	 * legacy `noRoot` never reach here.
+	 */
+	private mergeEntityPermissions(left: Acl.EntityPermissions, right: Acl.EntityPermissions): Acl.EntityPermissions {
 		let predicates: Writable<Acl.PredicateMap> = {}
 		const operations: Writable<Acl.EntityOperations> = {}
 		if (left.operations.customPrimary || right.operations.customPrimary) {
 			operations.customPrimary = true
 		}
-		const noRoot: `${Acl.Operation}`[] = []
 
 		for (
 			let operation of [
@@ -141,16 +169,12 @@ export class PermissionFactory {
 				'update',
 			] as const
 		) {
-			const { predicates: opPredicates, permissions: fieldPermissions, noRoot: opNoRoot } = this.mergeOperationPermissions(
-				left,
-				right,
-				operation,
-				includeThrough,
+			const { predicates: opPredicates, permissions: fieldPermissions } = this.mergeFieldPermissions(
+				left.predicates,
+				left.operations[operation],
+				right.predicates,
+				right.operations[operation],
 			)
-
-			if (opNoRoot) {
-				noRoot.push(operation)
-			}
 
 			predicates = { ...predicates, ...opPredicates }
 			if (Object.keys(fieldPermissions).length > 0) {
@@ -158,10 +182,12 @@ export class PermissionFactory {
 			}
 		}
 
-		const { predicateDefinition, predicate, noRoot: opNoRoot } = this.mergeDeletePermissions(left, right, includeThrough)
-		if (opNoRoot) {
-			noRoot.push('delete')
-		}
+		const { predicateDefinition, predicate } = this.mergePredicates(
+			left.predicates,
+			left.operations.delete,
+			right.predicates,
+			right.operations.delete,
+		)
 		if (predicate === true) {
 			operations.delete = true
 		} else if (predicateDefinition !== undefined && typeof predicate === 'string') {
@@ -169,84 +195,9 @@ export class PermissionFactory {
 			operations.delete = predicate
 		}
 
-		if (noRoot.length > 0) {
-			operations.noRoot = noRoot
-		}
-
 		return {
 			predicates: predicates,
 			operations: operations,
-		}
-	}
-
-	private mergeOperationPermissions(
-		left: Acl.EntityPermissions,
-		right: Acl.EntityPermissions,
-		operation: 'create' | 'read' | 'update',
-		includeThrough = false,
-	): {
-		noRoot: boolean
-		predicates: Acl.PredicateMap
-		permissions: Acl.FieldPermissions
-	} {
-		const { noRoot, leftPermissions, rightPermissions } = this.resolveNoRoot(left, right, operation, includeThrough)
-		return {
-			noRoot,
-			...this.mergeFieldPermissions(
-				left.predicates,
-				leftPermissions,
-				right.predicates,
-				rightPermissions,
-			),
-		}
-	}
-
-	private mergeDeletePermissions(left: Acl.EntityPermissions, right: Acl.EntityPermissions, includeThrough = false): {
-		noRoot: boolean
-		predicate: Acl.PredicateReference | boolean
-		predicateDefinition: Acl.PredicateDefinition | undefined
-	} {
-		const { noRoot, leftPermissions, rightPermissions } = this.resolveNoRoot(left, right, 'delete', includeThrough)
-
-		return {
-			noRoot,
-			...this.mergePredicates(
-				left.predicates,
-				leftPermissions,
-				right.predicates,
-				rightPermissions,
-			),
-		}
-	}
-
-	private resolveNoRoot<const Op extends `${Acl.Operation}`>(
-		left: Acl.EntityPermissions,
-		right: Acl.EntityPermissions,
-		operation: Op,
-		includeThrough = false,
-	): {
-		noRoot: boolean
-		leftPermissions: Acl.EntityPermissions['operations'][Op] | undefined
-		rightPermissions: Acl.EntityPermissions['operations'][Op] | undefined
-	} {
-		const leftRootForbidden = left.operations.noRoot?.includes(operation) || false
-		const rightRootForbidden = right.operations.noRoot?.includes(operation) || false
-		const leftPermissions = left.operations[operation]
-		const rightPermissions = right.operations[operation]
-
-		const rootForbidden = (leftRootForbidden && rightRootForbidden)
-			|| (leftRootForbidden && !rightPermissions)
-			|| (rightRootForbidden && !leftPermissions)
-
-		// When includeThrough is true, keep all permissions regardless of noRoot
-		// (used for "all" permissions that apply when accessing through relations)
-		const resolvedLeftPermissions = !includeThrough && !rootForbidden && leftRootForbidden ? undefined : leftPermissions
-		const resolvedRightPermissions = !includeThrough && !rootForbidden && rightRootForbidden ? undefined : rightPermissions
-
-		return {
-			noRoot: rootForbidden,
-			leftPermissions: resolvedLeftPermissions,
-			rightPermissions: resolvedRightPermissions,
 		}
 	}
 

--- a/packages/engine-content-api/src/acl/PermissionFactory.ts
+++ b/packages/engine-content-api/src/acl/PermissionFactory.ts
@@ -158,8 +158,12 @@ export class PermissionFactory {
 	private mergeEntityPermissions(left: Acl.EntityPermissions, right: Acl.EntityPermissions): Acl.EntityPermissions {
 		let predicates: Writable<Acl.PredicateMap> = {}
 		const operations: Writable<Acl.EntityOperations> = {}
-		if (left.operations.customPrimary || right.operations.customPrimary) {
-			operations.customPrimary = true
+		// Three-state: unstated stays unstated so the role-level default still applies, an explicit `false` survives, and `true` wins across roles.
+		if (left.operations.customPrimary !== undefined || right.operations.customPrimary !== undefined) {
+			operations.customPrimary = (left.operations.customPrimary ?? false) || (right.operations.customPrimary ?? false)
+		}
+		if (left.operations.refreshMaterializedView !== undefined || right.operations.refreshMaterializedView !== undefined) {
+			operations.refreshMaterializedView = (left.operations.refreshMaterializedView ?? false) || (right.operations.refreshMaterializedView ?? false)
 		}
 
 		for (

--- a/packages/engine-content-api/src/acl/PredicateFactory.ts
+++ b/packages/engine-content-api/src/acl/PredicateFactory.ts
@@ -1,6 +1,7 @@
 import { Acl, Input, Model } from '@contember/schema'
 import { VariableInjector } from './VariableInjector.js'
 import { EvaluatedPredicateReplacer } from './EvaluatedPredicateReplacer.js'
+import { AclScope } from './AclScope.js'
 
 const getRowLevelPredicatePseudoField = (entity: Model.Entity) => entity.primary
 
@@ -14,20 +15,19 @@ export class PredicateFactory {
 		private readonly permissions: Acl.Permissions,
 		private readonly model: Model.Schema,
 		private readonly variableInjector: VariableInjector,
-		private readonly allPermissions?: Acl.Permissions,
+		private readonly nestedPermissions?: Acl.Permissions,
 	) {}
 
 	/**
-	 * Selects the appropriate permission set based on query context:
-	 * - `isRoot === false` (nested/relation context): uses allPermissions (includes through-only permissions)
-	 * - `isRoot === true` or `isRoot === undefined` (root or unknown context): uses root-only permissions
+	 * `nested` uses the permission set that includes `through` grants; `root` uses the root grants
+	 * only. The scope is a required argument on every entry point - see {@link AclScope}.
 	 *
-	 * The `undefined` vs `true` distinction matters: `undefined` is the default for callers
-	 * that don't track root context, and must fall through to root permissions for safety.
+	 * `nestedPermissions` is optional so that callers with a single flat permission set (tests, the
+	 * system API's internal executor) keep working; they simply get the same set for both scopes.
 	 */
-	private getPermissionsForContext(isRoot?: boolean): Acl.Permissions {
-		if (isRoot === false && this.allPermissions) {
-			return this.allPermissions
+	private permissionsFor(scope: AclScope): Acl.Permissions {
+		if (scope === 'nested' && this.nestedPermissions) {
+			return this.nestedPermissions
 		}
 		return this.permissions
 	}
@@ -36,9 +36,9 @@ export class PredicateFactory {
 		entity: Model.Entity,
 		operation: Acl.Operation.update | Acl.Operation.read | Acl.Operation.create,
 		fieldName: string,
-		isRoot?: boolean,
+		scope: AclScope,
 	): FieldRequiredPredicate {
-		const perms = this.getPermissionsForContext(isRoot)
+		const perms = this.permissionsFor(scope)
 		const permissions = perms[entity.name]?.operations?.[operation]
 		const predicate = permissions?.[fieldName] ?? false
 		const rowLevelField = getRowLevelPredicatePseudoField(entity)
@@ -56,18 +56,17 @@ export class PredicateFactory {
 		entity: Model.Entity,
 		operation: Acl.Operation.read,
 		fieldName: string,
-		isRoot?: boolean,
+		scope: AclScope,
 	): boolean {
-		const perms = this.getPermissionsForContext(isRoot)
+		const perms = this.permissionsFor(scope)
 		const rowLevelField = getRowLevelPredicatePseudoField(entity)
 		const permissions = perms[entity.name]?.operations?.[operation]
 		return permissions?.[fieldName] !== permissions?.[rowLevelField]
 	}
 
-	/** Delete predicates are not context-aware — through-permission support is scoped to read operations only. */
-	public createDeletePredicate(entity: Model.Entity) {
+	public createDeletePredicate(entity: Model.Entity, scope: AclScope) {
 		const neverCondition: Input.Where = { [entity.primary]: { never: true } }
-		const entityPermissions = this.permissions[entity.name]
+		const entityPermissions = this.permissionsFor(scope)[entity.name]
 		if (!entityPermissions) {
 			return neverCondition
 		}
@@ -78,17 +77,17 @@ export class PredicateFactory {
 		if (deletePredicate === true) {
 			return {}
 		}
-		return this.buildPredicates(entity, [deletePredicate])
+		return this.buildPredicates(entity, [deletePredicate], scope)
 	}
 
 	public create(
 		entity: Model.Entity,
 		operation: Acl.Operation.update | Acl.Operation.read | Acl.Operation.create,
+		scope: AclScope,
 		fieldNames: string[] = [getRowLevelPredicatePseudoField(entity)],
 		relationContext?: Model.AnyRelationContext,
-		isRoot?: boolean,
 	): Input.OptionalWhere {
-		const perms = this.getPermissionsForContext(isRoot)
+		const perms = this.permissionsFor(scope)
 		const entityPermissions: Acl.EntityPermissions = perms[entity.name]
 		const neverCondition: Input.Where = { [entity.primary]: { never: true } }
 
@@ -108,16 +107,16 @@ export class PredicateFactory {
 			return neverCondition
 		}
 
-		return this.buildPredicates(entity, operationPredicates, relationContext, isRoot)
+		return this.buildPredicates(entity, operationPredicates, scope, relationContext)
 	}
 
 	public buildPredicates(
 		entity: Model.Entity,
 		predicates: Acl.PredicateReference[],
+		scope: AclScope,
 		relationContext?: Model.AnyRelationContext,
-		isRoot?: boolean,
 	): Input.OptionalWhere {
-		const perms = this.getPermissionsForContext(isRoot)
+		const perms = this.permissionsFor(scope)
 		const entityPermissions: Acl.EntityPermissions = perms[entity.name] ?? {}
 
 		const predicatesWhere: Input.Where[] = predicates.reduce(
@@ -134,7 +133,7 @@ export class PredicateFactory {
 			return {}
 		}
 		const where: Input.Where = predicatesWhere.length === 1 ? predicatesWhere[0] : { and: predicatesWhere }
-		return this.optimizePredicates(where, relationContext, isRoot)
+		return this.optimizePredicates(where, scope, relationContext)
 	}
 
 	private getRequiredPredicates(
@@ -157,11 +156,11 @@ export class PredicateFactory {
 		return predicates
 	}
 
-	public optimizePredicates(where: Input.OptionalWhere, relationContext?: Model.AnyRelationContext, isRoot?: boolean) {
+	public optimizePredicates(where: Input.OptionalWhere, scope: AclScope, relationContext?: Model.AnyRelationContext) {
 		if (!relationContext || !relationContext.targetRelation) {
 			return where
 		}
-		const sourcePredicate = this.create(relationContext.entity, Acl.Operation.read, [relationContext.relation.name], undefined, isRoot)
+		const sourcePredicate = this.create(relationContext.entity, Acl.Operation.read, scope, [relationContext.relation.name])
 		if (Object.keys(sourcePredicate).length === 0) {
 			return where
 		}

--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -1,19 +1,25 @@
 import { Acl, Input, Model, Writable } from '@contember/schema'
 import { acceptFieldVisitor } from '@contember/schema-utils'
 import { PredicateFactory } from './PredicateFactory.js'
+import { aclScopeFromPath } from './AclScope.js'
 
 export class PredicatesInjector {
 	constructor(private readonly schema: Model.Schema, private readonly predicateFactory: PredicateFactory) {}
 
+	/**
+	 * The ACL scope is derived from the ancestor path at each node rather than decided once here and
+	 * carried down: an entity reached over a relation is nested even when the query itself started at
+	 * the root, so its `through` grants have to apply.
+	 */
 	public inject(
 		entity: Model.Entity,
 		where: Input.OptionalWhere,
 		relationContext?: Model.AnyRelationContext,
 		ancestorPath?: readonly Model.AnyRelationContext[],
 	): Input.OptionalWhere {
-		const isQueryRoot = !relationContext && (!ancestorPath || ancestorPath.length === 0)
-		const restrictedWhere = this.injectToWhere(where, entity, true, relationContext, false, ancestorPath ?? [], isQueryRoot)
-		return this.createWhere(entity, undefined, restrictedWhere, relationContext, false, ancestorPath ?? [], isQueryRoot)
+		const path = ancestorPath ?? []
+		const restrictedWhere = this.injectToWhere(where, entity, true, relationContext, false, path)
+		return this.createWhere(entity, undefined, restrictedWhere, relationContext, false, path)
 	}
 
 	/**
@@ -41,7 +47,6 @@ export class PredicatesInjector {
 		relationContext?: Model.AnyRelationContext,
 		isBackReferenceContext?: boolean,
 		ancestorPath?: readonly Model.AnyRelationContext[],
-		isQueryRoot?: boolean,
 	): Input.OptionalWhere {
 		// Simplify predicates when:
 		// 1. We're in a back-reference context (inside a filter that traverses back)
@@ -57,14 +62,19 @@ export class PredicatesInjector {
 		if (shouldSimplify) {
 			predicatesWhere = { [entity.primary]: { always: true } }
 		} else {
-			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
+			const rawPredicate = this.predicateFactory.create(
+				entity,
+				Acl.Operation.read,
+				aclScopeFromPath(ancestorPath),
+				fieldNames,
+				relationContext,
+			)
 			// Process the predicate to inject nested entity predicates
 			predicatesWhere = this.injectPredicatesToPredicate(
 				rawPredicate,
 				entity,
 				isBackReferenceContext ?? false,
 				ancestorPath ?? [],
-				isQueryRoot,
 			)
 		}
 
@@ -88,22 +98,21 @@ export class PredicatesInjector {
 		entity: Model.Entity,
 		isBackReferenceContext: boolean,
 		ancestorPath: readonly Model.AnyRelationContext[],
-		isQueryRoot?: boolean,
 	): Input.OptionalWhere {
 		const resultWhere: Writable<Input.OptionalWhere> = {}
 
 		if (where.and) {
 			resultWhere.and = where.and
 				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
+				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath))
 		}
 		if (where.or) {
 			resultWhere.or = where.or
 				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
+				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath))
 		}
 		if (where.not) {
-			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath, isQueryRoot)
+			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath)
 		}
 
 		const fields = Object.keys(where).filter(it => !['and', 'or', 'not'].includes(it))
@@ -132,7 +141,6 @@ export class PredicatesInjector {
 						context.targetEntity,
 						nestedIsBackReferenceContext,
 						nestedAncestorPath,
-						isQueryRoot,
 					)
 
 					// Check if we should simplify the target entity's predicate
@@ -142,7 +150,13 @@ export class PredicatesInjector {
 					// Get target entity's predicate (simplified if back-reference)
 					const targetPredicate = shouldSimplifyNested
 						? { [context.targetEntity.primary]: { always: true } }
-						: this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, isQueryRoot)
+						: this.predicateFactory.create(
+							context.targetEntity,
+							Acl.Operation.read,
+							aclScopeFromPath(nestedAncestorPath),
+							undefined,
+							context,
+						)
 
 					// Optimization: avoid duplicate { id: always } when both are simplified
 					const primaryKey = context.targetEntity.primary
@@ -180,21 +194,20 @@ export class PredicatesInjector {
 		relationContext: Model.AnyRelationContext | undefined,
 		isBackReferenceContext: boolean,
 		ancestorPath: readonly Model.AnyRelationContext[],
-		isQueryRoot?: boolean,
 	): Input.OptionalWhere {
 		const resultWhere: Writable<Input.OptionalWhere> = {}
 		if (where.and) {
 			resultWhere.and = where.and.filter((it): it is Input.Where => !!it).map(it =>
-				this.injectToWhere(it, entity, isRoot, relationContext, isBackReferenceContext, ancestorPath, isQueryRoot)
+				this.injectToWhere(it, entity, isRoot, relationContext, isBackReferenceContext, ancestorPath)
 			)
 		}
 		if (where.or) {
 			resultWhere.or = where.or.filter((it): it is Input.Where => !!it).map(it =>
-				this.injectToWhere(it, entity, isRoot, relationContext, isBackReferenceContext, ancestorPath, isQueryRoot)
+				this.injectToWhere(it, entity, isRoot, relationContext, isBackReferenceContext, ancestorPath)
 			)
 		}
 		if (where.not) {
-			resultWhere.not = this.injectToWhere(where.not, entity, isRoot, relationContext, isBackReferenceContext, ancestorPath, isQueryRoot)
+			resultWhere.not = this.injectToWhere(where.not, entity, isRoot, relationContext, isBackReferenceContext, ancestorPath)
 		}
 
 		const fields = Object.keys(where).filter(it => !['and', 'or', 'not'].includes(it))
@@ -216,14 +229,14 @@ export class PredicatesInjector {
 					const nestedIsBackReferenceContext = isBackReference || isBackReferenceContext
 					// Build extended ancestor path for nested traversal
 					const nestedAncestorPath: Model.AnyRelationContext[] = [...ancestorPath, context]
-					return this.injectToWhere(relationWhere, context.targetEntity, false, context, nestedIsBackReferenceContext, nestedAncestorPath, isQueryRoot)
+					return this.injectToWhere(relationWhere, context.targetEntity, false, context, nestedIsBackReferenceContext, nestedAncestorPath)
 				},
 			})
 		}
 		const fieldsForPredicate = !isRoot
 			? fields
-			: fields.filter(it => this.predicateFactory.shouldApplyCellLevelPredicate(entity, Acl.Operation.read, it, isQueryRoot))
+			: fields.filter(it => this.predicateFactory.shouldApplyCellLevelPredicate(entity, Acl.Operation.read, it, aclScopeFromPath(ancestorPath)))
 
-		return this.createWhere(entity, fieldsForPredicate, resultWhere, relationContext, isBackReferenceContext, ancestorPath, isQueryRoot)
+		return this.createWhere(entity, fieldsForPredicate, resultWhere, relationContext, isBackReferenceContext, ancestorPath)
 	}
 }

--- a/packages/engine-content-api/src/acl/index.ts
+++ b/packages/engine-content-api/src/acl/index.ts
@@ -1,3 +1,4 @@
+export * from './AclScope.js'
 export * from './Authorizator.js'
 export * from './PermissionFactory.js'
 export * from './PredicateFactory.js'

--- a/packages/engine-content-api/src/mapper/JunctionTableManager.ts
+++ b/packages/engine-content-api/src/mapper/JunctionTableManager.ts
@@ -22,6 +22,17 @@ type JunctionMutationResult =
 	| MutationNothingToDo
 	| MutationNoResultError
 
+/**
+ * A junction write touches two entities, and they do not sit in the same place: the entity the
+ * caller named is where the mutation already is - the root, when the mutation is a root one - while
+ * the other one is only ever reached over the relation. Resolving both with a single scope is what
+ * let a `through`-only grant on the named entity apply at the mutation root.
+ */
+export interface JunctionScopes {
+	owning: AclScope
+	inverse: AclScope
+}
+
 export class JunctionTableManager {
 	constructor(
 		private readonly schema: Model.Schema,
@@ -38,7 +49,7 @@ export class JunctionTableManager {
 		relation: Model.ManyHasManyOwningRelation,
 		owningUnique: Input.PrimaryValue,
 		inverseUnique: Input.PrimaryValue,
-		scope: AclScope,
+		scopes: JunctionScopes,
 	): Promise<MutationResultList> {
 		const beforeEvent = new BeforeJunctionUpdateEvent(owningEntity, relation, owningUnique, inverseUnique, 'connect')
 		await mapper.eventManager.fire(beforeEvent)
@@ -49,7 +60,7 @@ export class JunctionTableManager {
 			owningUnique,
 			inverseUnique,
 			this.connectJunctionHandler,
-			scope,
+			scopes,
 		)
 		if (result.result !== MutationResultType.noResultError) {
 			const afterEvent = new AfterJunctionUpdateEvent(
@@ -71,7 +82,7 @@ export class JunctionTableManager {
 		relation: Model.ManyHasManyOwningRelation,
 		owningUnique: Input.PrimaryValue,
 		inverseUnique: Input.PrimaryValue,
-		scope: AclScope,
+		scopes: JunctionScopes,
 	): Promise<MutationResultList> {
 		const beforeEvent = new BeforeJunctionUpdateEvent(owningEntity, relation, owningUnique, inverseUnique, 'connect')
 		await mapper.eventManager.fire(beforeEvent)
@@ -82,7 +93,7 @@ export class JunctionTableManager {
 			owningUnique,
 			inverseUnique,
 			this.disconnectJunctionHandler,
-			scope,
+			scopes,
 		)
 		if (result.result !== MutationResultType.noResultError) {
 			const afterEvent = new AfterJunctionUpdateEvent(
@@ -106,7 +117,7 @@ export class JunctionTableManager {
 		owningPrimary: Input.PrimaryValue,
 		inversePrimary: Input.PrimaryValue,
 		handler: JunctionHandler,
-		scope: AclScope,
+		scopes: JunctionScopes,
 	): Promise<JunctionMutationResult> {
 		const joiningTable = relation.joiningTable
 		const inverseEntity = getEntity(this.schema, relation.target)
@@ -114,10 +125,10 @@ export class JunctionTableManager {
 			throw new ImplementationException()
 		}
 
-		const owningPredicate = this.predicateFactory.create(owningEntity, Acl.Operation.update, scope, [relation.name])
+		const owningPredicate = this.predicateFactory.create(owningEntity, Acl.Operation.update, scopes.owning, [relation.name])
 		let inversePredicate: Input.OptionalWhere = {}
 		if (relation.inversedBy) {
-			inversePredicate = this.predicateFactory.create(inverseEntity, Acl.Operation.update, scope, [relation.inversedBy])
+			inversePredicate = this.predicateFactory.create(inverseEntity, Acl.Operation.update, scopes.inverse, [relation.inversedBy])
 		}
 
 		const hasNoPredicates = Object.keys(owningPredicate).length === 0 && Object.keys(inversePredicate).length === 0

--- a/packages/engine-content-api/src/mapper/JunctionTableManager.ts
+++ b/packages/engine-content-api/src/mapper/JunctionTableManager.ts
@@ -1,6 +1,6 @@
 import { getEntity } from '@contember/schema-utils'
 import { PathFactory, WhereBuilder } from './select/index.js'
-import { PredicateFactory } from '../acl/index.js'
+import { AclScope, PredicateFactory } from '../acl/index.js'
 import { Client, ConflictActionType, DeleteBuilder, InsertBuilder, Literal, Operator, SelectBuilder } from '@contember/database'
 import { Acl, Input, Model } from '@contember/schema'
 import {
@@ -38,6 +38,7 @@ export class JunctionTableManager {
 		relation: Model.ManyHasManyOwningRelation,
 		owningUnique: Input.PrimaryValue,
 		inverseUnique: Input.PrimaryValue,
+		scope: AclScope,
 	): Promise<MutationResultList> {
 		const beforeEvent = new BeforeJunctionUpdateEvent(owningEntity, relation, owningUnique, inverseUnique, 'connect')
 		await mapper.eventManager.fire(beforeEvent)
@@ -48,6 +49,7 @@ export class JunctionTableManager {
 			owningUnique,
 			inverseUnique,
 			this.connectJunctionHandler,
+			scope,
 		)
 		if (result.result !== MutationResultType.noResultError) {
 			const afterEvent = new AfterJunctionUpdateEvent(
@@ -69,6 +71,7 @@ export class JunctionTableManager {
 		relation: Model.ManyHasManyOwningRelation,
 		owningUnique: Input.PrimaryValue,
 		inverseUnique: Input.PrimaryValue,
+		scope: AclScope,
 	): Promise<MutationResultList> {
 		const beforeEvent = new BeforeJunctionUpdateEvent(owningEntity, relation, owningUnique, inverseUnique, 'connect')
 		await mapper.eventManager.fire(beforeEvent)
@@ -79,6 +82,7 @@ export class JunctionTableManager {
 			owningUnique,
 			inverseUnique,
 			this.disconnectJunctionHandler,
+			scope,
 		)
 		if (result.result !== MutationResultType.noResultError) {
 			const afterEvent = new AfterJunctionUpdateEvent(
@@ -102,6 +106,7 @@ export class JunctionTableManager {
 		owningPrimary: Input.PrimaryValue,
 		inversePrimary: Input.PrimaryValue,
 		handler: JunctionHandler,
+		scope: AclScope,
 	): Promise<JunctionMutationResult> {
 		const joiningTable = relation.joiningTable
 		const inverseEntity = getEntity(this.schema, relation.target)
@@ -109,10 +114,10 @@ export class JunctionTableManager {
 			throw new ImplementationException()
 		}
 
-		const owningPredicate = this.predicateFactory.create(owningEntity, Acl.Operation.update, [relation.name])
+		const owningPredicate = this.predicateFactory.create(owningEntity, Acl.Operation.update, scope, [relation.name])
 		let inversePredicate: Input.OptionalWhere = {}
 		if (relation.inversedBy) {
-			inversePredicate = this.predicateFactory.create(inverseEntity, Acl.Operation.update, [relation.inversedBy])
+			inversePredicate = this.predicateFactory.create(inverseEntity, Acl.Operation.update, scope, [relation.inversedBy])
 		}
 
 		const hasNoPredicates = Object.keys(owningPredicate).length === 0 && Object.keys(inversePredicate).length === 0

--- a/packages/engine-content-api/src/mapper/Mapper.ts
+++ b/packages/engine-content-api/src/mapper/Mapper.ts
@@ -285,6 +285,10 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		})
 	}
 
+	/**
+	 * `scope` belongs to `entity` - the side the caller named. The other side of the junction is
+	 * reached over the relation, so it always resolves as nested.
+	 */
 	public async connectJunction(
 		entity: Model.Entity,
 		relation: Model.ManyHasManyOwningRelation | Model.ManyHasManyInverseRelation,
@@ -298,10 +302,16 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		}
 		return await acceptFieldVisitor(this.schema, entity, relation, {
 			visitManyHasManyOwning: ({ entity, relation }) => {
-				return this.junctionTableManager.connectJunction(this, entity, relation, thisPrimary, otherPrimary, scope)
+				return this.junctionTableManager.connectJunction(this, entity, relation, thisPrimary, otherPrimary, {
+					owning: scope,
+					inverse: 'nested',
+				})
 			},
 			visitManyHasManyInverse: ({ targetEntity, targetRelation }) => {
-				return this.junctionTableManager.connectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary, scope)
+				return this.junctionTableManager.connectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary, {
+					owning: 'nested',
+					inverse: scope,
+				})
 			},
 			visitColumn: err,
 			visitOneHasMany: err,
@@ -311,6 +321,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		})
 	}
 
+	/** See {@link connectJunction} for how `scope` maps onto the two sides. */
 	public async disconnectJunction(
 		entity: Model.Entity,
 		relation: Model.ManyHasManyOwningRelation | Model.ManyHasManyInverseRelation,
@@ -324,10 +335,16 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		}
 		return await acceptFieldVisitor(this.schema, entity, relation, {
 			visitManyHasManyOwning: ({ entity, relation }) => {
-				return this.junctionTableManager.disconnectJunction(this, entity, relation, thisPrimary, otherPrimary, scope)
+				return this.junctionTableManager.disconnectJunction(this, entity, relation, thisPrimary, otherPrimary, {
+					owning: scope,
+					inverse: 'nested',
+				})
 			},
 			visitManyHasManyInverse: ({ targetEntity, targetRelation }) => {
-				return this.junctionTableManager.disconnectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary, scope)
+				return this.junctionTableManager.disconnectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary, {
+					owning: 'nested',
+					inverse: scope,
+				})
 			},
 			visitColumn: err,
 			visitOneHasMany: err,

--- a/packages/engine-content-api/src/mapper/Mapper.ts
+++ b/packages/engine-content-api/src/mapper/Mapper.ts
@@ -11,7 +11,7 @@ import {
 	WhereBuilder,
 } from './select/index.js'
 import { Client, Connection, ConstraintHelper, DatabaseMetadata, SelectBuilder } from '@contember/database'
-import { PredicatesInjector } from '../acl/index.js'
+import { AclScope, PredicatesInjector } from '../acl/index.js'
 import { JunctionTableManager } from './JunctionTableManager.js'
 import { DeletedEntitiesStorage, DeleteExecutor } from './delete/index.js'
 import { MutationEntryNotFoundError, MutationResultList } from './Result.js'
@@ -186,19 +186,21 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 	public async insert(
 		entity: Model.Entity,
 		data: MapperInput.CreateDataInput,
+		scope: AclScope,
 		builderCb: (builder: InsertBuilder) => void = () => {},
 	): Promise<MutationResultList> {
 		if (entity.view) {
 			throw new ImplementationException()
 		}
 		await this.setupSystemVariables()
-		return tryMutation(this.schema, this.schemaDatabaseMetadata, () => this.insertInternal(entity, data, builderCb))
+		return tryMutation(this.schema, this.schemaDatabaseMetadata, () => this.insertInternal(entity, data, scope, builderCb))
 	}
 
 	public async update(
 		entity: Model.Entity,
 		by: Input.UniqueWhere | CheckedPrimary,
 		data: MapperInput.UpdateDataInput,
+		scope: AclScope,
 		filter?: Input.OptionalWhere,
 	): Promise<MutationResultList> {
 		if (entity.view) {
@@ -209,7 +211,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 			const [primaryValue, err] = await this.getPrimaryValue(entity, by)
 			if (err) return [err]
 
-			return await this.updater.update(this, entity, primaryValue, data, filter)
+			return await this.updater.update(this, entity, primaryValue, data, scope, filter)
 		})
 	}
 
@@ -217,6 +219,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		entity: Model.Entity,
 		by: Input.UniqueWhere | CheckedPrimary,
 		builderCb: (builder: UpdateBuilder) => void,
+		scope: AclScope,
 	): Promise<MutationResultList> {
 		if (entity.view) {
 			throw new ImplementationException()
@@ -226,7 +229,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 			const [primaryValue, err] = await this.getPrimaryValue(entity, by)
 			if (err) return [err]
 
-			return await this.updater.updateCb(this, entity, primaryValue, builderCb)
+			return await this.updater.updateCb(this, entity, primaryValue, builderCb, scope)
 		})
 	}
 	public async upsert(
@@ -234,6 +237,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		by: Input.UniqueWhere | CheckedPrimary,
 		update: MapperInput.UpdateDataInput,
 		create: MapperInput.CreateDataInput,
+		scope: AclScope,
 		filter?: Input.OptionalWhere,
 	): Promise<MutationResultList> {
 		if (entity.view) {
@@ -243,20 +247,33 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		return tryMutation(this.schema, this.schemaDatabaseMetadata, async () => {
 			const [primaryValue] = await this.getPrimaryValue(entity, by)
 			if (primaryValue === undefined) {
-				return await this.insertInternal(entity, create)
+				return await this.insertInternal(entity, create, scope)
 			}
-			return await this.updater.update(this, entity, primaryValue, update, filter)
+			return await this.updater.update(this, entity, primaryValue, update, scope, filter)
 		})
 	}
 
-	private insertInternal(entity: Model.Entity, data: MapperInput.CreateDataInput, builderCb: (builder: InsertBuilder) => void = () => {}) {
-		return this.inserter.insert(this, entity, data, id => {
-		}, builderCb)
+	private insertInternal(
+		entity: Model.Entity,
+		data: MapperInput.CreateDataInput,
+		scope: AclScope,
+		builderCb: (builder: InsertBuilder) => void = () => {},
+	) {
+		return this.inserter.insert(
+			this,
+			entity,
+			data,
+			id => {
+			},
+			builderCb,
+			scope,
+		)
 	}
 
 	public async delete(
 		entity: Model.Entity,
 		by: Input.UniqueWhere | CheckedPrimary,
+		scope: AclScope,
 		filter?: Input.OptionalWhere,
 	): Promise<MutationResultList> {
 		if (entity.view) {
@@ -264,7 +281,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		}
 		await this.setupSystemVariables()
 		return tryMutation(this.schema, this.schemaDatabaseMetadata, () => {
-			return this.deleteExecutor.execute(this, entity, by, filter)
+			return this.deleteExecutor.execute(this, entity, by, scope, filter)
 		})
 	}
 
@@ -273,6 +290,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		relation: Model.ManyHasManyOwningRelation | Model.ManyHasManyInverseRelation,
 		thisPrimary: Input.PrimaryValue,
 		otherPrimary: Input.PrimaryValue,
+		scope: AclScope,
 	): Promise<MutationResultList> {
 		await this.setupSystemVariables()
 		const err = () => {
@@ -280,10 +298,10 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		}
 		return await acceptFieldVisitor(this.schema, entity, relation, {
 			visitManyHasManyOwning: ({ entity, relation }) => {
-				return this.junctionTableManager.connectJunction(this, entity, relation, thisPrimary, otherPrimary)
+				return this.junctionTableManager.connectJunction(this, entity, relation, thisPrimary, otherPrimary, scope)
 			},
 			visitManyHasManyInverse: ({ targetEntity, targetRelation }) => {
-				return this.junctionTableManager.connectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary)
+				return this.junctionTableManager.connectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary, scope)
 			},
 			visitColumn: err,
 			visitOneHasMany: err,
@@ -298,6 +316,7 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		relation: Model.ManyHasManyOwningRelation | Model.ManyHasManyInverseRelation,
 		thisPrimary: Input.PrimaryValue,
 		otherPrimary: Input.PrimaryValue,
+		scope: AclScope,
 	): Promise<MutationResultList> {
 		await this.setupSystemVariables()
 		const err = () => {
@@ -305,10 +324,10 @@ export class Mapper<ConnectionType extends Connection.ConnectionLike = Connectio
 		}
 		return await acceptFieldVisitor(this.schema, entity, relation, {
 			visitManyHasManyOwning: ({ entity, relation }) => {
-				return this.junctionTableManager.disconnectJunction(this, entity, relation, thisPrimary, otherPrimary)
+				return this.junctionTableManager.disconnectJunction(this, entity, relation, thisPrimary, otherPrimary, scope)
 			},
 			visitManyHasManyInverse: ({ targetEntity, targetRelation }) => {
-				return this.junctionTableManager.disconnectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary)
+				return this.junctionTableManager.disconnectJunction(this, targetEntity, targetRelation, otherPrimary, thisPrimary, scope)
 			},
 			visitColumn: err,
 			visitOneHasMany: err,

--- a/packages/engine-content-api/src/mapper/delete/DeleteExecutor.ts
+++ b/packages/engine-content-api/src/mapper/delete/DeleteExecutor.ts
@@ -2,7 +2,7 @@ import { Acl, Input, Model } from '@contember/schema'
 import { assertNever } from '../../utils/index.js'
 import { Client, DeleteBuilder, Literal, SelectBuilder } from '@contember/database'
 import { PathFactory, WhereBuilder } from '../select/index.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { AclScope, PredicateFactory } from '../../acl/index.js'
 import { UpdateBuilderFactory } from '../update/index.js'
 import {
 	ConstraintType,
@@ -47,6 +47,7 @@ export class DeleteExecutor {
 		mapper: Mapper,
 		entity: Model.Entity,
 		by: Input.UniqueWhere | CheckedPrimary,
+		scope: AclScope,
 		filter?: Input.OptionalWhere,
 	): Promise<MutationResultList> {
 		return mapper.mutex.execute(async () => {
@@ -59,7 +60,7 @@ export class DeleteExecutor {
 
 			const primaryWhere = { [entity.primary]: { eq: primaryValue } }
 			const where = filter ? { and: [primaryWhere, filter] } : primaryWhere
-			const state = new DeleteState(mapper.deletedEntities)
+			const state = new DeleteState(mapper.deletedEntities, scope)
 			const deletePrimary = await this.collectDeleteInfo(state, mapper, entity, where)
 
 			const deleteQueue: DeleteQueue = [[entity, deletePrimary]]
@@ -129,7 +130,7 @@ export class DeleteExecutor {
 		entity: Model.Entity,
 		where: Input.OptionalWhere,
 	): Promise<Input.PrimaryValue[]> {
-		const predicate = this.predicateFactory.createDeletePredicate(entity)
+		const predicate = this.predicateFactory.createDeletePredicate(entity, state.scope)
 		const orphanRemovals = findRelationsWithOrphanRemoval(this.schema, entity)
 
 		const qb = SelectBuilder.create<DeleteInfoRow>()
@@ -187,7 +188,7 @@ export class DeleteExecutor {
 		relation: Model.ManyHasOneRelation | Model.OneHasOneOwningRelation,
 		values: Input.PrimaryValue[],
 	): Promise<void> {
-		const predicate = this.predicateFactory.createDeletePredicate(entity)
+		const predicate = this.predicateFactory.createDeletePredicate(entity, state.scope)
 		const orphanRemovals = findRelationsWithOrphanRemoval(this.schema, entity)
 
 		const qb = this.createFetchByIdQueryBuilder(entity, relation, values)
@@ -216,7 +217,7 @@ export class DeleteExecutor {
 		relation: Model.ManyHasOneRelation | Model.OneHasOneOwningRelation,
 		values: Input.PrimaryValue[],
 	): Promise<void> {
-		const predicate = this.predicateFactory.create(entity, Acl.Operation.update, [relation.name])
+		const predicate = this.predicateFactory.create(entity, Acl.Operation.update, state.scope, [relation.name])
 
 		const qb = this.createFetchByIdQueryBuilder(entity, relation, values)
 		const qbWithAllowed = this.qbWithAllowed(entity, predicate, qb)

--- a/packages/engine-content-api/src/mapper/delete/DeleteState.ts
+++ b/packages/engine-content-api/src/mapper/delete/DeleteState.ts
@@ -2,6 +2,7 @@ import { DeletedEntitiesStorage } from './DeletedEntitiesStorage.js'
 import { Input } from '@contember/schema'
 import { ImplementationException } from '../../exception.js'
 import { MutationResult, MutationResultList } from '../Result.js'
+import { AclScope } from '../../acl/index.js'
 
 export class DeleteState {
 	private plannedDelete = new DeletedEntitiesStorage()
@@ -14,6 +15,12 @@ export class DeleteState {
 
 	constructor(
 		private alreadyDeleted: DeletedEntitiesStorage,
+		/**
+		 * Scope of the delete that started this cascade. Cascades and orphan removals inherit it
+		 * rather than escalating - a root delete stays evaluated against the root grants all the way
+		 * down, the same way it behaved before the scope existed.
+		 */
+		public readonly scope: AclScope,
 	) {
 	}
 

--- a/packages/engine-content-api/src/mapper/insert/InsertBuilder.ts
+++ b/packages/engine-content-api/src/mapper/insert/InsertBuilder.ts
@@ -3,7 +3,7 @@ import { InsertBuilder as DbInsertBuilder, QueryBuilder, Value as DbValue } from
 import { PathFactory, WhereBuilder } from '../select/index.js'
 import { getColumnName, getColumnType } from '@contember/schema-utils'
 import { ColumnValue, normalizeDbValue } from '../ColumnValue.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { AclScope, PredicateFactory } from '../../acl/index.js'
 import { AfterInsertEvent, BeforeInsertEvent } from '../EventManager.js'
 import { Mapper } from '../Mapper.js'
 
@@ -23,6 +23,7 @@ export class InsertBuilder {
 		private readonly whereBuilder: WhereBuilder,
 		private readonly pathFactory: PathFactory,
 		private readonly predicateFactory: PredicateFactory,
+		private readonly scope: AclScope,
 	) {}
 
 	public addFieldValue(
@@ -38,7 +39,7 @@ export class InsertBuilder {
 	}
 
 	public addPredicates(fields: string[]): void {
-		const where = this.predicateFactory.create(this.entity, Acl.Operation.create, fields)
+		const where = this.predicateFactory.create(this.entity, Acl.Operation.create, this.scope, fields)
 		this.addWhere(where)
 	}
 

--- a/packages/engine-content-api/src/mapper/insert/InsertBuilderFactory.ts
+++ b/packages/engine-content-api/src/mapper/insert/InsertBuilderFactory.ts
@@ -1,7 +1,7 @@
 import { PathFactory, WhereBuilder } from '../select/index.js'
 import { Model } from '@contember/schema'
 import { InsertBuilder } from './InsertBuilder.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { AclScope, PredicateFactory } from '../../acl/index.js'
 
 export class InsertBuilderFactory {
 	constructor(
@@ -11,7 +11,7 @@ export class InsertBuilderFactory {
 		private readonly predicateFactory: PredicateFactory,
 	) {}
 
-	public create(entity: Model.Entity): InsertBuilder {
-		return new InsertBuilder(this.schema, entity, this.whereBuilder, this.pathFactory, this.predicateFactory)
+	public create(entity: Model.Entity, scope: AclScope): InsertBuilder {
+		return new InsertBuilder(this.schema, entity, this.whereBuilder, this.pathFactory, this.predicateFactory, scope)
 	}
 }

--- a/packages/engine-content-api/src/mapper/insert/Inserter.ts
+++ b/packages/engine-content-api/src/mapper/insert/Inserter.ts
@@ -2,6 +2,7 @@ import { MutationCreateOk, MutationNoResultError, MutationResultList } from '../
 import { CreateInputVisitor } from '../../inputProcessing/index.js'
 import { SqlCreateInputProcessor, SqlCreateInputProcessorResult } from './SqlCreateInputProcessor.js'
 import { Mapper } from '../Mapper.js'
+import { AclScope } from '../../acl/index.js'
 import { Model } from '@contember/schema'
 import { acceptFieldVisitor, Providers } from '@contember/schema-utils'
 import { InsertBuilderFactory } from './InsertBuilderFactory.js'
@@ -25,8 +26,9 @@ export class Inserter {
 		data: MapperInput.CreateDataInput,
 		insertIdCallback: (id: string) => void,
 		builderCb: (builder: InsertBuilder) => void,
+		scope: AclScope,
 	): Promise<MutationResultList> {
-		const insertBuilder = this.insertBuilderFactory.create(entity)
+		const insertBuilder = this.insertBuilderFactory.create(entity, scope)
 
 		insertBuilder.addPredicates(Object.keys(data))
 

--- a/packages/engine-content-api/src/mapper/insert/Inserter.ts
+++ b/packages/engine-content-api/src/mapper/insert/Inserter.ts
@@ -33,7 +33,7 @@ export class Inserter {
 		insertBuilder.addPredicates(Object.keys(data))
 
 		const visitor = new CreateInputVisitor<SqlCreateInputProcessorResult>(
-			new SqlCreateInputProcessor(insertBuilder, mapper, this.providers, this.options),
+			new SqlCreateInputProcessor(insertBuilder, mapper, this.providers, scope, this.options),
 			this.schema,
 			data,
 		)

--- a/packages/engine-content-api/src/mapper/insert/SqlCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/SqlCreateInputProcessor.ts
@@ -10,6 +10,7 @@ import { OneHasOneOwningCreateInputProcessor } from './relations/OneHasOneOwning
 import { OneHasManyCreateInputProcessor } from './relations/OneHasManyCreateInputProcessor.js'
 import { ManyHasOneCreateInputProcessor } from './relations/ManyHasOneCreateInputProcessor.js'
 import { ManyHasManyCreateInputProcessor } from './relations/ManyHasManyCreateInputProcessor.js'
+import { AclScope } from '../../acl/index.js'
 
 export type SqlCreateInputProcessorResult = MutationResultList | ((ctx: { primary: Input.PrimaryValue }) => Promise<MutationResultList>)
 export class SqlCreateInputProcessor implements CreateInputProcessor<SqlCreateInputProcessorResult> {
@@ -23,13 +24,15 @@ export class SqlCreateInputProcessor implements CreateInputProcessor<SqlCreateIn
 		private readonly insertBuilder: InsertBuilder,
 		private readonly mapper: Mapper,
 		private readonly providers: Providers,
+		/** Scope of the entity being created; relation targets are always reached over a relation and stay nested. */
+		private readonly scope: AclScope,
 		private readonly options: { uuidVersion?: 4 | 7 } = {},
 	) {
 		this.oneHasOneInverseCreateInputProcessor = new OneHasOneInverseCreateInputProcessor(this.mapper)
 		this.oneHasOneOwningCreateInputProcessor = new OneHasOneOwningCreateInputProcessor(this.mapper, this.insertBuilder)
 		this.oneHasManyCreateInputProcessor = new OneHasManyCreateInputProcessor(this.mapper)
 		this.manyHasOneCreateInputProcessor = new ManyHasOneCreateInputProcessor(this.mapper, this.insertBuilder)
-		this.manyHasManyCreateInputProcessor = new ManyHasManyCreateInputProcessor(this.mapper)
+		this.manyHasManyCreateInputProcessor = new ManyHasManyCreateInputProcessor(this.mapper, this.scope)
 	}
 
 	public async column(context: Model.ColumnContext & { input: Input.ColumnValue | undefined }): Promise<SqlCreateInputProcessorResult> {

--- a/packages/engine-content-api/src/mapper/insert/relations/ManyHasManyCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/relations/ManyHasManyCreateInputProcessor.ts
@@ -5,12 +5,15 @@ import { CreateInputProcessor } from '../../../inputProcessing/index.js'
 import { SqlCreateInputProcessorResult } from '../SqlCreateInputProcessor.js'
 import { CheckedPrimary } from '../../CheckedPrimary.js'
 import { MapperInput } from '../../types.js'
+import { AclScope } from '../../../acl/index.js'
 
 type Context = Model.ManyHasManyOwningContext | Model.ManyHasManyInverseContext
 
 export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.HasManyRelationProcessor<Context, SqlCreateInputProcessorResult> {
 	constructor(
 		private readonly mapper: Mapper,
+		/** Scope of the entity being written, the one that declares this relation; the other side of the junction stays nested. */
+		private readonly scope: AclScope,
 	) {
 	}
 
@@ -20,7 +23,7 @@ export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.Has
 		return async ({ primary }) => {
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, input)
 			if (err) return [err]
-			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')
+			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary, this.scope)
 		}
 	}
 
@@ -35,7 +38,7 @@ export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.Has
 			}
 			return [
 				...insertResult,
-				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary, 'nested')),
+				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary, this.scope)),
 			]
 		}
 	}
@@ -52,7 +55,7 @@ export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.Has
 					return insertResult
 				}
 			}
-			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary, 'nested')
+			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary, this.scope)
 		}
 	}
 }

--- a/packages/engine-content-api/src/mapper/insert/relations/ManyHasManyCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/relations/ManyHasManyCreateInputProcessor.ts
@@ -20,7 +20,7 @@ export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.Has
 		return async ({ primary }) => {
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, input)
 			if (err) return [err]
-			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary)
+			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')
 		}
 	}
 
@@ -28,14 +28,14 @@ export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.Has
 		{ entity, targetEntity, relation, input }: Context & { input: MapperInput.CreateDataInput },
 	) {
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
-			const insertResult = await this.mapper.insert(targetEntity, input)
+			const insertResult = await this.mapper.insert(targetEntity, input, 'nested')
 			const insertPrimary = getInsertPrimary(insertResult)
 			if (!insertPrimary) {
 				return insertResult
 			}
 			return [
 				...insertResult,
-				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary)),
+				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary, 'nested')),
 			]
 		}
 	}
@@ -46,13 +46,13 @@ export class ManyHasManyCreateInputProcessor implements CreateInputProcessor.Has
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			let [otherPrimary] = await this.mapper.getPrimaryValue(context.targetEntity, context.input.connect)
 			if (!otherPrimary) {
-				const insertResult = await this.mapper.insert(context.targetEntity, context.input.create)
+				const insertResult = await this.mapper.insert(context.targetEntity, context.input.create, 'nested')
 				otherPrimary = getInsertPrimary(insertResult)
 				if (!otherPrimary) {
 					return insertResult
 				}
 			}
-			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary)
+			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary, 'nested')
 		}
 	}
 }

--- a/packages/engine-content-api/src/mapper/insert/relations/ManyHasOneCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/relations/ManyHasOneCreateInputProcessor.ts
@@ -27,7 +27,7 @@ export class ManyHasOneCreateInputProcessor implements CreateInputProcessor.HasM
 	public async create(
 		{ relation, targetEntity, input }: Context & { input: MapperInput.CreateDataInput },
 	) {
-		const insertResult = await this.mapper.insert(targetEntity, input)
+		const insertResult = await this.mapper.insert(targetEntity, input, 'nested')
 		const value = getInsertPrimary(insertResult)
 		if (!value) {
 			return insertResult
@@ -43,7 +43,7 @@ export class ManyHasOneCreateInputProcessor implements CreateInputProcessor.HasM
 		if (value) {
 			this.insertBuilder.addFieldValue(relation.name, value)
 		} else {
-			const insertResult = await this.mapper.insert(targetEntity, create)
+			const insertResult = await this.mapper.insert(targetEntity, create, 'nested')
 			const primary = getInsertPrimary(insertResult)
 			if (!primary) {
 				return insertResult

--- a/packages/engine-content-api/src/mapper/insert/relations/OneHasManyCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/relations/OneHasManyCreateInputProcessor.ts
@@ -18,7 +18,7 @@ export class OneHasManyCreateInputProcessor implements CreateInputProcessor.HasM
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			return await this.mapper.update(targetEntity, input, {
 				[targetRelation.name]: { connect: new CheckedPrimary(primary) },
-			})
+			}, 'nested')
 		}
 	}
 
@@ -29,7 +29,7 @@ export class OneHasManyCreateInputProcessor implements CreateInputProcessor.HasM
 			return await this.mapper.insert(targetEntity, {
 				...input,
 				[targetRelation.name]: { connect: new CheckedPrimary(primary) },
-			})
+			}, 'nested')
 		}
 	}
 
@@ -45,7 +45,7 @@ export class OneHasManyCreateInputProcessor implements CreateInputProcessor.HasM
 			return await this.mapper.upsert(targetEntity, connect, connectData, {
 				...create,
 				...connectData,
-			})
+			}, 'nested')
 		}
 	}
 }

--- a/packages/engine-content-api/src/mapper/insert/relations/OneHasOneInverseCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/relations/OneHasOneInverseCreateInputProcessor.ts
@@ -28,7 +28,7 @@ export class OneHasOneInverseCreateInputProcessor implements CreateInputProcesso
 		{ input, targetRelation, targetEntity }: Context & { input: MapperInput.CreateDataInput },
 	) {
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
-			return await this.mapper.insert(targetEntity, input, builder => {
+			return await this.mapper.insert(targetEntity, input, 'nested', builder => {
 				builder.addPredicates([targetRelation.name])
 				builder.addFieldValue(targetRelation.name, primary)
 			})
@@ -57,7 +57,7 @@ export class OneHasOneInverseCreateInputProcessor implements CreateInputProcesso
 		if (currentInverseSideOfOwner) {
 			if (targetRelation.orphanRemoval) {
 				const orphanUnique = { [entity.primary]: currentInverseSideOfOwner }
-				const orphanDelete = await this.mapper.delete(entity, orphanUnique)
+				const orphanDelete = await this.mapper.delete(entity, orphanUnique, 'nested')
 				orphanResult.push(...orphanDelete)
 			} else if (!relation.nullable) {
 				return [new MutationConstraintViolationError([], ConstraintType.notNull)]
@@ -67,7 +67,7 @@ export class OneHasOneInverseCreateInputProcessor implements CreateInputProcesso
 		const connectResult = await this.mapper.updateInternal(targetEntity, input, update => {
 			update.addPredicates([targetRelation.name])
 			update.addFieldValue(targetRelation.name, primary)
-		})
+		}, 'nested')
 
 		return [
 			...connectResult,
@@ -79,7 +79,7 @@ export class OneHasOneInverseCreateInputProcessor implements CreateInputProcesso
 		context: Context & { input: MapperInput.CreateDataInput },
 		primary: Input.PrimaryValue,
 	) {
-		return await this.mapper.insert(context.targetEntity, context.input, builder => {
+		return await this.mapper.insert(context.targetEntity, context.input, 'nested', builder => {
 			builder.addPredicates([context.targetRelation.name])
 			builder.addFieldValue(context.targetRelation.name, primary)
 		})

--- a/packages/engine-content-api/src/mapper/insert/relations/OneHasOneOwningCreateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/insert/relations/OneHasOneOwningCreateInputProcessor.ts
@@ -29,7 +29,7 @@ export class OneHasOneOwningCreateInputProcessor implements CreateInputProcessor
 	}
 
 	public async create(context: Context & { input: MapperInput.CreateDataInput }) {
-		const insertResult = await this.mapper.insert(context.targetEntity, context.input)
+		const insertResult = await this.mapper.insert(context.targetEntity, context.input, 'nested')
 		const primary = getInsertPrimary(insertResult)
 		if (!primary) {
 			return insertResult
@@ -48,7 +48,7 @@ export class OneHasOneOwningCreateInputProcessor implements CreateInputProcessor
 			}
 			return []
 		} else {
-			const insertResult = await this.mapper.insert(context.targetEntity, input.create)
+			const insertResult = await this.mapper.insert(context.targetEntity, input.create, 'nested')
 			const primary = getInsertPrimary(insertResult)
 			if (primary) {
 				this.insertBuilder.addFieldValue(context.relation.name, primary)
@@ -75,6 +75,6 @@ export class OneHasOneOwningCreateInputProcessor implements CreateInputProcessor
 		return await this.mapper.updateInternal(entity, currentOwnerUnique, builder => {
 			builder.addPredicates([relation.name])
 			builder.addFieldValue(relation.name, null)
-		})
+		}, 'nested')
 	}
 }

--- a/packages/engine-content-api/src/mapper/select/SelectBuilder.ts
+++ b/packages/engine-content-api/src/mapper/select/SelectBuilder.ts
@@ -11,7 +11,7 @@ import { MetaHandler } from './handlers/index.js'
 import { Mapper } from '../Mapper.js'
 import { FieldNode, ObjectNode } from '../../inputProcessing/index.js'
 import { assertNever } from '../../utils/index.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { aclScopeFromPath, PredicateFactory } from '../../acl/index.js'
 
 export class SelectBuilder {
 	private resolver: (value: SelectRow[]) => void = () => {
@@ -96,8 +96,10 @@ export class SelectBuilder {
 			if (!fetchedPredicates.has(predicate)) {
 				const relationContext = this.relationPath[this.relationPath.length - 1]
 
-				const primaryPredicate = this.predicateFactory.create(entity, Acl.Operation.read, undefined, relationContext)
-				const fieldPredicate = this.predicateFactory.buildPredicates(entity, [predicate], relationContext)
+				const scope = aclScopeFromPath(this.relationPath)
+
+				const primaryPredicate = this.predicateFactory.create(entity, Acl.Operation.read, scope, undefined, relationContext)
+				const fieldPredicate = this.predicateFactory.buildPredicates(entity, [predicate], scope, relationContext)
 
 				this.qb = this.whereBuilder.buildAdvanced(
 					entity,

--- a/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/FieldsVisitor.ts
@@ -2,7 +2,7 @@ import { Acl, Input, Model, Settings } from '@contember/schema'
 import { Mapper } from '../../Mapper.js'
 import { RelationFetcher } from '../RelationFetcher.js'
 import { SelectExecutionHandlerContext } from '../SelectExecutionHandler.js'
-import { PredicateFactory } from '../../../acl/index.js'
+import { aclScopeFromPath, PredicateFactory } from '../../../acl/index.js'
 import { Literal, wrapIdentifier } from '@contember/database'
 import { ColumnValueGetter } from '../SelectHydrator.js'
 import { Providers } from '@contember/schema-utils'
@@ -235,8 +235,12 @@ export class FieldsVisitor implements Model.RelationByTypeVisitor<void>, Model.C
 	}
 
 	private getRequiredPredicate(entity: Model.Entity, field: Model.AnyField): Acl.Predicate | undefined {
-		const isRoot = this.relationPath.length === 0
-		const fieldPredicate = this.predicateFactory.getFieldPredicate(entity, Acl.Operation.read, field.name, isRoot)
+		const fieldPredicate = this.predicateFactory.getFieldPredicate(
+			entity,
+			Acl.Operation.read,
+			field.name,
+			aclScopeFromPath(this.relationPath),
+		)
 		return fieldPredicate.isSameAsPrimary ? undefined : fieldPredicate.predicate
 	}
 }

--- a/packages/engine-content-api/src/mapper/select/handlers/MetaHandler.ts
+++ b/packages/engine-content-api/src/mapper/select/handlers/MetaHandler.ts
@@ -1,7 +1,7 @@
 import { SelectExecutionHandler, SelectExecutionHandlerContext } from '../SelectExecutionHandler.js'
 import { Path } from '../Path.js'
 import { Acl, Input } from '@contember/schema'
-import { PredicateFactory } from '../../../acl/index.js'
+import { aclScopeFromPath, PredicateFactory } from '../../../acl/index.js'
 import { WhereBuilder } from '../WhereBuilder.js'
 import { ObjectNode } from '../../../inputProcessing/index.js'
 
@@ -32,11 +32,11 @@ export class MetaHandler implements SelectExecutionHandler<{}> {
 		metaPath: Path,
 		operation: Acl.Operation.read | Acl.Operation.update,
 	): void {
-		const { entity } = context
+		const { entity, relationPath } = context
 		if (entity.primary === fieldName) {
 			return
 		}
-		const fieldPredicate = this.predicateFactory.getFieldPredicate(entity, operation, fieldName)
+		const fieldPredicate = this.predicateFactory.getFieldPredicate(entity, operation, fieldName, aclScopeFromPath(relationPath))
 		context.addColumn({
 			path: metaPath,
 			valueGetter: context.addPredicate(fieldPredicate.predicate),

--- a/packages/engine-content-api/src/mapper/update/SqlUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/SqlUpdateInputProcessor.ts
@@ -10,6 +10,7 @@ import { UpdateInputProcessor } from '../../inputProcessing/index.js'
 import { MutationResultList } from '../Result.js'
 import { ManyHasOneUpdateInputProcessor } from './relations/ManyHasOneUpdateInputProcessor.js'
 import { MapperInput } from '../types.js'
+import { AclScope } from '../../acl/index.js'
 
 export type SqlUpdateInputProcessorResult = MutationResultList | ((ctx: { primary: Input.PrimaryValue }) => Promise<MutationResultList>)
 
@@ -25,12 +26,14 @@ export class SqlUpdateInputProcessor implements UpdateInputProcessor<SqlUpdateIn
 		private readonly data: MapperInput.UpdateDataInput,
 		private readonly updateBuilder: UpdateBuilder,
 		private readonly mapper: Mapper,
+		/** Scope of the entity being updated; relation targets are always reached over a relation and stay nested. */
+		private readonly scope: AclScope,
 	) {
 		this.oneHasOneInverseUpdateInputProcessor = new OneHasOneInverseUpdateInputProcessor(this.primaryValue, this.mapper)
 		this.oneHasOneOwningUpdateInputProcessor = new OneHasOneOwningUpdateInputProcessor(this.primaryValue, this.mapper, this.updateBuilder)
 		this.oneHasManyUpdateInputProcessor = new OneHasManyUpdateInputProcessor(this.mapper)
 		this.manyHasOneUpdateInputProcessor = new ManyHasOneUpdateInputProcessor(this.mapper, this.updateBuilder, this.primaryValue)
-		this.manyHasManyUpdateInputProcessor = new ManyHasManyUpdateInputProcessor(this.mapper)
+		this.manyHasManyUpdateInputProcessor = new ManyHasManyUpdateInputProcessor(this.mapper, this.scope, this.updateBuilder)
 	}
 
 	public column({ entity, column }: Model.ColumnContext) {

--- a/packages/engine-content-api/src/mapper/update/UpdateBuilder.ts
+++ b/packages/engine-content-api/src/mapper/update/UpdateBuilder.ts
@@ -4,7 +4,7 @@ import { acceptEveryFieldVisitor, getColumnName, getColumnType } from '@contembe
 import { Operator, QueryBuilder, UpdateBuilder as DbUpdateBuilder, Value as DbValue } from '@contember/database'
 import { PathFactory, WhereBuilder } from '../select/index.js'
 import { ColumnValue, normalizeDbValue } from '../ColumnValue.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { AclScope, PredicateFactory } from '../../acl/index.js'
 import { AfterUpdateEvent, BeforeUpdateEvent } from '../EventManager.js'
 import { Mapper } from '../Mapper.js'
 
@@ -27,6 +27,7 @@ export class UpdateBuilder {
 		private readonly primary: Input.PrimaryValue,
 		private readonly pathFactory: PathFactory,
 		private readonly predicateFactory: PredicateFactory,
+		private readonly scope: AclScope,
 	) {}
 
 	public addFieldValue(
@@ -51,7 +52,7 @@ export class UpdateBuilder {
 	}
 
 	public addPredicates(fields: string[]): void {
-		const predicate = this.predicateFactory.create(this.entity, Acl.Operation.update, fields)
+		const predicate = this.predicateFactory.create(this.entity, Acl.Operation.update, this.scope, fields)
 		this.addNewWhere(predicate)
 		this.addOldWhere(predicate)
 	}

--- a/packages/engine-content-api/src/mapper/update/UpdateBuilder.ts
+++ b/packages/engine-content-api/src/mapper/update/UpdateBuilder.ts
@@ -1,7 +1,7 @@
 import { tuple } from '../../utils/index.js'
 import { Acl, Input, Model, Value } from '@contember/schema'
 import { acceptEveryFieldVisitor, getColumnName, getColumnType } from '@contember/schema-utils'
-import { Operator, QueryBuilder, UpdateBuilder as DbUpdateBuilder, Value as DbValue } from '@contember/database'
+import { Operator, QueryBuilder, SelectBuilder, UpdateBuilder as DbUpdateBuilder, Value as DbValue } from '@contember/database'
 import { PathFactory, WhereBuilder } from '../select/index.js'
 import { ColumnValue, normalizeDbValue } from '../ColumnValue.js'
 import { AclScope, PredicateFactory } from '../../acl/index.js'
@@ -19,6 +19,8 @@ export class UpdateBuilder {
 
 	private newWhere: { and: Input.OptionalWhere[] } = { and: [] }
 	private oldWhere: { and: Input.OptionalWhere[] } = { and: [] }
+	private predicateFields: string[] = []
+	private fieldsCheckedElsewhere = new Set<string>()
 
 	constructor(
 		private readonly schema: Model.Schema,
@@ -53,8 +55,43 @@ export class UpdateBuilder {
 
 	public addPredicates(fields: string[]): void {
 		const predicate = this.predicateFactory.create(this.entity, Acl.Operation.update, this.scope, fields)
+		this.predicateFields.push(...fields)
 		this.addNewWhere(predicate)
 		this.addOldWhere(predicate)
+	}
+
+	/**
+	 * Declares that another statement of this mutation resolves this field's update predicate. A m:n
+	 * write does exactly that: `JunctionTableManager` builds the same predicate for the side it was
+	 * called about, so re-checking it here would only cost a query.
+	 */
+	public markPredicateCheckedElsewhere(field: string): void {
+		this.fieldsCheckedElsewhere.add(field)
+	}
+
+	/**
+	 * Checks the row against the predicates of the fields nothing else covers. {@link execute} skips
+	 * the statement when there is no column to set, so with relation-only data the predicates never
+	 * reach the database on their own - which used to let a mutation write through a relation the
+	 * role may not update at this scope.
+	 */
+	public async verifyPredicates(mapper: Mapper): Promise<boolean> {
+		const fields = this.predicateFields.filter(it => !this.fieldsCheckedElsewhere.has(it))
+		if (fields.length === 0) {
+			return true
+		}
+		const predicate = this.predicateFactory.create(this.entity, Acl.Operation.update, this.scope, fields)
+		if (Object.keys(predicate).length === 0) {
+			return true
+		}
+		const path = this.pathFactory.create([])
+		const qb = SelectBuilder.create()
+			.from(this.entity.tableName, path.alias)
+			.select([path.alias, this.entity.primaryColumn])
+		const where: Input.OptionalWhere = { and: [predicate, { [this.entity.primary]: { eq: this.primary } }] }
+		const result = await this.whereBuilder.build(qb, this.entity, path, where).getResult(mapper.db)
+
+		return result.length > 0
 	}
 
 	public async execute(mapper: Mapper): Promise<UpdateResult> {

--- a/packages/engine-content-api/src/mapper/update/UpdateBuilderFactory.ts
+++ b/packages/engine-content-api/src/mapper/update/UpdateBuilderFactory.ts
@@ -1,7 +1,7 @@
 import { PathFactory, WhereBuilder } from '../select/index.js'
 import { Input, Model } from '@contember/schema'
 import { UpdateBuilder } from './UpdateBuilder.js'
-import { PredicateFactory } from '../../acl/index.js'
+import { AclScope, PredicateFactory } from '../../acl/index.js'
 
 export class UpdateBuilderFactory {
 	constructor(
@@ -11,7 +11,7 @@ export class UpdateBuilderFactory {
 		private readonly predicateFactory: PredicateFactory,
 	) {}
 
-	public create(entity: Model.Entity, primary: Input.PrimaryValue): UpdateBuilder {
+	public create(entity: Model.Entity, primary: Input.PrimaryValue, scope: AclScope): UpdateBuilder {
 		return new UpdateBuilder(
 			this.schema,
 			entity,
@@ -19,6 +19,7 @@ export class UpdateBuilderFactory {
 			primary,
 			this.pathFactory,
 			this.predicateFactory,
+			scope,
 		)
 	}
 }

--- a/packages/engine-content-api/src/mapper/update/Updater.ts
+++ b/packages/engine-content-api/src/mapper/update/Updater.ts
@@ -15,6 +15,7 @@ import {
 import { UpdateBuilder } from './UpdateBuilder.js'
 import { rowDataToFieldValues } from '../ColumnValue.js'
 import { MapperInput } from '../types.js'
+import { AclScope } from '../../acl/index.js'
 
 export class Updater {
 	constructor(
@@ -27,9 +28,10 @@ export class Updater {
 		entity: Model.Entity,
 		primaryValue: Input.PrimaryValue,
 		data: MapperInput.UpdateDataInput,
+		scope: AclScope,
 		filter?: Input.OptionalWhere,
 	): Promise<MutationResultList> {
-		const updateBuilder = this.updateBuilderFactory.create(entity, primaryValue)
+		const updateBuilder = this.updateBuilderFactory.create(entity, primaryValue, scope)
 
 		const predicateFields = Object.keys(data)
 		updateBuilder.addPredicates(predicateFields)
@@ -110,8 +112,9 @@ export class Updater {
 		entity: Model.Entity,
 		primaryValue: Input.PrimaryValue,
 		builderCb: (builder: UpdateBuilder) => void,
+		scope: AclScope,
 	): Promise<MutationResultList> {
-		const updateBuilder = this.updateBuilderFactory.create(entity, primaryValue)
+		const updateBuilder = this.updateBuilderFactory.create(entity, primaryValue, scope)
 
 		builderCb(updateBuilder)
 

--- a/packages/engine-content-api/src/mapper/update/Updater.ts
+++ b/packages/engine-content-api/src/mapper/update/Updater.ts
@@ -40,7 +40,7 @@ export class Updater {
 		}
 
 		const visitor = new UpdateInputVisitor<SqlUpdateInputProcessorResult>(
-			new SqlUpdateInputProcessor(primaryValue, data, updateBuilder, mapper),
+			new SqlUpdateInputProcessor(primaryValue, data, updateBuilder, mapper, scope),
 			this.schema,
 			data,
 		)
@@ -71,6 +71,10 @@ export class Updater {
 		const result = await updateBuilder.execute(mapper)
 
 		if (!result.executed) {
+			// direct update was not invoked, so its predicates never reached the database
+			if (!(await updateBuilder.verifyPredicates(mapper))) {
+				return [new MutationNoResultError([])]
+			}
 			if (filter && Object.keys(filter).length > 0) {
 				// direct update was not invoked, but we still need to check if the row matches the filter
 				const where: Input.OptionalWhere = {

--- a/packages/engine-content-api/src/mapper/update/relations/ManyHasManyUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/relations/ManyHasManyUpdateInputProcessor.ts
@@ -5,28 +5,35 @@ import { Mapper } from '../../Mapper.js'
 import { SqlUpdateInputProcessorResult } from '../../update/index.js'
 import { CheckedPrimary } from '../../CheckedPrimary.js'
 import { MapperInput } from '../../types.js'
+import { AclScope } from '../../../acl/index.js'
+import { UpdateBuilder } from '../UpdateBuilder.js'
 
 type Context = Model.ManyHasManyOwningContext | Model.ManyHasManyInverseContext
 
 export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.HasManyRelationInputProcessor<Context, SqlUpdateInputProcessorResult> {
 	constructor(
 		private readonly mapper: Mapper,
+		/** Scope of the entity being written, the one that declares this relation; the other side of the junction stays nested. */
+		private readonly scope: AclScope,
+		private readonly updateBuilder: UpdateBuilder,
 	) {
 	}
 
 	public async connect(
 		{ entity, targetEntity, relation, targetRelation, input }: Context & { input: Input.UniqueWhere | CheckedPrimary },
 	) {
+		this.updateBuilder.markPredicateCheckedElsewhere(relation.name)
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, input)
 			if (err) return [err]
-			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')
+			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary, this.scope)
 		}
 	}
 
 	public async create(
 		{ entity, targetEntity, relation, input }: Context & { input: MapperInput.CreateDataInput },
 	) {
+		this.updateBuilder.markPredicateCheckedElsewhere(relation.name)
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const insertResult = await this.mapper.insert(targetEntity, input, 'nested')
 			const insertPrimary = getInsertPrimary(insertResult)
@@ -35,7 +42,7 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 			}
 			return [
 				...insertResult,
-				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary, 'nested')),
+				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary, this.scope)),
 			]
 		}
 	}
@@ -43,6 +50,7 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 	public async connectOrCreate(
 		context: Context & { input: MapperInput.ConnectOrCreateInput },
 	) {
+		this.updateBuilder.markPredicateCheckedElsewhere(context.relation.name)
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			let [otherPrimary] = await this.mapper.getPrimaryValue(context.targetEntity, context.input.connect)
 			if (!otherPrimary) {
@@ -52,19 +60,20 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 					return insertResult
 				}
 			}
-			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary, 'nested')
+			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary, this.scope)
 		}
 	}
 
 	public async update(
 		{ entity, targetEntity, relation, input: { where, data } }: Context & { input: UpdateInputProcessor.UpdateManyInput },
 	) {
+		this.updateBuilder.markPredicateCheckedElsewhere(relation.name)
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, where)
 			if (err) return [err]
 			return [
 				...(await this.mapper.update(targetEntity, new CheckedPrimary(otherPrimary), data, 'nested')),
-				...(await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')),
+				...(await this.mapper.connectJunction(entity, relation, primary, otherPrimary, this.scope)),
 			]
 		}
 	}
@@ -72,11 +81,12 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 	public async upsert(
 		{ entity, relation, targetEntity, input: { create, update, where } }: Context & { input: UpdateInputProcessor.UpsertManyInput },
 	) {
+		this.updateBuilder.markPredicateCheckedElsewhere(relation.name)
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const [otherPrimary] = await this.mapper.getPrimaryValue(targetEntity, where)
 			if (otherPrimary) {
 				const updateResult = await this.mapper.update(targetEntity, new CheckedPrimary(otherPrimary), update, 'nested')
-				const connectResult = await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')
+				const connectResult = await this.mapper.connectJunction(entity, relation, primary, otherPrimary, this.scope)
 				return [...updateResult, ...connectResult]
 			} else {
 				const insertResult = await this.mapper.insert(targetEntity, create, 'nested')
@@ -85,7 +95,7 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 				if (!primaryValue) {
 					return insertResult
 				}
-				const connectResult = await this.mapper.connectJunction(entity, relation, primary, primaryValue, 'nested')
+				const connectResult = await this.mapper.connectJunction(entity, relation, primary, primaryValue, this.scope)
 				return [...insertResult, ...connectResult]
 			}
 		}
@@ -94,11 +104,12 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 	public async disconnect(
 		{ entity, targetEntity, relation, input }: Context & { input: Input.UniqueWhere },
 	) {
+		this.updateBuilder.markPredicateCheckedElsewhere(relation.name)
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, input)
 			if (err) return [err]
 
-			return await this.mapper.disconnectJunction(entity, relation, primary, otherPrimary, 'nested')
+			return await this.mapper.disconnectJunction(entity, relation, primary, otherPrimary, this.scope)
 		}
 	}
 

--- a/packages/engine-content-api/src/mapper/update/relations/ManyHasManyUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/relations/ManyHasManyUpdateInputProcessor.ts
@@ -20,7 +20,7 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, input)
 			if (err) return [err]
-			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary)
+			return await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')
 		}
 	}
 
@@ -28,14 +28,14 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 		{ entity, targetEntity, relation, input }: Context & { input: MapperInput.CreateDataInput },
 	) {
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
-			const insertResult = await this.mapper.insert(targetEntity, input)
+			const insertResult = await this.mapper.insert(targetEntity, input, 'nested')
 			const insertPrimary = getInsertPrimary(insertResult)
 			if (!insertPrimary) {
 				return insertResult
 			}
 			return [
 				...insertResult,
-				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary)),
+				...(await this.mapper.connectJunction(entity, relation, primary, insertPrimary, 'nested')),
 			]
 		}
 	}
@@ -46,13 +46,13 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			let [otherPrimary] = await this.mapper.getPrimaryValue(context.targetEntity, context.input.connect)
 			if (!otherPrimary) {
-				const insertResult = await this.mapper.insert(context.targetEntity, context.input.create)
+				const insertResult = await this.mapper.insert(context.targetEntity, context.input.create, 'nested')
 				otherPrimary = getInsertPrimary(insertResult)
 				if (!otherPrimary) {
 					return insertResult
 				}
 			}
-			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary)
+			return await this.mapper.connectJunction(context.entity, context.relation, primary, otherPrimary, 'nested')
 		}
 	}
 
@@ -63,8 +63,8 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, where)
 			if (err) return [err]
 			return [
-				...(await this.mapper.update(targetEntity, new CheckedPrimary(otherPrimary), data)),
-				...(await this.mapper.connectJunction(entity, relation, primary, otherPrimary)),
+				...(await this.mapper.update(targetEntity, new CheckedPrimary(otherPrimary), data, 'nested')),
+				...(await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')),
 			]
 		}
 	}
@@ -75,17 +75,17 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			const [otherPrimary] = await this.mapper.getPrimaryValue(targetEntity, where)
 			if (otherPrimary) {
-				const updateResult = await this.mapper.update(targetEntity, new CheckedPrimary(otherPrimary), update)
-				const connectResult = await this.mapper.connectJunction(entity, relation, primary, otherPrimary)
+				const updateResult = await this.mapper.update(targetEntity, new CheckedPrimary(otherPrimary), update, 'nested')
+				const connectResult = await this.mapper.connectJunction(entity, relation, primary, otherPrimary, 'nested')
 				return [...updateResult, ...connectResult]
 			} else {
-				const insertResult = await this.mapper.insert(targetEntity, create)
+				const insertResult = await this.mapper.insert(targetEntity, create, 'nested')
 
 				const primaryValue = getInsertPrimary(insertResult)
 				if (!primaryValue) {
 					return insertResult
 				}
-				const connectResult = await this.mapper.connectJunction(entity, relation, primary, primaryValue)
+				const connectResult = await this.mapper.connectJunction(entity, relation, primary, primaryValue, 'nested')
 				return [...insertResult, ...connectResult]
 			}
 		}
@@ -98,7 +98,7 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 			const [otherPrimary, err] = await this.mapper.getPrimaryValue(targetEntity, input)
 			if (err) return [err]
 
-			return await this.mapper.disconnectJunction(entity, relation, primary, otherPrimary)
+			return await this.mapper.disconnectJunction(entity, relation, primary, otherPrimary, 'nested')
 		}
 	}
 
@@ -106,7 +106,7 @@ export class ManyHasManyUpdateInputProcessor implements UpdateInputProcessor.Has
 		{ entity, targetEntity, relation, targetRelation, input }: Context & { input: Input.UniqueWhere },
 	) {
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
-			return await this.mapper.delete(targetEntity, input)
+			return await this.mapper.delete(targetEntity, input, 'nested')
 		}
 	}
 }

--- a/packages/engine-content-api/src/mapper/update/relations/ManyHasOneUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/relations/ManyHasOneUpdateInputProcessor.ts
@@ -36,7 +36,7 @@ export class ManyHasOneUpdateInputProcessor implements UpdateInputProcessor.HasO
 	public async create(
 		{ relation, targetEntity, input }: Context & { input: MapperInput.CreateDataInput },
 	) {
-		const insertResult = await this.mapper.insert(targetEntity, input)
+		const insertResult = await this.mapper.insert(targetEntity, input, 'nested')
 		const value = getInsertPrimary(insertResult)
 		if (!value) {
 			return insertResult
@@ -52,7 +52,7 @@ export class ManyHasOneUpdateInputProcessor implements UpdateInputProcessor.HasO
 		if (value) {
 			this.builder.addFieldValue(relation.name, value)
 		} else {
-			const insertResult = await this.mapper.insert(targetEntity, create)
+			const insertResult = await this.mapper.insert(targetEntity, create, 'nested')
 			const primary = getInsertPrimary(insertResult)
 			if (!primary) {
 				return insertResult
@@ -75,7 +75,7 @@ export class ManyHasOneUpdateInputProcessor implements UpdateInputProcessor.HasO
 			if (!inversePrimary) {
 				return [new MutationNothingToDo([], NothingToDoReason.emptyRelation)]
 			}
-			return await this.mapper.update(targetEntity, new CheckedPrimary(inversePrimary), input)
+			return await this.mapper.update(targetEntity, new CheckedPrimary(inversePrimary), input, 'nested')
 		}
 	}
 
@@ -84,7 +84,7 @@ export class ManyHasOneUpdateInputProcessor implements UpdateInputProcessor.HasO
 	) {
 		const inversePrimary = await this.mapper.selectField(entity, { [entity.primary]: this.primary }, relation.name)
 		if (!inversePrimary) {
-			const insertResult = await this.mapper.insert(targetEntity, create)
+			const insertResult = await this.mapper.insert(targetEntity, create, 'nested')
 			const insertPrimary = getInsertPrimary(insertResult)
 			if (insertPrimary) {
 				this.builder.addFieldValue(relation.name, insertPrimary)
@@ -92,7 +92,7 @@ export class ManyHasOneUpdateInputProcessor implements UpdateInputProcessor.HasO
 			return insertResult
 		}
 
-		return async () => await this.mapper.update(targetEntity, new CheckedPrimary(inversePrimary), update)
+		return async () => await this.mapper.update(targetEntity, new CheckedPrimary(inversePrimary), update, 'nested')
 	}
 
 	public async disconnect(
@@ -117,7 +117,7 @@ export class ManyHasOneUpdateInputProcessor implements UpdateInputProcessor.HasO
 				{ [entity.primary]: primary },
 				relation.name,
 			)
-			return await this.mapper.delete(targetEntity, { [targetEntity.primary]: inversePrimary })
+			return await this.mapper.delete(targetEntity, { [targetEntity.primary]: inversePrimary }, 'nested')
 		}
 	}
 }

--- a/packages/engine-content-api/src/mapper/update/relations/OneHasManyUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/relations/OneHasManyUpdateInputProcessor.ts
@@ -20,7 +20,7 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 		return async ({ primary }: { primary: Input.PrimaryValue }) => {
 			return await this.mapper.update(targetEntity, input, {
 				[targetRelation.name]: { connect: new CheckedPrimary(primary) },
-			})
+			}, 'nested')
 		}
 	}
 
@@ -31,7 +31,7 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 			return await this.mapper.insert(targetEntity, {
 				...input,
 				[targetRelation.name]: { connect: new CheckedPrimary(primary) },
-			})
+			}, 'nested')
 		}
 	}
 
@@ -47,7 +47,7 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 			return await this.mapper.upsert(targetEntity, connect, connectData, {
 				...create,
 				...connectData,
-			})
+			}, 'nested')
 		}
 	}
 
@@ -62,6 +62,7 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 					...data,
 					// [targetRelation.name]: {connect: thisPrimary}
 				},
+				'nested',
 			)
 		}
 	}
@@ -77,12 +78,13 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 					...update,
 					// [targetRelation.name]: {connect: thisPrimary}
 				},
+				'nested',
 			)
 			if (result[0].result === MutationResultType.notFoundError) {
 				return await this.mapper.insert(targetEntity, {
 					...create,
 					[targetRelation.name]: { connect: new CheckedPrimary(primary) },
-				})
+				}, 'nested')
 			}
 			return result
 		}
@@ -96,6 +98,7 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 				targetEntity,
 				{ ...input, [targetRelation.name]: { [entity.primary]: primary } },
 				{ [targetRelation.name]: { disconnect: true } },
+				'nested',
 			)
 		}
 	}
@@ -107,7 +110,7 @@ export class OneHasManyUpdateInputProcessor implements UpdateInputProcessor.HasM
 			return await this.mapper.delete(targetEntity, {
 				...input,
 				[targetRelation.name]: { [entity.primary]: primary },
-			})
+			}, 'nested')
 		}
 	}
 }

--- a/packages/engine-content-api/src/mapper/update/relations/OneHasOneInverseUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/relations/OneHasOneInverseUpdateInputProcessor.ts
@@ -56,6 +56,7 @@ export class OneHasOneInverseUpdateInputProcessor
 				targetEntity,
 				{ [targetRelation.name]: { [entity.primary]: this.primaryValue } },
 				input,
+				'nested',
 			)
 		}
 	}
@@ -67,6 +68,7 @@ export class OneHasOneInverseUpdateInputProcessor
 				targetEntity,
 				{ [targetRelation.name]: { [entity.primary]: this.primaryValue } },
 				update,
+				'nested',
 			)
 			if (result[0].result === MutationResultType.notFoundError) {
 				return await this.createInternal({
@@ -100,9 +102,10 @@ export class OneHasOneInverseUpdateInputProcessor
 					builder.addPredicates([targetRelation.name])
 					builder.addFieldValue(targetRelation.name, null)
 				},
+				'nested',
 			)
 			if (targetRelation.orphanRemoval) {
-				result.push(...(await this.mapper.delete(entity, { [entity.primary]: this.primaryValue })))
+				result.push(...(await this.mapper.delete(entity, { [entity.primary]: this.primaryValue }, 'nested')))
 			}
 			return result
 		}
@@ -114,7 +117,7 @@ export class OneHasOneInverseUpdateInputProcessor
 				return [new MutationConstraintViolationError([], ConstraintType.notNull)]
 			}
 			// orphan removal is handled in mapper.delete
-			return await this.mapper.delete(targetEntity, { [targetRelation.name]: { [entity.primary]: this.primaryValue } })
+			return await this.mapper.delete(targetEntity, { [targetRelation.name]: { [entity.primary]: this.primaryValue } }, 'nested')
 		}
 	}
 
@@ -137,7 +140,7 @@ export class OneHasOneInverseUpdateInputProcessor
 			const disconnectFromCurrentOwner = await this.mapper.updateInternal(targetEntity, new CheckedPrimary(currentOwner), builder => {
 				builder.addPredicates([targetRelation.name])
 				builder.addFieldValue(targetRelation.name, null)
-			})
+			}, 'nested')
 			result.push(...disconnectFromCurrentOwner)
 		}
 		const orphanedInverseSide = targetRelation.orphanRemoval
@@ -147,11 +150,11 @@ export class OneHasOneInverseUpdateInputProcessor
 		const connectToNewOwner = await this.mapper.updateInternal(targetEntity, new CheckedPrimary(newOwner), builder => {
 			builder.addPredicates([targetRelation.name])
 			builder.addFieldValue(targetRelation.name, this.primaryValue)
-		})
+		}, 'nested')
 		result.push(...connectToNewOwner)
 
 		if (orphanedInverseSide) {
-			const deleteOrphanedInverseSide = await this.mapper.delete(entity, { [entity.primary]: orphanedInverseSide })
+			const deleteOrphanedInverseSide = await this.mapper.delete(entity, { [entity.primary]: orphanedInverseSide }, 'nested')
 			result.push(...deleteOrphanedInverseSide)
 		}
 		return result
@@ -172,11 +175,11 @@ export class OneHasOneInverseUpdateInputProcessor
 			const disconnectFromCurrentOwner = await this.mapper.updateInternal(targetEntity, new CheckedPrimary(currentOwner), builder => {
 				builder.addPredicates([targetRelation.name])
 				builder.addFieldValue(targetRelation.name, null)
-			})
+			}, 'nested')
 			result.push(...disconnectFromCurrentOwner)
 		}
 
-		const connectToNewlyCreatedOwner = await this.mapper.insert(targetEntity, input, builder => {
+		const connectToNewlyCreatedOwner = await this.mapper.insert(targetEntity, input, 'nested', builder => {
 			builder.addFieldValue(targetRelation.name, this.primaryValue)
 			builder.addPredicates([targetRelation.name])
 		})

--- a/packages/engine-content-api/src/mapper/update/relations/OneHasOneOwningUpdateInputProcessor.ts
+++ b/packages/engine-content-api/src/mapper/update/relations/OneHasOneOwningUpdateInputProcessor.ts
@@ -117,7 +117,7 @@ export class OneHasOneOwningUpdateInputProcessor
 			if (!inversePrimary) {
 				return [new MutationNothingToDo([], NothingToDoReason.emptyRelation)]
 			}
-			return await this.mapper.update(targetEntity, new CheckedPrimary(inversePrimary), input)
+			return await this.mapper.update(targetEntity, new CheckedPrimary(inversePrimary), input, 'nested')
 		}
 	}
 
@@ -126,7 +126,7 @@ export class OneHasOneOwningUpdateInputProcessor
 	) {
 		const primary = await this.mapper.selectField(entity, { [entity.primary]: this.primaryValue }, relation.name)
 		if (!primary) {
-			const insertResult = await this.mapper.insert(targetEntity, create)
+			const insertResult = await this.mapper.insert(targetEntity, create, 'nested')
 			const insertPrimary = getInsertPrimary(insertResult)
 			if (!insertPrimary) {
 				return insertResult
@@ -136,7 +136,7 @@ export class OneHasOneOwningUpdateInputProcessor
 		}
 
 		return async () => {
-			return await this.mapper.update(targetEntity, new CheckedPrimary(primary), update)
+			return await this.mapper.update(targetEntity, new CheckedPrimary(primary), update, 'nested')
 		}
 	}
 
@@ -155,7 +155,7 @@ export class OneHasOneOwningUpdateInputProcessor
 
 		if (relation.orphanRemoval && inversePrimary) {
 			return async () => {
-				return await this.mapper.delete(targetEntity, new CheckedPrimary(inversePrimary))
+				return await this.mapper.delete(targetEntity, new CheckedPrimary(inversePrimary), 'nested')
 			}
 		}
 
@@ -176,7 +176,7 @@ export class OneHasOneOwningUpdateInputProcessor
 			if (!targetPrimary) {
 				return [new MutationNothingToDo([], NothingToDoReason.emptyRelation)]
 			}
-			return await this.mapper.delete(targetEntity, new CheckedPrimary(targetPrimary))
+			return await this.mapper.delete(targetEntity, new CheckedPrimary(targetPrimary), 'nested')
 		}
 	}
 
@@ -188,7 +188,7 @@ export class OneHasOneOwningUpdateInputProcessor
 			return [new MutationConstraintViolationError([], ConstraintType.notNull)]
 		}
 
-		return await this.mapper.insert(targetEntity, input)
+		return await this.mapper.insert(targetEntity, input, 'nested')
 	}
 
 	private async getCurrentInverseSide(
@@ -208,7 +208,7 @@ export class OneHasOneOwningUpdateInputProcessor
 		currentInverseSide: Input.PrimaryValue | undefined,
 	) {
 		if (relation.orphanRemoval && currentInverseSide) {
-			return await this.mapper.delete(targetEntity, { [targetEntity.primary]: currentInverseSide })
+			return await this.mapper.delete(targetEntity, { [targetEntity.primary]: currentInverseSide }, 'nested')
 		}
 		return []
 	}
@@ -247,6 +247,7 @@ export class OneHasOneOwningUpdateInputProcessor
 					builder.addPredicates([relation.name])
 					builder.addFieldValue(relation.name, null)
 				},
+				'nested',
 			)
 		}
 		return []

--- a/packages/engine-content-api/src/resolvers/MutationResolver.ts
+++ b/packages/engine-content-api/src/resolvers/MutationResolver.ts
@@ -253,7 +253,7 @@ export class MutationResolver {
 		queryAst: ObjectNode<Input.UpdateInput>,
 	): Promise<WithoutNode<Result.UpdateResult>> {
 		const input = queryAst.args
-		const result = await mapper.update(entity, input.by, input.data, input.filter)
+		const result = await mapper.update(entity, input.by, input.data, 'root', input.filter)
 		const errorResponse = this.createErrorResponse(result)
 		if (errorResponse) {
 			return errorResponse
@@ -310,7 +310,7 @@ export class MutationResolver {
 		queryAst: ObjectNode<Input.CreateInput>,
 	): Promise<WithoutNode<Result.CreateResult>> {
 		const input = queryAst.args
-		const result = await mapper.insert(entity, input.data)
+		const result = await mapper.insert(entity, input.data, 'root')
 		const errorResponse = this.createErrorResponse(result)
 		if (errorResponse) {
 			return errorResponse
@@ -385,7 +385,7 @@ export class MutationResolver {
 		queryAst: ObjectNode<Input.UpsertInput>,
 	): Promise<WithoutNode<Result.UpsertResult>> {
 		const input = queryAst.args
-		const result = await mapper.upsert(entity, input.by, input.update, input.create, input.filter)
+		const result = await mapper.upsert(entity, input.by, input.update, input.create, 'root', input.filter)
 		const errorResponse = this.createErrorResponse(result)
 		if (errorResponse) {
 			return errorResponse
@@ -427,7 +427,7 @@ export class MutationResolver {
 
 		const nodes = await this.resolveResultNodes(mapper, entity, input.by, queryAst)
 
-		const result = await mapper.delete(entity, queryAst.args.by, queryAst.args.filter)
+		const result = await mapper.delete(entity, queryAst.args.by, 'root', queryAst.args.filter)
 		if (
 			result.length >= 1
 			&& (result[0].result === MutationResultType.ok || result[0].result === MutationResultType.nothingToDo)

--- a/packages/engine-content-api/src/schema/EntityTypeProvider.ts
+++ b/packages/engine-content-api/src/schema/EntityTypeProvider.ts
@@ -43,6 +43,7 @@ export class EntityTypeProvider {
 	constructor(
 		private readonly schema: Model.Schema,
 		private readonly authorizator: Authorizator,
+		private readonly rootAuthorizator: Authorizator,
 		private readonly columnTypeResolver: ColumnTypeResolver,
 		private readonly whereTypeProvider: WhereTypeProvider,
 		private readonly orderByTypeProvider: OrderByTypeProvider,
@@ -99,7 +100,7 @@ export class EntityTypeProvider {
 		}
 
 		for (const field of accessibleFields) {
-			const fieldTypeVisitor = new FieldTypeVisitor(this.columnTypeResolver, this, this.authorizator)
+			const fieldTypeVisitor = new FieldTypeVisitor(this.columnTypeResolver, this, this.authorizator, this.rootAuthorizator)
 			const type: GraphQLOutputType = acceptFieldVisitor(this.schema, entity, field.name, fieldTypeVisitor)
 
 			const fieldArgsVisitor = new FieldArgsVisitor(this.whereTypeProvider, this.orderByTypeProvider)

--- a/packages/engine-content-api/src/schema/GraphQlSchemaBuilderFactory.ts
+++ b/packages/engine-content-api/src/schema/GraphQlSchemaBuilderFactory.ts
@@ -32,14 +32,21 @@ import { ConnectOrCreateRelationInputProvider } from './mutations/ConnectOrCreat
 import { RefreshViewMutationProvider } from './RefreshViewMutationProvider.js'
 
 export class GraphQlSchemaBuilderFactory {
-	public create(schema: Model.Schema, authorizator: Authorizator): GraphQlSchemaBuilder {
-		return this.createContainerBuilder(schema, authorizator).build().graphQlSchemaBuilder
+	/**
+	 * `authorizator` shapes the types - it must carry the nested permission set, so a field granted
+	 * only via `through` still exists on the shared type. `rootAuthorizator` gates the root query and
+	 * mutation fields and therefore must carry the root grants only. Callers with a single flat
+	 * permission set can omit it.
+	 */
+	public create(schema: Model.Schema, authorizator: Authorizator, rootAuthorizator?: Authorizator): GraphQlSchemaBuilder {
+		return this.createContainerBuilder(schema, authorizator, rootAuthorizator).build().graphQlSchemaBuilder
 	}
 
-	public createContainerBuilder(schema: Model.Schema, authorizator: Authorizator) {
+	public createContainerBuilder(schema: Model.Schema, authorizator: Authorizator, rootAuthorizator: Authorizator = authorizator) {
 		return new Builder({})
 			.addService('schema', () => schema)
 			.addService('authorizator', () => authorizator)
+			.addService('rootAuthorizator', () => rootAuthorizator)
 			.addService('customTypesProvider', ({}) => new CustomTypesProvider())
 			.addService('enumsProvider', ({ schema }) => new EnumsProvider(schema))
 			.addService(
@@ -79,8 +86,8 @@ export class GraphQlSchemaBuilderFactory {
 			)
 			.addService(
 				'queryProvider',
-				({ authorizator, whereTypeProvider, orderByTypeProvider, entityTypeProvider, paginatedFieldConfigFactory }) =>
-					new QueryProvider(authorizator, whereTypeProvider, orderByTypeProvider, entityTypeProvider, paginatedFieldConfigFactory),
+				({ authorizator, rootAuthorizator, whereTypeProvider, orderByTypeProvider, entityTypeProvider, paginatedFieldConfigFactory }) =>
+					new QueryProvider(authorizator, rootAuthorizator, whereTypeProvider, orderByTypeProvider, entityTypeProvider, paginatedFieldConfigFactory),
 			)
 			.addService('createEntityInputProviderAccessor', ({}) => new Accessor<EntityInputProvider<EntityInputType.create>>())
 			.addService('createEntityRelationAllowedOperationsVisitor', ({ authorizator }) => new CreateEntityRelationAllowedOperationsVisitor(authorizator))
@@ -160,9 +167,18 @@ export class GraphQlSchemaBuilderFactory {
 			.addService('resultSchemaTypeProvider', ({}) => new ResultSchemaTypeProvider())
 			.addService(
 				'mutationProvider',
-				({ authorizator, whereTypeProvider, entityTypeProvider, createEntityInputProvider, updateEntityInputProvider, resultSchemaTypeProvider }) =>
+				({
+					authorizator,
+					rootAuthorizator,
+					whereTypeProvider,
+					entityTypeProvider,
+					createEntityInputProvider,
+					updateEntityInputProvider,
+					resultSchemaTypeProvider,
+				}) =>
 					new MutationProvider(
 						authorizator,
+						rootAuthorizator,
 						whereTypeProvider,
 						entityTypeProvider,
 						createEntityInputProvider,

--- a/packages/engine-content-api/src/schema/GraphQlSchemaBuilderFactory.ts
+++ b/packages/engine-content-api/src/schema/GraphQlSchemaBuilderFactory.ts
@@ -62,8 +62,8 @@ export class GraphQlSchemaBuilderFactory {
 			.addService('orderByTypeProvider', ({ schema, authorizator }) => new OrderByTypeProvider(schema, authorizator))
 			.addService(
 				'entityTypeProvider',
-				({ schema, authorizator, columnTypeResolver, whereTypeProvider, orderByTypeProvider }) =>
-					new EntityTypeProvider(schema, authorizator, columnTypeResolver, whereTypeProvider, orderByTypeProvider),
+				({ schema, authorizator, rootAuthorizator, columnTypeResolver, whereTypeProvider, orderByTypeProvider }) =>
+					new EntityTypeProvider(schema, authorizator, rootAuthorizator, columnTypeResolver, whereTypeProvider, orderByTypeProvider),
 			)
 			.addService(
 				'paginatedFieldConfigFactory',

--- a/packages/engine-content-api/src/schema/MutationProvider.ts
+++ b/packages/engine-content-api/src/schema/MutationProvider.ts
@@ -15,6 +15,7 @@ type FieldConfig<TArgs> = GraphQLFieldConfig<any, Context, TArgs>
 export class MutationProvider {
 	constructor(
 		private readonly authorizator: Authorizator,
+		private readonly rootAuthorizator: Authorizator,
 		private readonly whereTypeProvider: WhereTypeProvider,
 		private readonly entityTypeProvider: EntityTypeProvider,
 		private readonly createEntityInputProvider: EntityInputProvider<EntityInputType.create>,
@@ -34,7 +35,8 @@ export class MutationProvider {
 	}
 
 	protected getCreateMutation(entity: Model.Entity): FieldConfig<Input.CreateInput> | undefined {
-		if (this.authorizator.isRootOperationDisallowed(entity.name, Acl.Operation.create)) {
+		// Root entry points are gated on the root grants alone - a `through` grant must not open one.
+		if (this.rootAuthorizator.getEntityPermission(Acl.Operation.create, entity.name) === 'no') {
 			return undefined
 		}
 		const entityName = entity.name
@@ -62,13 +64,10 @@ export class MutationProvider {
 
 	protected getDeleteMutation(entity: Model.Entity): FieldConfig<Input.DeleteInput> | undefined {
 		const entityName = entity.name
-		if (this.authorizator.isRootOperationDisallowed(entityName, Acl.Operation.delete)) {
-			return undefined
-		}
 		if (entity.view) {
 			return undefined
 		}
-		if (this.authorizator.getEntityPermission(Acl.Operation.delete, entityName) === 'no') {
+		if (this.rootAuthorizator.getEntityPermission(Acl.Operation.delete, entityName) === 'no') {
 			return undefined
 		}
 		const uniqueWhere = this.whereTypeProvider.getEntityUniqueWhereType(entityName)
@@ -98,7 +97,7 @@ export class MutationProvider {
 	}
 
 	protected getUpdateMutation(entity: Model.Entity): FieldConfig<Input.UpdateInput> | undefined {
-		if (this.authorizator.isRootOperationDisallowed(entity.name, Acl.Operation.update)) {
+		if (this.rootAuthorizator.getEntityPermission(Acl.Operation.update, entity.name) === 'no') {
 			return undefined
 		}
 		const entityName = entity.name
@@ -136,8 +135,8 @@ export class MutationProvider {
 
 	private getUpsertMutation(entity: Model.Entity): FieldConfig<Input.UpsertInput> | undefined {
 		if (
-			this.authorizator.isRootOperationDisallowed(entity.name, Acl.Operation.update)
-			|| this.authorizator.isRootOperationDisallowed(entity.name, Acl.Operation.create)
+			this.rootAuthorizator.getEntityPermission(Acl.Operation.update, entity.name) === 'no'
+			|| this.rootAuthorizator.getEntityPermission(Acl.Operation.create, entity.name) === 'no'
 		) {
 			return undefined
 		}

--- a/packages/engine-content-api/src/schema/QueryProvider.ts
+++ b/packages/engine-content-api/src/schema/QueryProvider.ts
@@ -12,6 +12,7 @@ import { PaginatedFieldConfigFactory } from './PaginatedFieldConfigFactory.js'
 export class QueryProvider {
 	constructor(
 		private readonly authorizator: Authorizator,
+		private readonly rootAuthorizator: Authorizator,
 		private readonly whereTypeProvider: WhereTypeProvider,
 		private readonly orderByTypeProvider: OrderByTypeProvider,
 		private readonly entityTypeProvider: EntityTypeProvider,
@@ -19,10 +20,9 @@ export class QueryProvider {
 	) {}
 
 	public getQueries(entity: Model.Entity): { [fieldName: string]: GraphQLFieldConfig<any, Context, any> } {
-		if (this.authorizator.getEntityPermission(Acl.Operation.read, entity.name) === 'no') {
-			return {}
-		}
-		if (this.authorizator.isRootOperationDisallowed(entity.name, Acl.Operation.read)) {
+		// Root entry points are gated on the root grants alone; `through` grants exist to apply only
+		// when the entity is reached over a relation, so they must not open a root query.
+		if (this.rootAuthorizator.getEntityPermission(Acl.Operation.read, entity.name) === 'no') {
 			return {}
 		}
 		return {

--- a/packages/engine-content-api/src/schema/entities/FieldTypeVisitor.ts
+++ b/packages/engine-content-api/src/schema/entities/FieldTypeVisitor.ts
@@ -10,6 +10,7 @@ export class FieldTypeVisitor implements Model.ColumnVisitor<GraphQLOutputType>,
 		private readonly columnTypeResolver: ColumnTypeResolver,
 		private readonly entityTypeProvider: EntityTypeProvider,
 		private readonly authorizator: Authorizator,
+		private readonly rootAuthorizator: Authorizator,
 	) {
 	}
 
@@ -20,7 +21,9 @@ export class FieldTypeVisitor implements Model.ColumnVisitor<GraphQLOutputType>,
 		if (!fieldPredicate || !idPredicate) {
 			throw new ImplementationException()
 		}
-		if (!column.nullable && (fieldPredicate === true || fieldPredicate === idPredicate)) {
+		// one type serves both scopes, so it must take the weaker of the two - a column granted only via `through` is not filled at the root
+		const alwaysReadable = this.isAlwaysReadable(this.authorizator, entity, column) && this.isAlwaysReadable(this.rootAuthorizator, entity, column)
+		if (!column.nullable && alwaysReadable) {
 			return new GraphQLNonNull(type)
 		}
 		return type
@@ -33,5 +36,18 @@ export class FieldTypeVisitor implements Model.ColumnVisitor<GraphQLOutputType>,
 
 	public visitHasOne({ relation }: Model.AnyHasOneRelationContext): GraphQLOutputType {
 		return this.entityTypeProvider.getEntity(relation.target)
+	}
+
+	/** Whether a row this scope returns always carries the column, so it may be non-null as far as this scope is concerned. */
+	private isAlwaysReadable(authorizator: Authorizator, entity: Model.Entity, column: Model.AnyColumn): boolean {
+		if (authorizator.getEntityPermission(Acl.Operation.read, entity.name) === 'no') {
+			// the scope never returns a row of this entity, so it constrains nothing
+			return true
+		}
+		const fieldPredicate = authorizator.getFieldPredicate(Acl.Operation.read, entity.name, column.name)
+		if (!fieldPredicate) {
+			return false
+		}
+		return fieldPredicate === true || fieldPredicate === authorizator.getFieldPredicate(Acl.Operation.read, entity.name, entity.primary)
 	}
 }

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/delete/acl/throughScope.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/delete/acl/throughScope.test.ts
@@ -1,0 +1,264 @@
+import { test } from 'bun:test'
+import { execute, failedTransaction, sqlTransaction } from '../../../../../src/test.js'
+import { c, createSchema } from '@contember/schema-definition'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * `Post` may be deleted only through `Author.posts`. The root permission set carries no delete grant
+ * for it at all, so a nested delete works only if `DeleteExecutor` resolves its predicate against
+ * the nested set.
+ */
+namespace NestedDelete {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['id', 'posts'],
+	})
+	export class Author {
+		posts = c.oneHasMany(Post, 'author')
+	}
+
+	@c.Allow(editor, {
+		read: ['id', 'author'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		update: ['author'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		when: { locked: { eq: false } },
+		delete: true,
+	})
+	export class Post {
+		locked = c.boolColumn().notNull()
+		author = c.manyHasOne(Author, 'posts').notNull()
+	}
+}
+
+const nestedDeleteSchema = createSchema(NestedDelete)
+const nestedDeletePermissions = new PermissionFactory().createContextual(nestedDeleteSchema, ['editor'])
+
+test('nested delete uses a delete grant the root permission set does not carry', async () => {
+	await execute({
+		schema: nestedDeleteSchema.model,
+		permissions: nestedDeletePermissions.root,
+		nestedPermissions: nestedDeletePermissions.all,
+		query: GQL`mutation {
+        updateAuthor(
+            by: {id: "${testUuid(1)}"},
+            data: {posts: [{delete: {id: "${testUuid(2)}"}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."author" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ? and "root_"."author_id" = ?`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					// the through grant's own predicate - the root set has no delete grant, which would be `false as "allowed"`
+					sql: SQL`select "root_"."id" as "id", "root_"."locked" = ? as "allowed" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [false, testUuid(2)],
+					response: { rows: [{ id: testUuid(2), allowed: true }] },
+				},
+				{
+					sql: SQL`delete from "public"."post" where "id" in (?)`,
+					parameters: [testUuid(2)],
+					response: {},
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateAuthor: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('a through-only delete grant opens no root delete mutation', async () => {
+	await execute({
+		schema: nestedDeleteSchema.model,
+		permissions: nestedDeletePermissions.root,
+		nestedPermissions: nestedDeletePermissions.all,
+		query: GQL`mutation {
+        deletePost(by: {id: "${testUuid(2)}"}) {
+          ok
+        }
+      }`,
+		executes: [],
+		return: {
+			errors: [
+				{ message: 'Cannot query field "deletePost" on type "Mutation".' },
+			],
+		},
+	})
+})
+
+/**
+ * A cascade keeps the scope of the delete that started it. `Item` may be deleted only through a
+ * relation, so a root `deleteCategory` cascading into it stays denied - the cascade must not
+ * escalate to the nested set as it descends.
+ */
+namespace CascadeScope {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, {
+		read: ['id'],
+		delete: true,
+	})
+	export class Category {
+		title = c.stringColumn()
+	}
+
+	@c.Allow(editor, {
+		read: ['id', 'category'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		delete: true,
+	})
+	export class Item {
+		category = c.manyHasOne(Category).cascadeOnDelete()
+	}
+}
+
+const cascadeScopeSchema = createSchema(CascadeScope)
+const cascadeScopePermissions = new PermissionFactory().createContextual(cascadeScopeSchema, ['editor'])
+
+test('a cascade of a root delete stays at root scope and does not pick up a through grant', async () => {
+	await execute({
+		schema: cascadeScopeSchema.model,
+		permissions: cascadeScopePermissions.root,
+		nestedPermissions: cascadeScopePermissions.all,
+		query: GQL`mutation {
+        deleteCategory(by: {id: "${testUuid(1)}"}) {
+          ok
+          errorMessage
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" as "id", true as "allowed" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1), allowed: true }] },
+				},
+				{
+					// `false as "allowed"`: the cascade still evaluates Item at root scope, where it has no delete grant
+					sql:
+						SQL`select "root_"."id" as "id", "root_"."category_id" as "ref", false as "allowed" from "public"."item" as "root_" where "root_"."category_id" in (?)`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(2), ref: testUuid(1), allowed: false }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				deleteCategory: {
+					ok: false,
+					errorMessage: 'Execution has failed:\n'
+						+ 'unknown field: ForeignKeyConstraintViolation (Cannot delete 123e4567-e89b-12d3-a456-000000000001 row(s) of entity Category, '
+						+ 'because it is still referenced from 123e4567-e89b-12d3-a456-000000000002 row(s) of entity Item in relation category. '
+						+ 'OnDelete behaviour of this relation is set to "cascade". This is possibly caused by ACL denial.)',
+				},
+			},
+		},
+	})
+})
+
+/**
+ * Unlinking `Entry.blog` is granted only through the relation, so the update that nulls the joining
+ * column has to resolve its predicate in the nested scope.
+ */
+namespace NestedDisconnect {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['id', 'entries'],
+	})
+	export class Blog {
+		entries = c.oneHasMany(Entry, 'blog')
+	}
+
+	@c.Allow(editor, {
+		read: ['id', 'blog'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		when: { archived: { eq: true } },
+		update: ['blog'],
+	})
+	export class Entry {
+		archived = c.boolColumn().notNull()
+		blog = c.manyHasOne(Blog, 'entries')
+	}
+}
+
+const nestedDisconnectSchema = createSchema(NestedDisconnect)
+const nestedDisconnectPermissions = new PermissionFactory().createContextual(nestedDisconnectSchema, ['editor'])
+
+test('nested disconnect resolves the update predicate in the nested scope', async () => {
+	await execute({
+		schema: nestedDisconnectSchema.model,
+		permissions: nestedDisconnectPermissions.root,
+		nestedPermissions: nestedDisconnectPermissions.all,
+		query: GQL`mutation {
+        updateBlog(
+            by: {id: "${testUuid(1)}"},
+            data: {entries: [{disconnect: {id: "${testUuid(2)}"}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."blog" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."entry" as "root_" where "root_"."id" = ? and "root_"."blog_id" = ?`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					// `"root_"."archived" = ?` is the through grant's predicate; at root scope `Entry.blog` has no update grant at all
+					sql:
+						SQL`with "newData_" as (select ? :: uuid as "blog_id", "root_"."blog_id" as "blog_id_old__", "root_"."id", "root_"."archived" from "public"."entry" as "root_" where "root_"."id" = ? and "root_"."archived" = ?)
+						update "public"."entry" set "blog_id" = "newData_"."blog_id" from "newData_" where "entry"."id" = "newData_"."id" and "newData_"."archived" = ? returning "blog_id_old__"`,
+					parameters: [null, testUuid(2), true, true],
+					response: { rows: [{ blog_id_old__: testUuid(1) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateBlog: {
+					ok: true,
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/acl/throughScope.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/acl/throughScope.test.ts
@@ -1,0 +1,421 @@
+import { test } from 'bun:test'
+import { execute, failedTransaction, sqlTransaction } from '../../../../../src/test.js'
+import { c, createSchema } from '@contember/schema-definition'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * Every create relation processor resolves its target against the nested permission set, so a
+ * `through` create grant applies under a relation and nowhere else. Each positive case gives the
+ * through grant a `when` predicate: the predicate lives only in the `through` bucket, so seeing it
+ * in the insert's where clause is what proves the nested set was used.
+ */
+
+namespace ManyHasOneThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true, create: true })
+	export class Post {
+		title = c.stringColumn()
+		author = c.manyHasOne(Author)
+	}
+
+	@c.Allow(editorRole, { through: true, when: { name: { eq: 'John' } }, create: ['name'] })
+	export class Author {
+		name = c.stringColumn()
+	}
+}
+
+test('many has one: nested create resolves against the through grant', async () => {
+	const schema = createSchema(ManyHasOneThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createPost(data: {title: "Hello", author: {create: {name: "John"}}}) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "name")
+						insert into "public"."author" ("id", "name")
+						select "root_"."id", "root_"."name" from "root_" where "root_"."name" = ? returning "id"`,
+					parameters: [testUuid(2), 'John', 'John'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title", ? :: uuid as "author_id")
+						insert into "public"."post" ("id", "title", "author_id")
+						select "root_"."id", "root_"."title", "root_"."author_id" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'Hello', testUuid(2)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createPost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('a through-only create grant does not open a root mutation', async () => {
+	const schema = createSchema(ManyHasOneThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createAuthor(data: {name: "John"}) {
+          ok
+        }
+      }`,
+		executes: [],
+		return: {
+			errors: [{ message: 'Cannot query field "createAuthor" on type "Mutation".' }],
+		},
+	})
+})
+
+namespace OneHasManyThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true, create: true })
+	export class Post {
+		title = c.stringColumn()
+		locales = c.oneHasMany(PostLocale, 'post')
+	}
+
+	@c.Allow(editorRole, { through: true, when: { title: { eq: 'Ahoj svete' } }, create: ['title', 'post'] })
+	export class PostLocale {
+		title = c.stringColumn()
+		post = c.manyHasOne(Post, 'locales')
+	}
+}
+
+test('one has many: nested create resolves against the through grant', async () => {
+	const schema = createSchema(OneHasManyThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createPost(data: {title: "Hello", locales: [{create: {title: "Ahoj svete"}}]}) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title")
+						insert into "public"."post" ("id", "title")
+						select "root_"."id", "root_"."title" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'Hello'],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title", ? :: uuid as "post_id")
+						insert into "public"."post_locale" ("id", "title", "post_id")
+						select "root_"."id", "root_"."title", "root_"."post_id" from "root_" where "root_"."title" = ? returning "id"`,
+					parameters: [testUuid(2), 'Ahoj svete', testUuid(1), 'Ahoj svete'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createPost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+namespace ManyHasManyThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true, create: true, update: true })
+	export class Post {
+		title = c.stringColumn()
+		categories = c.manyHasMany(Category)
+	}
+
+	@c.Allow(editorRole, { through: true, when: { name: { eq: 'News' } }, create: ['name'] })
+	export class Category {
+		name = c.stringColumn()
+	}
+}
+
+test('many has many: nested create resolves against the through grant', async () => {
+	const schema = createSchema(ManyHasManyThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createPost(data: {title: "Hello", categories: [{create: {name: "News"}}]}) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title")
+						insert into "public"."post" ("id", "title")
+						select "root_"."id", "root_"."title" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'Hello'],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "name")
+						insert into "public"."category" ("id", "name")
+						select "root_"."id", "root_"."name" from "root_" where "root_"."name" = ? returning "id"`,
+					parameters: [testUuid(2), 'News', 'News'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`insert into "public"."post_categories" ("post_id", "category_id") values (?, ?) on conflict do nothing`,
+					parameters: [testUuid(1), testUuid(2)],
+					response: 1,
+				},
+			]),
+		],
+		return: {
+			data: {
+				createPost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+namespace OneHasOneOwningThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true, create: true })
+	export class Site {
+		name = c.stringColumn()
+		setting = c.oneHasOne(SiteSetting)
+	}
+
+	@c.Allow(editorRole, { through: true, when: { url: { eq: 'https://example.com' } }, create: ['url'] })
+	export class SiteSetting {
+		url = c.stringColumn()
+	}
+}
+
+test('one has one owning: nested create resolves against the through grant', async () => {
+	const schema = createSchema(OneHasOneOwningThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createSite(data: {name: "Example", setting: {create: {url: "https://example.com"}}}) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "url")
+						insert into "public"."site_setting" ("id", "url")
+						select "root_"."id", "root_"."url" from "root_" where "root_"."url" = ? returning "id"`,
+					parameters: [testUuid(2), 'https://example.com', 'https://example.com'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "name", ? :: uuid as "setting_id")
+						insert into "public"."site" ("id", "name", "setting_id")
+						select "root_"."id", "root_"."name", "root_"."setting_id" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'Example', testUuid(2)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createSite: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+namespace OneHasOneInverseThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true, create: true })
+	export class SiteSetting {
+		url = c.stringColumn()
+		site = c.oneHasOneInverse(Site, 'setting')
+	}
+
+	@c.Allow(editorRole, { through: true, create: ['setting'] })
+	@c.Allow(editorRole, { through: true, when: { name: { eq: 'Example' } }, create: ['name'] })
+	export class Site {
+		name = c.stringColumn()
+		setting = c.oneHasOne(SiteSetting, 'site')
+	}
+}
+
+test('one has one inverse: nested create resolves against the through grant', async () => {
+	const schema = createSchema(OneHasOneInverseThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createSiteSetting(data: {url: "https://example.com", site: {create: {name: "Example"}}}) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "url")
+						insert into "public"."site_setting" ("id", "url")
+						select "root_"."id", "root_"."url" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'https://example.com'],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "name", ? :: uuid as "setting_id")
+						insert into "public"."site" ("id", "name", "setting_id")
+						select "root_"."id", "root_"."name", "root_"."setting_id" from "root_" where "root_"."name" = ? returning "id"`,
+					parameters: [testUuid(2), 'Example', testUuid(1), 'Example'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createSiteSetting: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+/**
+ * `Author` is creatable at the root, but `secret` is granted only through a relation. The field
+ * still appears on the shared create input type, so both mutations parse - only execution differs.
+ */
+namespace RootCreateWithThroughField {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true, create: true })
+	export class Post {
+		title = c.stringColumn()
+		author = c.manyHasOne(Author)
+	}
+
+	@c.Allow(editorRole, { read: true, create: ['name'] })
+	@c.Allow(editorRole, { through: true, when: { secret: { eq: 'classified' } }, create: ['secret'] })
+	export class Author {
+		name = c.stringColumn()
+		secret = c.stringColumn()
+	}
+}
+
+test('a through-only field is denied when the entity is created at the root', async () => {
+	const schema = createSchema(RootCreateWithThroughField)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createAuthor(data: {name: "John", secret: "classified"}) {
+          ok
+          errors {
+            type
+          }
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "name", ? :: text as "secret")
+						insert into "public"."author" ("id", "name", "secret")
+						select "root_"."id", "root_"."name", "root_"."secret" from "root_" where false returning "id"`,
+					parameters: [testUuid(1), 'John', 'classified'],
+					response: { rows: [] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createAuthor: {
+					ok: false,
+					errors: [{ type: 'NotFoundOrDenied' }],
+				},
+			},
+		},
+	})
+})
+
+test('the same through-only field is writable when the entity is created through a relation', async () => {
+	const schema = createSchema(RootCreateWithThroughField)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createPost(data: {title: "Hello", author: {create: {name: "John", secret: "classified"}}}) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "name", ? :: text as "secret")
+						insert into "public"."author" ("id", "name", "secret")
+						select "root_"."id", "root_"."name", "root_"."secret" from "root_" where "root_"."secret" = ? returning "id"`,
+					parameters: [testUuid(2), 'John', 'classified', 'classified'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title", ? :: uuid as "author_id")
+						insert into "public"."post" ("id", "title", "author_id")
+						select "root_"."id", "root_"."title", "root_"."author_id" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'Hello', testUuid(2)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createPost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/acl/throughScope.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/insert/acl/throughScope.test.ts
@@ -419,3 +419,84 @@ test('the same through-only field is writable when the entity is created through
 		},
 	})
 })
+
+/**
+ * `JunctionTableManager` resolves the owning side's `update` grant for the relation field even when
+ * the row is being created, so the create path needs the same root/nested distinction as the update
+ * path. `Content.categories` is granted only through a relation.
+ */
+namespace RootCreateWithThroughJunction {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: ['id', 'contents'], create: ['contents'], update: ['contents'] })
+	export class Page {
+		contents: c.OneHasManyDefinition = c.oneHasMany(Content, 'page')
+	}
+
+	// `create` on the relation field is granted at the root, so the insert itself passes and the
+	// denial can only come from the junction write, which resolves the `update` grant.
+	@c.Allow(editorRole, { read: ['id', 'title'], create: ['title', 'page', 'categories'], update: ['title'] })
+	@c.Allow(editorRole, { through: true, update: ['categories'] })
+	export class Content {
+		title = c.stringColumn()
+		page = c.manyHasOne(Page, 'contents')
+		categories = c.manyHasMany(Category, 'contents')
+	}
+
+	@c.Allow(editorRole, { read: ['id'], update: ['contents'] })
+	export class Category {
+		contents: c.ManyHasManyInverse<Content> = c.manyHasManyInverse(Content, 'categories')
+	}
+}
+
+test('a root create denies a junction write granted only through a relation', async () => {
+	const schema = createSchema(RootCreateWithThroughJunction)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        createContent(data: {title: "Hello", categories: [{connect: {id: "${testUuid(3)}"}}]}) {
+          ok
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title", ? :: uuid as "page_id")
+						insert into "public"."content" ("id", "title", "page_id")
+						select "root_"."id", "root_"."title", "root_"."page_id" from "root_" returning "id"`,
+					parameters: [testUuid(1), 'Hello', null],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(3)],
+					response: { rows: [{ id: testUuid(3) }] },
+				},
+				{
+					sql: SQL`with "data" as (select "owning"."id" as "content_id", "inverse"."id" as "category_id", true as "selected"
+							from (values (null)) as "t"
+							inner join "public"."content" as "owning" on true
+							inner join "public"."category" as "inverse" on true
+							where false and "inverse"."id" = ?),
+						"insert" as (insert into "public"."content_categories" ("content_id", "category_id")
+							select "data"."content_id", "data"."category_id" from "data" on conflict do nothing returning true as inserted)
+						select coalesce(data.selected, false) as "selected", coalesce(insert.inserted, false) as "inserted"
+						from (values (null)) as "t" left join "data" as "data" on true left join "insert" as "insert" on true`,
+					parameters: [testUuid(3)],
+					response: { rows: [{ selected: false, inserted: false }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				createContent: {
+					ok: false,
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScope.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScope.test.ts
@@ -1,0 +1,348 @@
+import { c, createSchema } from '@contember/schema-definition'
+import { test } from 'bun:test'
+import { execute } from '../../../../../src/test.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * A single role on purpose: for one role the root and nested sets used to be identical, so a
+ * through-only grant leaked into the root set. Two roles would hide that.
+ */
+namespace ThroughRead {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: ['title', 'author'],
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		author = c.manyHasOne(Author).notNull()
+	}
+
+	@c.Allow(editorRole, {
+		read: ['name'],
+	})
+	@c.Allow(editorRole, {
+		through: true,
+		when: { disclosed: { eq: true } },
+		read: ['secret'],
+	})
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+		disclosed = c.boolColumn().notNull()
+	}
+}
+
+test('reads a through-only field over a relation', async () => {
+	const schema = createSchema(ThroughRead)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle {
+            title
+            author {
+              name
+              secret
+            }
+          }
+        }`,
+		executes: [
+			{
+				sql:
+					SQL`select "root_"."title" as "root_title", "root_"."author_id" as "root_author", "root_"."id" as "root_id" from "public"."article" as "root_"`,
+				parameters: [],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_title: 'Article A', root_author: testUuid(10) },
+					],
+				},
+			},
+			{
+				sql:
+					SQL`select "root_"."id" as "root_id", "root_"."name" as "root_name", "root_"."disclosed" = ? as "root___predicate_disclosed_eq_true", "root_"."secret" as "root_secret", "root_"."id" as "root_id" 
+from "public"."author" as "root_" where "root_"."id" in (?)`,
+				parameters: [true, testUuid(10)],
+				response: {
+					rows: [
+						{
+							root_id: testUuid(10),
+							root_name: 'John Doe',
+							root_secret: 'shh',
+							root___predicate_disclosed_eq_true: true,
+						},
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{
+						title: 'Article A',
+						author: { name: 'John Doe', secret: 'shh' },
+					},
+				],
+			},
+		},
+	})
+})
+
+test('through-only field is not readable at the root', async () => {
+	const schema = createSchema(ThroughRead)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listAuthor {
+            name
+            secret
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."name" as "root_name", "root_"."id" as "root_id" from "public"."author" as "root_"`,
+				parameters: [],
+				response: {
+					rows: [
+						{ root_id: testUuid(10), root_name: 'John Doe' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listAuthor: [
+					{ name: 'John Doe', secret: null },
+				],
+			},
+		},
+	})
+})
+
+namespace ThroughOnlyEntity {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: ['title', 'image'],
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		image = c.manyHasOne(Image).notNull()
+	}
+
+	@c.Allow(editorRole, {
+		through: true,
+		read: ['url'],
+	})
+	export class Image {
+		url = c.stringColumn().notNull()
+	}
+}
+
+test('entity with only through grants has no root queries', async () => {
+	const schema = createSchema(ThroughOnlyEntity)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listImage { url }
+          getImage(by: { id: "00000000-0000-0000-0000-000000000001" }) { url }
+          paginateImage { pageInfo { totalCount } }
+        }`,
+		executes: [],
+		return: {
+			errors: [
+				{ message: 'Cannot query field "listImage" on type "Query".' },
+				{ message: 'Cannot query field "getImage" on type "Query".' },
+				{ message: 'Cannot query field "paginateImage" on type "Query". Did you mean "paginateArticle"?' },
+			],
+		},
+	})
+})
+
+test('the same entity is readable over a relation', async () => {
+	const schema = createSchema(ThroughOnlyEntity)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle {
+            image {
+              url
+            }
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."image_id" as "root_image", "root_"."id" as "root_id" from "public"."article" as "root_"`,
+				parameters: [],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_image: testUuid(20) },
+					],
+				},
+			},
+			{
+				sql:
+					SQL`select "root_"."id" as "root_id", "root_"."url" as "root_url", "root_"."id" as "root_id" from "public"."image" as "root_" where "root_"."id" in (?)`,
+				parameters: [testUuid(20)],
+				response: {
+					rows: [
+						{ root_id: testUuid(20), root_url: 'https://example.com/a.png' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{ image: { url: 'https://example.com/a.png' } },
+				],
+			},
+		},
+	})
+})
+
+/**
+ * Neither grant is unconditional, so the primary-key predicate really is the union of the field
+ * predicates in its own scope: `published` at the root, `published or disclosed` under a relation.
+ */
+namespace RowLevelUnion {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: ['title', 'author'],
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		author = c.manyHasOne(Author).notNull()
+	}
+
+	@c.Allow(editorRole, {
+		when: { published: { eq: true } },
+		read: ['name'],
+	})
+	@c.Allow(editorRole, {
+		through: true,
+		when: { disclosed: { eq: true } },
+		read: ['secret'],
+	})
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+		published = c.boolColumn().notNull()
+		disclosed = c.boolColumn().notNull()
+	}
+}
+
+test('row-level predicate over a relation is the union of the root and through field predicates', async () => {
+	const schema = createSchema(RowLevelUnion)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle {
+            author {
+              secret
+            }
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."author_id" as "root_author", "root_"."id" as "root_id" from "public"."article" as "root_"`,
+				parameters: [],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_author: testUuid(10) },
+					],
+				},
+			},
+			{
+				sql:
+					SQL`select "root_"."id" as "root_id", "root_"."disclosed" = ? as "root___predicate_disclosed_eq_true", "root_"."secret" as "root_secret", "root_"."id" as "root_id" 
+from "public"."author" as "root_" where "root_"."id" in (?) and ("root_"."published" = ? or "root_"."disclosed" = ?)`,
+				parameters: [true, testUuid(10), true, true],
+				response: {
+					rows: [
+						{
+							root_id: testUuid(10),
+							root_secret: 'shh',
+							root___predicate_disclosed_eq_true: true,
+						},
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{ author: { secret: 'shh' } },
+				],
+			},
+		},
+	})
+})
+
+test('row-level predicate at the root is the union of the root field predicates only', async () => {
+	const schema = createSchema(RowLevelUnion)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listAuthor {
+            name
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."name" as "root_name", "root_"."id" as "root_id" from "public"."author" as "root_" where "root_"."published" = ?`,
+				parameters: [true],
+				response: {
+					rows: [
+						{ root_id: testUuid(10), root_name: 'John Doe' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listAuthor: [
+					{ name: 'John Doe' },
+				],
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScopeFilter.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScopeFilter.test.ts
@@ -226,3 +226,50 @@ where "root_author"."verified" = ? and ("root_author"."published" = ? or "root_a
 		},
 	})
 })
+
+/**
+ * `AuthorWhere` carries `secret` because the where-input, like the entity type, is shared between
+ * both scopes and filtering by it is legitimate under a relation. At the root the field is not
+ * readable, so the injected read predicate is a never-condition and the filter matches nothing -
+ * the wider input surface is fail-closed, not a way to probe a value the role cannot read.
+ */
+namespace RootFilterOnThroughOnlyField {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: ['name'] })
+	@c.Allow(editorRole, { through: true, read: ['secret'] })
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+	}
+}
+
+test('a root filter on a through-only field matches nothing', async () => {
+	const schema = createSchema(RootFilterOnThroughOnlyField)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`
+        query {
+          listAuthor(filter: {secret: {eq: "shh"}}) {
+          	name
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."name" as "root_name", "root_"."id" as "root_id" 
+from "public"."author" as "root_" where false`,
+				parameters: [],
+				response: { rows: [] },
+			},
+		],
+		return: {
+			data: {
+				listAuthor: [],
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScopeFilter.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScopeFilter.test.ts
@@ -1,0 +1,228 @@
+import { c, createSchema } from '@contember/schema-definition'
+import { test } from 'bun:test'
+import { execute } from '../../../../../src/test.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * The query starts at `Article`, but `Author` is reached over a relation inside the filter, so it
+ * is nested - the scope has to be derived per node, not decided once for the whole query.
+ */
+namespace FilterTarget {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: ['title', 'author'],
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		author = c.manyHasOne(Author).notNull()
+	}
+
+	@c.Allow(editorRole, {
+		read: ['name'],
+	})
+	@c.Allow(editorRole, {
+		through: true,
+		when: { disclosed: { eq: true } },
+		read: ['secret'],
+	})
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+		disclosed = c.boolColumn().notNull()
+	}
+}
+
+test('through-only target inside a root filter resolves at nested scope', async () => {
+	const schema = createSchema(FilterTarget)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle(filter: { author: { secret: { eq: "shh" } } }) {
+            title
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."title" as "root_title", "root_"."id" as "root_id" 
+from "public"."article" as "root_" left join "public"."author" as "root_author" on "root_"."author_id" = "root_author"."id" 
+where "root_author"."secret" = ? and "root_author"."disclosed" = ?`,
+				parameters: ['shh', true],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_title: 'Article A' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{ title: 'Article A' },
+				],
+			},
+		},
+	})
+})
+
+test('through-only target inside a not branch of a root filter resolves at nested scope', async () => {
+	const schema = createSchema(FilterTarget)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle(filter: { not: { author: { secret: { eq: "shh" } } } }) {
+            title
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."title" as "root_title", "root_"."id" as "root_id" 
+from "public"."article" as "root_" left join "public"."author" as "root_author" on "root_"."author_id" = "root_author"."id" 
+where not("root_author"."secret" = ? and "root_author"."disclosed" = ?)`,
+				parameters: ['shh', true],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_title: 'Article A' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{ title: 'Article A' },
+				],
+			},
+		},
+	})
+})
+
+test('through-only target inside or and and branches of a root filter resolves at nested scope', async () => {
+	const schema = createSchema(FilterTarget)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle(filter: {
+            or: [
+              { author: { secret: { eq: "shh" } } },
+              { and: [{ author: { secret: { eq: "psst" } } }, { title: { eq: "Article A" } }] }
+            ]
+          }) {
+            title
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."title" as "root_title", "root_"."id" as "root_id" 
+from "public"."article" as "root_" left join "public"."author" as "root_author" on "root_"."author_id" = "root_author"."id" 
+where ("root_author"."secret" = ? and "root_author"."disclosed" = ? or "root_author"."secret" = ? and "root_author"."disclosed" = ? and "root_"."title" = ?)`,
+				parameters: ['shh', true, 'psst', true, 'Article A'],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_title: 'Article A' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{ title: 'Article A' },
+				],
+			},
+		},
+	})
+})
+
+/**
+ * `Article`'s own read predicate traverses into `Author`, so the target of a predicate - not of a
+ * user filter - is the nested node here. It filters on `verified`, which no `Author` grant mentions,
+ * so the injected target predicate survives the where optimizer instead of being absorbed.
+ */
+namespace PredicateTarget {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		when: { author: { verified: { eq: true } } },
+		read: ['title', 'author'],
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		author = c.manyHasOne(Author).notNull()
+	}
+
+	@c.Allow(editorRole, {
+		when: { published: { eq: true } },
+		read: ['name'],
+	})
+	@c.Allow(editorRole, {
+		through: true,
+		when: { disclosed: { eq: true } },
+		read: ['secret'],
+	})
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+		verified = c.boolColumn().notNull()
+		published = c.boolColumn().notNull()
+		disclosed = c.boolColumn().notNull()
+	}
+}
+
+test('relation target inside a predicate resolves at nested scope', async () => {
+	const schema = createSchema(PredicateTarget)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle {
+            title
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."title" as "root_title", "root_"."id" as "root_id" 
+from "public"."article" as "root_" left join "public"."author" as "root_author" on "root_"."author_id" = "root_author"."id" 
+where "root_author"."verified" = ? and ("root_author"."published" = ? or "root_author"."disclosed" = ?)`,
+				parameters: [true, true, true],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_title: 'Article A' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{ title: 'Article A' },
+				],
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScopeNullability.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/query/acl/throughScopeNullability.test.ts
@@ -1,0 +1,127 @@
+import { c, createSchema } from '@contember/schema-definition'
+import { test } from 'bun:test'
+import { execute } from '../../../../../src/test.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * The `through` grant carries no `when`, so its predicate is plain `true` in the nested set. The
+ * column is `notNull`, and the GraphQL type is shared by both scopes - emitting it as non-null on
+ * the strength of the nested grant alone nulls the whole response at the root, where the grant
+ * does not apply.
+ */
+namespace UnconditionalThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: ['title', 'author'],
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		author = c.manyHasOne(Author).notNull()
+	}
+
+	@c.Allow(editorRole, {
+		read: ['name'],
+	})
+	@c.Allow(editorRole, {
+		through: true,
+		read: ['secret'],
+	})
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+	}
+}
+
+test('a not-null column granted only via an unconditional through is denied at the root, not nulled everywhere', async () => {
+	const schema = createSchema(UnconditionalThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listAuthor {
+            name
+            secret
+          }
+        }`,
+		executes: [
+			{
+				sql: SQL`select "root_"."name" as "root_name", "root_"."id" as "root_id" from "public"."author" as "root_"`,
+				parameters: [],
+				response: {
+					rows: [
+						{ root_id: testUuid(10), root_name: 'John Doe' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listAuthor: [
+					{ name: 'John Doe', secret: null },
+				],
+			},
+		},
+	})
+})
+
+test('the same not-null column is read over a relation', async () => {
+	const schema = createSchema(UnconditionalThrough)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		variables: {},
+		query: GQL`
+        query {
+          listArticle {
+            title
+            author {
+              name
+              secret
+            }
+          }
+        }`,
+		executes: [
+			{
+				sql:
+					SQL`select "root_"."title" as "root_title", "root_"."author_id" as "root_author", "root_"."id" as "root_id" from "public"."article" as "root_"`,
+				parameters: [],
+				response: {
+					rows: [
+						{ root_id: testUuid(1), root_title: 'Article A', root_author: testUuid(10) },
+					],
+				},
+			},
+			{
+				sql: SQL`select "root_"."id" as "root_id", "root_"."name" as "root_name", "root_"."secret" as "root_secret", "root_"."id" as "root_id" 
+from "public"."author" as "root_" where "root_"."id" in (?)`,
+				parameters: [testUuid(10)],
+				response: {
+					rows: [
+						{ root_id: testUuid(10), root_name: 'John Doe', root_secret: 'shh' },
+					],
+				},
+			},
+		],
+		return: {
+			data: {
+				listArticle: [
+					{
+						title: 'Article A',
+						author: { name: 'John Doe', secret: 'shh' },
+					},
+				],
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScope.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScope.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'bun:test'
+import { execute, sqlTransaction } from '../../../../../src/test.js'
+import { Model } from '@contember/schema'
+import { SchemaBuilder } from '@contember/schema-definition'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * `Author.name` is updatable only through a relation. The root permission set does not carry the
+ * grant at all, so this only works if the write path resolves its predicates against the nested set
+ * once it descends into `Post.author`.
+ */
+const schema = new SchemaBuilder()
+	.entity('Author', e => e.column('name', c => c.type(Model.ColumnType.String)))
+	.entity('Post', e =>
+		e.column('title', c => c.type(Model.ColumnType.String))
+			.manyHasOne('author', r => r.target('Author')))
+	.buildSchema()
+
+const rootPermissions = {
+	Post: {
+		predicates: {},
+		operations: {
+			read: { id: true },
+			update: { id: true, author: true },
+		},
+	},
+	Author: {
+		predicates: {},
+		operations: {
+			read: { id: true },
+		},
+	},
+}
+
+const nestedPermissions = {
+	Post: rootPermissions.Post,
+	Author: {
+		predicates: {},
+		operations: {
+			read: { id: true },
+			update: { id: true, name: true },
+		},
+	},
+}
+
+test('nested update uses a grant the root permission set does not carry', async () => {
+	await execute({
+		schema,
+		permissions: rootPermissions,
+		nestedPermissions,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(1)}"},
+            data: {author: {update: {name: "John"}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."author_id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ author_id: testUuid(2) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "name", "root_"."name" as "name_old__", "root_"."id"  from "public"."author" as "root_"  where "root_"."id" = ?)
+						update  "public"."author" set  "name" =  "newData_"."name"   from "newData_"  where "author"."id" = "newData_"."id"  returning "name_old__"`,
+					parameters: ['John', testUuid(2)],
+					response: { rows: [{ name_old__: 'Jack' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScopeJunction.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScopeJunction.test.ts
@@ -1,0 +1,296 @@
+import { test } from 'bun:test'
+import { execute, sqlTransaction } from '../../../../../src/test.js'
+import { c, createSchema } from '@contember/schema-definition'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * Covers junction writes where the owning entity is reached over a relation: a `through`-only grant
+ * is honoured on connect, on disconnect, and on the inverse-side predicate `JunctionTableManager`
+ * builds from `relation.inversedBy`.
+ *
+ * The mirrored root case, where the very same grants have to be denied, lives in
+ * `throughScopeRootWrites.test.ts`.
+ */
+namespace JunctionThrough {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['id', 'content'],
+	})
+	export class Article {
+		content = c.manyHasOne(Content)
+	}
+
+	@c.Allow(editor, {
+		read: ['id'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		when: { published: { eq: true } },
+		update: ['categories'],
+	})
+	export class Content {
+		published = c.boolColumn().notNull()
+		categories = c.manyHasMany(Category, 'contents')
+	}
+
+	@c.Allow(editor, {
+		read: ['id'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		when: { visible: { eq: true } },
+		update: ['contents'],
+	})
+	export class Category {
+		visible = c.boolColumn().notNull()
+		contents = c.manyHasManyInverse(Content, 'categories')
+	}
+}
+
+const junctionSchema = createSchema(JunctionThrough)
+const junctionPermissions = new PermissionFactory().createContextual(junctionSchema, ['editor'])
+
+test('nested m:n connect resolves both junction predicates in the nested scope', async () => {
+	await execute({
+		schema: junctionSchema.model,
+		permissions: junctionPermissions.root,
+		nestedPermissions: junctionPermissions.all,
+		query: GQL`mutation {
+        updateArticle(
+            by: {id: "${testUuid(1)}"},
+            data: {content: {update: {categories: [{connect: {id: "${testUuid(3)}"}}]}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."content_id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ content_id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(3)],
+					response: { rows: [{ id: testUuid(3) }] },
+				},
+				{
+					// `"owning"."published"` and `"inverse"."visible"` both come from through-only grants
+					sql: SQL`with "data" as
+            (select
+               "owning"."id" as "content_id",
+               "inverse"."id" as "category_id",
+               true as "selected"
+             from (values (null)) as "t" inner join "public"."content" as "owning" on true
+               inner join "public"."category" as "inverse" on true
+             where "owning"."published" = ? and "owning"."id" = ? and "inverse"."visible" = ? and "inverse"."id" = ?),
+                "insert" as
+              (insert into "public"."content_categories" ("content_id", "category_id")
+                select
+                  "data"."content_id",
+                  "data"."category_id"
+                from "data"
+              on conflict do nothing
+              returning true as inserted)
+            select
+              coalesce(data.selected, false) as "selected",
+              coalesce(insert.inserted, false) as "inserted"
+            from (values (null)) as "t" left join "data" as "data" on true
+              left join "insert" as "insert" on true`,
+					parameters: [true, testUuid(2), true, testUuid(3)],
+					response: { rows: [{ selected: true, inserted: true }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateArticle: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('nested m:n disconnect resolves both junction predicates in the nested scope', async () => {
+	await execute({
+		schema: junctionSchema.model,
+		permissions: junctionPermissions.root,
+		nestedPermissions: junctionPermissions.all,
+		query: GQL`mutation {
+        updateArticle(
+            by: {id: "${testUuid(1)}"},
+            data: {content: {update: {categories: [{disconnect: {id: "${testUuid(3)}"}}]}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."content_id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ content_id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(3)],
+					response: { rows: [{ id: testUuid(3) }] },
+				},
+				{
+					// same pair of through-only predicates guards the junction delete
+					sql: SQL`with "data" as
+            (select
+               "owning"."id" as "content_id",
+               "inverse"."id" as "category_id",
+               true as "selected"
+             from (values (null)) as "t" inner join "public"."content" as "owning" on true
+               inner join "public"."category" as "inverse" on true
+             where "owning"."published" = ? and "owning"."id" = ? and "inverse"."visible" = ? and "inverse"."id" = ?),
+                "delete" as
+              (delete from "public"."content_categories"
+              using "data" as "data"
+              where "content_categories"."content_id" = "data"."content_id" and "content_categories"."category_id" = "data"."category_id"
+              returning true as deleted)
+            select
+              coalesce(data.selected, false) as "selected",
+              coalesce(delete.deleted, false) as "deleted"
+            from (values (null)) as "t" left join "data" as "data" on true
+              left join "delete" as "delete" on true`,
+					parameters: [true, testUuid(2), true, testUuid(3)],
+					response: { rows: [{ selected: true, deleted: true }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateArticle: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+/**
+ * Here only the inverse side is through-only, so the junction SQL isolates the second predicate
+ * `JunctionTableManager` builds from `relation.inversedBy`.
+ */
+namespace JunctionInverseThrough {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['id', 'page'],
+	})
+	export class Site {
+		page = c.manyHasOne(Page)
+	}
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['id', 'tags'],
+	})
+	export class Page {
+		tags = c.manyHasMany(Tag, 'pages')
+	}
+
+	@c.Allow(editor, {
+		read: ['id'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		when: { approved: { eq: true } },
+		update: ['pages'],
+	})
+	export class Tag {
+		approved = c.boolColumn().notNull()
+		pages = c.manyHasManyInverse(Page, 'tags')
+	}
+}
+
+const inverseSchema = createSchema(JunctionInverseThrough)
+const inversePermissions = new PermissionFactory().createContextual(inverseSchema, ['editor'])
+
+test('the inverse side of a junction write uses the inverse entity through grant', async () => {
+	await execute({
+		schema: inverseSchema.model,
+		permissions: inversePermissions.root,
+		nestedPermissions: inversePermissions.all,
+		query: GQL`mutation {
+        updateSite(
+            by: {id: "${testUuid(1)}"},
+            data: {page: {update: {tags: [{connect: {id: "${testUuid(3)}"}}]}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."site" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."page_id" from "public"."site" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ page_id: testUuid(2) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."tag" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(3)],
+					response: { rows: [{ id: testUuid(3) }] },
+				},
+				{
+					// the owning side contributes no predicate, so `"inverse"."approved"` is the only ACL condition
+					sql: SQL`with "data" as
+            (select
+               "owning"."id" as "page_id",
+               "inverse"."id" as "tag_id",
+               true as "selected"
+             from (values (null)) as "t" inner join "public"."page" as "owning" on true
+               inner join "public"."tag" as "inverse" on true
+             where "owning"."id" = ? and "inverse"."approved" = ? and "inverse"."id" = ?),
+                "insert" as
+              (insert into "public"."page_tags" ("page_id", "tag_id")
+                select
+                  "data"."page_id",
+                  "data"."tag_id"
+                from "data"
+              on conflict do nothing
+              returning true as inserted)
+            select
+              coalesce(data.selected, false) as "selected",
+              coalesce(insert.inserted, false) as "inserted"
+            from (values (null)) as "t" left join "data" as "data" on true
+              left join "insert" as "insert" on true`,
+					parameters: [testUuid(2), true, testUuid(3)],
+					response: { rows: [{ selected: true, inserted: true }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateSite: {
+					ok: true,
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScopeRootWrites.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScopeRootWrites.test.ts
@@ -1,0 +1,437 @@
+import { test } from 'bun:test'
+import { execute, failedTransaction, sqlTransaction } from '../../../../../src/test.js'
+import { c, createSchema } from '@contember/schema-definition'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * The mirror of the nested junction and relation tests: the same grants, reached at the mutation
+ * root, have to be denied. Every pair below shares one fixture, so the only thing that differs
+ * between the denied case and its control is where the entity sits.
+ */
+namespace RootThrough {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['id', 'content', 'post'],
+	})
+	export class Article {
+		content = c.manyHasOne(Content)
+		post = c.manyHasOne(Post)
+	}
+
+	@c.Allow(editor, {
+		read: ['id', 'title'],
+		update: ['title'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		update: ['categories'],
+	})
+	export class Content {
+		title = c.stringColumn()
+		categories = c.manyHasMany(Category, 'contents')
+	}
+
+	@c.Allow(editor, {
+		read: ['id'],
+		update: ['contents'],
+	})
+	export class Category {
+		contents = c.manyHasManyInverse(Content, 'categories')
+	}
+
+	@c.Allow(editor, {
+		read: ['id', 'title'],
+		update: ['title'],
+	})
+	@c.Allow(editor, {
+		through: true,
+		update: ['locales'],
+	})
+	export class Post {
+		title = c.stringColumn()
+		locales = c.oneHasMany(PostLocale, 'post')
+	}
+
+	@c.Allow(editor, {
+		read: ['id', 'title', 'post'],
+		update: ['title', 'post'],
+	})
+	export class PostLocale {
+		title = c.stringColumn()
+		post = c.manyHasOne(Post, 'locales')
+	}
+}
+
+const schema = createSchema(RootThrough)
+const permissions = new PermissionFactory().createContextual(schema, ['editor'])
+
+const contentId = testUuid(1)
+const categoryId = testUuid(2)
+const postId = testUuid(3)
+const localeId = testUuid(4)
+const articleId = testUuid(10)
+
+test('root m:n connect is denied when the owning grant is through-only', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updateContent(
+            by: {id: "${contentId}"},
+            data: {categories: [{connect: {id: "${categoryId}"}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."content" as "root_" where "root_"."id" = ?`,
+					parameters: [contentId],
+					response: { rows: [{ id: contentId }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [categoryId],
+					response: { rows: [{ id: categoryId }] },
+				},
+				{
+					// `false` is the owning predicate resolved at the root: the only grant for `categories` is through-only
+					sql: SQL`with "data" as
+            (select
+               "owning"."id" as "content_id",
+               "inverse"."id" as "category_id",
+               true as "selected"
+             from (values (null)) as "t" inner join "public"."content" as "owning" on true
+               inner join "public"."category" as "inverse" on true
+             where false and "inverse"."id" = ?),
+                "insert" as
+              (insert into "public"."content_categories" ("content_id", "category_id")
+                select
+                  "data"."content_id",
+                  "data"."category_id"
+                from "data"
+              on conflict do nothing
+              returning true as inserted)
+            select
+              coalesce(data.selected, false) as "selected",
+              coalesce(insert.inserted, false) as "inserted"
+            from (values (null)) as "t" left join "data" as "data" on true
+              left join "insert" as "insert" on true`,
+					parameters: [categoryId],
+					response: { rows: [{ selected: false, inserted: false }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateContent: {
+					ok: false,
+				},
+			},
+		},
+	})
+})
+
+test('the same m:n connect reached over a relation is allowed', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updateArticle(
+            by: {id: "${articleId}"},
+            data: {content: {update: {categories: [{connect: {id: "${categoryId}"}}]}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [articleId],
+					response: { rows: [{ id: articleId }] },
+				},
+				{
+					sql: SQL`select "root_"."content_id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [articleId],
+					response: { rows: [{ content_id: contentId }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [categoryId],
+					response: { rows: [{ id: categoryId }] },
+				},
+				{
+					// nested, so the through grant applies: both sides carry no predicate and the plain insert is used
+					sql: SQL`insert into "public"."content_categories" ("content_id", "category_id")
+              values (?, ?)
+              on conflict do nothing`,
+					parameters: [contentId, categoryId],
+					response: { rowCount: 1 },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateArticle: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('root m:n disconnect is denied when the owning grant is through-only', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updateContent(
+            by: {id: "${contentId}"},
+            data: {categories: [{disconnect: {id: "${categoryId}"}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."content" as "root_" where "root_"."id" = ?`,
+					parameters: [contentId],
+					response: { rows: [{ id: contentId }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [categoryId],
+					response: { rows: [{ id: categoryId }] },
+				},
+				{
+					// same owning predicate, so the junction delete is guarded by `false` instead of running unconditionally
+					sql: SQL`with "data" as
+            (select
+               "owning"."id" as "content_id",
+               "inverse"."id" as "category_id",
+               true as "selected"
+             from (values (null)) as "t" inner join "public"."content" as "owning" on true
+               inner join "public"."category" as "inverse" on true
+             where false and "inverse"."id" = ?),
+                "delete" as
+              (delete from "public"."content_categories"
+              using "data" as "data"
+              where "content_categories"."content_id" = "data"."content_id" and "content_categories"."category_id" = "data"."category_id"
+              returning true as deleted)
+            select
+              coalesce(data.selected, false) as "selected",
+              coalesce(delete.deleted, false) as "deleted"
+            from (values (null)) as "t" left join "data" as "data" on true
+              left join "delete" as "delete" on true`,
+					parameters: [categoryId],
+					response: { rows: [{ selected: false, deleted: false }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateContent: {
+					ok: false,
+				},
+			},
+		},
+	})
+})
+
+test('the same m:n disconnect reached over a relation is allowed', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updateArticle(
+            by: {id: "${articleId}"},
+            data: {content: {update: {categories: [{disconnect: {id: "${categoryId}"}}]}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [articleId],
+					response: { rows: [{ id: articleId }] },
+				},
+				{
+					sql: SQL`select "root_"."content_id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [articleId],
+					response: { rows: [{ content_id: contentId }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."category" as "root_" where "root_"."id" = ?`,
+					parameters: [categoryId],
+					response: { rows: [{ id: categoryId }] },
+				},
+				{
+					// nested again: no predicate on either side, so the plain delete is used
+					sql: SQL`delete from "public"."content_categories"
+              where "content_id" = ? and "category_id" = ?`,
+					parameters: [contentId, categoryId],
+					response: { rowCount: 1 },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateArticle: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('root 1:N nested update is denied when the relation grant is through-only', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${postId}"},
+            data: {locales: [{update: {by: {id: "${localeId}"}, data: {title: "Hello"}}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [postId],
+					response: { rows: [{ id: postId }] },
+				},
+				{
+					// nothing else checks `locales` at the root, so the update predicate is verified on its own - and it is `false`
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where false`,
+					parameters: [],
+					response: { rows: [] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: false,
+				},
+			},
+		},
+	})
+})
+
+test('the same 1:N nested update reached over a relation is allowed', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updateArticle(
+            by: {id: "${articleId}"},
+            data: {post: {update: {locales: [{update: {by: {id: "${localeId}"}, data: {title: "Hello"}}}]}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [articleId],
+					response: { rows: [{ id: articleId }] },
+				},
+				{
+					sql: SQL`select "root_"."post_id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [articleId],
+					response: { rows: [{ post_id: postId }] },
+				},
+				{
+					// no `false` anywhere: nested, so the through grant covers `locales` and the locale update goes ahead
+					sql: SQL`select "root_"."id" from "public"."post_locale" as "root_" where "root_"."id" = ? and "root_"."post_id" = ?`,
+					parameters: [localeId, postId],
+					response: { rows: [{ id: localeId }] },
+				},
+				{
+					sql: SQL`with "newData_" as
+            (select ? :: text as "title", "root_"."title" as "title_old__", "root_"."id", "root_"."post_id"
+             from "public"."post_locale" as "root_"
+             where "root_"."id" = ?)
+            update "public"."post_locale"
+            set "title" = "newData_"."title"
+            from "newData_"
+            where "post_locale"."id" = "newData_"."id"
+            returning "title_old__"`,
+					parameters: ['Hello', localeId],
+					response: { rows: [{ title_old__: 'Old' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateArticle: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('an ordinary root update with column data pays no extra query', async () => {
+	await execute({
+		schema: schema.model,
+		permissions: permissions.root,
+		nestedPermissions: permissions.all,
+		query: GQL`mutation {
+        updateContent(
+            by: {id: "${contentId}"},
+            data: {title: "Hello"}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."content" as "root_" where "root_"."id" = ?`,
+					parameters: [contentId],
+					response: { rows: [{ id: contentId }] },
+				},
+				{
+					sql: SQL`with "newData_" as
+            (select ? :: text as "title", "root_"."title" as "title_old__", "root_"."id"
+             from "public"."content" as "root_"
+             where "root_"."id" = ?)
+            update "public"."content"
+            set "title" = "newData_"."title"
+            from "newData_"
+            where "content"."id" = "newData_"."id"
+            returning "title_old__"`,
+					parameters: ['Hello', contentId],
+					response: { rows: [{ title_old__: 'Old' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateContent: {
+					ok: true,
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScopeUpdate.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/update/acl/throughScopeUpdate.test.ts
@@ -1,0 +1,415 @@
+import { test } from 'bun:test'
+import { execute, failedTransaction, sqlTransaction } from '../../../../../src/test.js'
+import { c, createSchema } from '@contember/schema-definition'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * `PostLocale` may be updated only through `Post.locales`, and only where the locale is `cs`. The
+ * predicate is what makes the SQL below distinguishable from a root grant.
+ */
+namespace ThroughOneHasMany {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id'], update: ['id', 'locales'] })
+	export class Post {
+		locales = c.oneHasMany(PostLocale, 'post')
+	}
+
+	@c.Allow(editor, { read: ['id', 'post'] })
+	@c.Allow(editor, { through: true, when: { locale: { eq: 'cs' } }, update: ['title', 'post'] })
+	export class PostLocale {
+		title = c.stringColumn()
+		locale = c.stringColumn()
+		post = c.manyHasOne(Post, 'locales').notNull()
+	}
+}
+
+test('oneHasMany update uses the through grant', async () => {
+	const schema = createSchema(ThroughOneHasMany)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(1)}"},
+            data: {locales: [{update: {by: {id: "${testUuid(2)}"}, data: {title: "Hello"}}}]}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."post_locale" as "root_" where "root_"."id" = ? and "root_"."post_id" = ?`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "title", "root_"."title" as "title_old__", "root_"."id", "root_"."locale", "root_"."post_id"  from "public"."post_locale" as "root_"  where "root_"."id" = ? and "root_"."locale" = ?)
+						update  "public"."post_locale" set  "title" =  "newData_"."title"   from "newData_"  where "post_locale"."id" = "newData_"."id" and "newData_"."locale" = ?  returning "title_old__"`,
+					parameters: ['Hello', testUuid(2), 'cs', 'cs'],
+					response: { rows: [{ title_old__: 'Hi' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+namespace ThroughOneHasOneOwning {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id'], update: ['id', 'image'] })
+	export class Article {
+		image = c.oneHasOne(Image)
+	}
+
+	@c.Allow(editor, { read: ['id'] })
+	@c.Allow(editor, { through: true, when: { published: { eq: true } }, update: ['url'] })
+	export class Image {
+		url = c.stringColumn()
+		published = c.boolColumn()
+	}
+}
+
+test('oneHasOne owning update uses the through grant', async () => {
+	const schema = createSchema(ThroughOneHasOneOwning)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        updateArticle(
+            by: {id: "${testUuid(1)}"},
+            data: {image: {update: {url: "https://example.com/a.png"}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."image_id" from "public"."article" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ image_id: testUuid(2) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "url", "root_"."url" as "url_old__", "root_"."id", "root_"."published"  from "public"."image" as "root_"  where "root_"."id" = ? and "root_"."published" = ?)
+						update  "public"."image" set  "url" =  "newData_"."url"   from "newData_"  where "image"."id" = "newData_"."id" and "newData_"."published" = ?  returning "url_old__"`,
+					parameters: ['https://example.com/a.png', testUuid(2), true, true],
+					response: { rows: [{ url_old__: 'https://example.com/old.png' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateArticle: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+namespace ThroughOneHasOneInverse {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id'], update: ['id', 'contact'] })
+	export class Person {
+		contact = c.oneHasOneInverse(Contact, 'person')
+	}
+
+	@c.Allow(editor, { read: ['id', 'person'] })
+	@c.Allow(editor, { through: true, when: { verified: { eq: true } }, update: ['email', 'person'] })
+	export class Contact {
+		email = c.stringColumn()
+		verified = c.boolColumn()
+		person = c.oneHasOne(Person, 'contact')
+	}
+}
+
+test('oneHasOne inverse update uses the through grant', async () => {
+	const schema = createSchema(ThroughOneHasOneInverse)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        updatePerson(
+            by: {id: "${testUuid(1)}"},
+            data: {contact: {update: {email: "john@example.com"}}}
+          ) {
+          ok
+        }
+      }`,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."person" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."contact" as "root_" where "root_"."person_id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "email", "root_"."email" as "email_old__", "root_"."id", "root_"."verified", "root_"."person_id"  from "public"."contact" as "root_"  where "root_"."id" = ? and "root_"."verified" = ?)
+						update  "public"."contact" set  "email" =  "newData_"."email"   from "newData_"  where "contact"."id" = "newData_"."id" and "newData_"."verified" = ?  returning "email_old__"`,
+					parameters: ['john@example.com', testUuid(2), true, true],
+					response: { rows: [{ email_old__: 'old@example.com' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePerson: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+/** Both branches of a relation `upsert` are separate plumbing from the root `upsert` mutation. */
+namespace ThroughRelationUpsert {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id'], update: ['id', 'locales'] })
+	export class Post {
+		locales = c.oneHasMany(PostLocale, 'post')
+	}
+
+	@c.Allow(editor, { read: ['id', 'post'] })
+	@c.Allow(editor, {
+		through: true,
+		when: { locale: { eq: 'cs' } },
+		update: ['title', 'post'],
+		create: ['title', 'locale', 'post'],
+	})
+	export class PostLocale {
+		title = c.stringColumn()
+		locale = c.stringColumn()
+		post = c.manyHasOne(Post, 'locales').notNull()
+	}
+}
+
+const relationUpsertQuery = GQL`mutation {
+        updatePost(
+            by: {id: "${testUuid(1)}"},
+            data: {locales: [{upsert: {
+              by: {id: "${testUuid(2)}"},
+              update: {title: "Hello"},
+              create: {title: "World", locale: "cs"}
+            }}]}
+          ) {
+          ok
+        }
+      }`
+
+test('relation upsert - update branch uses the through grant', async () => {
+	const schema = createSchema(ThroughRelationUpsert)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: relationUpsertQuery,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."post_locale" as "root_" where "root_"."id" = ? and "root_"."post_id" = ?`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "title", "root_"."title" as "title_old__", "root_"."id", "root_"."locale", "root_"."post_id"  from "public"."post_locale" as "root_"  where "root_"."id" = ? and "root_"."locale" = ?)
+						update  "public"."post_locale" set  "title" =  "newData_"."title"   from "newData_"  where "post_locale"."id" = "newData_"."id" and "newData_"."locale" = ?  returning "title_old__"`,
+					parameters: ['Hello', testUuid(2), 'cs', 'cs'],
+					response: { rows: [{ title_old__: 'Hi' }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+test('relation upsert - create branch uses the through grant', async () => {
+	const schema = createSchema(ThroughRelationUpsert)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: relationUpsertQuery,
+		executes: [
+			...sqlTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."post" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql: SQL`select "root_"."id" from "public"."post_locale" as "root_" where "root_"."id" = ? and "root_"."post_id" = ?`,
+					parameters: [testUuid(2), testUuid(1)],
+					response: { rows: [] },
+				},
+				{
+					sql: SQL`with "root_" as (select ? :: uuid as "id", ? :: text as "title", ? :: text as "locale", ? :: uuid as "post_id")
+						insert into "public"."post_locale" ("id", "title", "locale", "post_id")
+						select "root_"."id", "root_"."title", "root_"."locale", "root_"."post_id"  from "root_"  where "root_"."locale" = ?  returning "id"`,
+					parameters: [testUuid(1), 'World', 'cs', testUuid(1), 'cs'],
+					response: { rows: [{ id: testUuid(3) }] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updatePost: {
+					ok: true,
+				},
+			},
+		},
+	})
+})
+
+/** `Image` is updatable only through `Article.image`; the root mutation must not exist. */
+namespace ThroughOnlyRootMutation {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id'], update: ['id', 'image'] })
+	export class Article {
+		image = c.oneHasOne(Image)
+	}
+
+	@c.Allow(editor, { read: ['id'] })
+	@c.Allow(editor, { through: true, update: ['url'] })
+	export class Image {
+		url = c.stringColumn()
+	}
+}
+
+test('through-only update grant opens no root update mutation', async () => {
+	const schema = createSchema(ThroughOnlyRootMutation)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	// `updateArticle` is in the same document on purpose - only `updateImage` may be reported missing.
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        a: updateArticle(by: {id: "${testUuid(1)}"}, data: {image: {update: {url: "https://example.com/a.png"}}}) {
+          ok
+        }
+        b: updateImage(by: {id: "${testUuid(2)}"}, data: {url: "https://example.com/a.png"}) {
+          ok
+        }
+      }`,
+		executes: [],
+		return: {
+			errors: [{ message: 'Cannot query field "updateImage" on type "Mutation".' }],
+		},
+	})
+})
+
+/** `secret` is on the shared update type - types come from the nested set - but the root scope denies it. */
+namespace MixedRootAndThroughUpdate {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id', 'name'], update: ['id', 'name'] })
+	@c.Allow(editor, { through: true, update: ['secret'] })
+	export class Author {
+		name = c.stringColumn()
+		secret = c.stringColumn()
+	}
+}
+
+test('root update denies a field granted only through a relation', async () => {
+	const schema = createSchema(MixedRootAndThroughUpdate)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        updateAuthor(
+            by: {id: "${testUuid(1)}"},
+            data: {secret: "hidden"}
+          ) {
+          ok
+          errors {
+            type
+          }
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."author" as "root_" where "root_"."id" = ?`,
+					parameters: [testUuid(1)],
+					response: { rows: [{ id: testUuid(1) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "secret", "root_"."secret" as "secret_old__", "root_"."id", "root_"."name"  from "public"."author" as "root_"  where false)
+						update  "public"."author" set  "secret" =  "newData_"."secret"   from "newData_"  where "author"."id" = "newData_"."id" and false  returning "secret_old__"`,
+					parameters: ['hidden'],
+					response: { rows: [] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				updateAuthor: {
+					ok: false,
+					errors: [{ type: 'NotFoundOrDenied' }],
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlRequests/upsert/acl/throughScope.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlRequests/upsert/acl/throughScope.test.ts
@@ -1,0 +1,134 @@
+import { test } from 'bun:test'
+import { execute, failedTransaction } from '../../../../../src/test.js'
+import { c, createSchema } from '@contember/schema-definition'
+import { PermissionFactory } from '../../../../../../src/index.js'
+import { GQL, SQL } from '../../../../../src/tags.js'
+import { testUuid } from '../../../../../src/testUuid.js'
+
+/**
+ * `upsert` is a root entry point for both update and create, so a `through` grant on either half
+ * must not open it. `Article` misses the root create, `Tag` misses the root update.
+ */
+namespace UpsertRootGating {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id', 'title'], update: ['title'] })
+	@c.Allow(editor, { through: true, create: ['title'] })
+	export class Article {
+		title = c.stringColumn()
+	}
+
+	@c.Allow(editor, { read: ['id', 'name'], create: ['name'] })
+	@c.Allow(editor, { through: true, update: ['name'] })
+	export class Tag {
+		name = c.stringColumn()
+	}
+}
+
+test('through-only create grant opens no root upsert mutation', async () => {
+	const schema = createSchema(UpsertRootGating)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	// `updateArticle` is in the same document on purpose - only `upsertArticle` may be reported missing.
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        a: updateArticle(by: {id: "${testUuid(1)}"}, data: {title: "Hello"}) {
+          ok
+        }
+        b: upsertArticle(by: {id: "${testUuid(1)}"}, update: {title: "Hello"}, create: {title: "Hello"}) {
+          ok
+        }
+      }`,
+		executes: [],
+		return: {
+			errors: [{ message: 'Cannot query field "upsertArticle" on type "Mutation". Did you mean "updateArticle"?' }],
+		},
+	})
+})
+
+test('through-only update grant opens no root upsert mutation', async () => {
+	const schema = createSchema(UpsertRootGating)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	// `createTag` is in the same document on purpose - only `upsertTag` may be reported missing.
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        a: createTag(data: {name: "Hello"}) {
+          ok
+        }
+        b: upsertTag(by: {id: "${testUuid(1)}"}, update: {name: "Hello"}, create: {name: "Hello"}) {
+          ok
+        }
+      }`,
+		executes: [],
+		return: {
+			errors: [{ message: 'Cannot query field "upsertTag" on type "Mutation".' }],
+		},
+	})
+})
+
+/** The root `upsert` exists, but its update branch still runs in the root scope. */
+namespace UpsertRootScope {
+	export const editor = c.createRole('editor')
+
+	@c.Allow(editor, { read: ['id', 'slug', 'name'], create: ['slug', 'name'], update: ['name'] })
+	@c.Allow(editor, { through: true, update: ['secret'] })
+	export class Author {
+		name = c.stringColumn()
+		secret = c.stringColumn()
+		slug = c.stringColumn().unique()
+	}
+}
+
+test('root upsert denies a field granted only through a relation', async () => {
+	const schema = createSchema(UpsertRootScope)
+	const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+	await execute({
+		schema: schema.model,
+		permissions: root,
+		nestedPermissions: all,
+		query: GQL`mutation {
+        upsertAuthor(
+            by: {slug: "john"},
+            update: {secret: "hidden"},
+            create: {slug: "john", name: "John"}
+          ) {
+          ok
+          errors {
+            type
+          }
+        }
+      }`,
+		executes: [
+			...failedTransaction([
+				{
+					sql: SQL`select "root_"."id" from "public"."author" as "root_" where "root_"."slug" = ?`,
+					parameters: ['john'],
+					response: { rows: [{ id: testUuid(2) }] },
+				},
+				{
+					sql:
+						SQL`with "newData_" as (select ? :: text as "secret", "root_"."secret" as "secret_old__", "root_"."id", "root_"."name", "root_"."slug"  from "public"."author" as "root_"  where false)
+						update  "public"."author" set  "secret" =  "newData_"."secret"   from "newData_"  where "author"."id" = "newData_"."id" and false  returning "secret_old__"`,
+					parameters: ['hidden'],
+					response: { rows: [] },
+				},
+			]),
+		],
+		return: {
+			data: {
+				upsertAuthor: {
+					ok: false,
+					errors: [{ type: 'NotFoundOrDenied' }],
+				},
+			},
+		},
+	})
+})

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/graphQlSchemaBuilder.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/graphQlSchemaBuilder.test.ts
@@ -409,6 +409,18 @@ describe('GraphQL schema builder', () => {
 		})
 	})
 
+	it('not null columns with root and through grants', async () => {
+		const schema = createSchema(NotNullRootAndThrough)
+		const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+		await testSchema({
+			schema: () => schema.model,
+			permissions: () => all,
+			rootPermissions: () => root,
+			graphQlSchemaFile: 'schema-not-null-through.gql',
+		})
+	})
+
 	it('array', async () => {
 		const schema = createSchema({
 			Foo: class Foo {
@@ -454,6 +466,39 @@ namespace MixedRootAndThrough {
 	export class Author {
 		name = c.stringColumn()
 		secret = c.stringColumn()
+	}
+}
+
+/**
+ * Every column is `notNull`, so this pins down which of them may stay non-null. The type is shared
+ * by the root and the nested scope, so only a column the root scope always fills qualifies - unless
+ * the entity is unreachable at the root, in which case the root scope constrains nothing.
+ */
+namespace NotNullRootAndThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: true,
+	})
+	export class Article {
+		title = c.stringColumn().notNull()
+		author = c.manyHasOne(Author).notNull()
+		image = c.manyHasOne(Image).notNull()
+	}
+
+	@c.Allow(editorRole, { read: ['name'] })
+	@c.Allow(editorRole, { through: true, read: ['secret'] })
+	@c.Allow(editorRole, { through: true, when: { disclosed: { eq: true } }, read: ['classified'] })
+	export class Author {
+		name = c.stringColumn().notNull()
+		secret = c.stringColumn().notNull()
+		classified = c.stringColumn().notNull()
+		disclosed = c.boolColumn().notNull()
+	}
+
+	@c.Allow(editorRole, { through: true, read: ['url'] })
+	export class Image {
+		url = c.stringColumn().notNull()
 	}
 }
 

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/graphQlSchemaBuilder.test.ts
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/graphQlSchemaBuilder.test.ts
@@ -11,7 +11,10 @@ import { fileURLToPath } from 'node:url'
 
 interface Test {
 	schema: (builder: SchemaBuilder) => SchemaBuilder | Model.Schema
+	/** Shapes the types - pass the nested set, the one that includes `through` grants. */
 	permissions: (schema: Model.Schema) => Acl.Permissions
+	/** Gates the root query and mutation fields. Defaults to `permissions` when the two coincide. */
+	rootPermissions?: (schema: Model.Schema) => Acl.Permissions
 	graphQlSchemaFile: string
 }
 
@@ -22,8 +25,10 @@ const testSchema = async (test: Test) => {
 	const schema = schemaResult instanceof SchemaBuilder ? schemaResult.buildSchema() : schemaResult
 	const schemaWithAcl = { ...schema, acl: { roles: {}, variables: {} } }
 	const permissions = test.permissions(schemaWithAcl)
+	const rootPermissions = test.rootPermissions ? test.rootPermissions(schemaWithAcl) : permissions
 	const authorizator = new Authorizator(permissions, false, false)
-	const graphQlSchemaBuilder = schemaFactory.create(schemaWithAcl, authorizator)
+	const rootAuthorizator = new Authorizator(rootPermissions, false, false)
+	const graphQlSchemaBuilder = schemaFactory.create(schemaWithAcl, authorizator, rootAuthorizator)
 	const graphQlSchema = graphQlSchemaBuilder.build()
 
 	const result = await graphql({
@@ -382,14 +387,25 @@ describe('GraphQL schema builder', () => {
 
 	it('no root ops', async () => {
 		const schema = createSchema(NoRootOperation)
+		const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
 
 		await testSchema({
 			schema: () => schema.model,
-			permissions: () => {
-				const factory = new PermissionFactory()
-				return factory.create(schema, ['editor'])
-			},
+			permissions: () => all,
+			rootPermissions: () => root,
 			graphQlSchemaFile: 'schema-no-root-ops.gql',
+		})
+	})
+
+	it('root and through grants on the same entity', async () => {
+		const schema = createSchema(MixedRootAndThrough)
+		const { root, all } = new PermissionFactory().createContextual(schema, ['editor'])
+
+		await testSchema({
+			schema: () => schema.model,
+			permissions: () => all,
+			rootPermissions: () => root,
+			graphQlSchemaFile: 'schema-mixed-root-through.gql',
 		})
 	})
 
@@ -414,6 +430,30 @@ namespace ViewEntity {
 	@def.View("SELECT null as id, 'John' AS name")
 	export class Author {
 		name = def.stringColumn()
+	}
+}
+
+/**
+ * `title` is readable at the root, `secret` only through a relation. Both belong to the same role,
+ * entity and operation - a combination the ACL factory used to reject outright.
+ */
+namespace MixedRootAndThrough {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, {
+		read: true,
+		update: true,
+	})
+	export class Article {
+		title = c.stringColumn()
+		author = c.manyHasOne(Author)
+	}
+
+	@c.Allow(editorRole, { read: ['name'] })
+	@c.Allow(editorRole, { through: true, read: ['secret'], update: ['secret'] })
+	export class Author {
+		name = c.stringColumn()
+		secret = c.stringColumn()
 	}
 }
 

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-mixed-root-through.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-mixed-root-through.gql
@@ -1,0 +1,264 @@
+type Query {
+  getArticle(by: ArticleUniqueWhere!, filter: ArticleWhere): Article
+  listArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], offset: Int, limit: Int): [Article!]!
+  paginateArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], skip: Int, first: Int): ArticleConnection!
+  validateUpdateArticle(by: ArticleUniqueWhere!, data: ArticleUpdateInput!): _ValidationResult!
+  getAuthor(by: AuthorUniqueWhere!, filter: AuthorWhere): Author
+  listAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], offset: Int, limit: Int): [Author!]!
+  paginateAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], skip: Int, first: Int): AuthorConnection!
+  validateUpdateAuthor(by: AuthorUniqueWhere!, data: AuthorUpdateInput!): _ValidationResult!
+  transaction: QueryTransaction
+  _info: Info
+}
+
+type Article {
+  _meta: ArticleMeta
+  id: UUID!
+  title: String
+  author(filter: AuthorWhere): Author
+}
+
+type ArticleMeta {
+  id: FieldMeta
+  title: FieldMeta
+  author: FieldMeta
+}
+
+type FieldMeta {
+  readable: Boolean
+  updatable: Boolean
+}
+
+scalar UUID
+
+type Author {
+  _meta: AuthorMeta
+  id: UUID!
+  name: String
+  secret: String
+}
+
+type AuthorMeta {
+  id: FieldMeta
+  name: FieldMeta
+  secret: FieldMeta
+}
+
+input AuthorWhere {
+  id: UUIDCondition
+  name: StringCondition
+  secret: StringCondition
+  and: [AuthorWhere]
+  or: [AuthorWhere]
+  not: AuthorWhere
+}
+
+input UUIDCondition {
+  and: [UUIDCondition!]
+  or: [UUIDCondition!]
+  not: UUIDCondition
+  null: Boolean
+  isNull: Boolean
+  eq: UUID
+  notEq: UUID
+  in: [UUID!]
+  notIn: [UUID!]
+  lt: UUID
+  lte: UUID
+  gt: UUID
+  gte: UUID
+}
+
+input StringCondition {
+  and: [StringCondition!]
+  or: [StringCondition!]
+  not: StringCondition
+  null: Boolean
+  isNull: Boolean
+  eq: String
+  notEq: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  containsCI: String
+  startsWithCI: String
+  endsWithCI: String
+  similar: String
+  wordSimilar: String
+}
+
+input ArticleUniqueWhere {
+  id: UUID
+}
+
+input ArticleWhere {
+  id: UUIDCondition
+  title: StringCondition
+  author: AuthorWhere
+  and: [ArticleWhere]
+  or: [ArticleWhere]
+  not: ArticleWhere
+}
+
+input ArticleOrderBy {
+  _random: Boolean
+  _randomSeeded: Int
+  id: OrderDirection
+  title: OrderDirection
+  author: AuthorOrderBy
+}
+
+enum OrderDirection {
+  asc
+  desc
+  ascNullsFirst
+  descNullsLast
+}
+
+input AuthorOrderBy {
+  _random: Boolean
+  _randomSeeded: Int
+  id: OrderDirection
+  name: OrderDirection
+  secret: OrderDirection
+}
+
+type ArticleConnection {
+  pageInfo: PageInfo!
+  edges: [ArticleEdge!]!
+}
+
+type PageInfo {
+  totalCount: Int!
+}
+
+type ArticleEdge {
+  node: Article!
+}
+
+type _ValidationResult {
+  valid: Boolean!
+  errors: [_ValidationError!]!
+}
+
+type _ValidationError {
+  path: [_PathFragment!]!
+  message: _ValidationMessage!
+}
+
+union _PathFragment = _FieldPathFragment | _IndexPathFragment
+
+type _FieldPathFragment {
+  field: String!
+}
+
+type _IndexPathFragment {
+  index: Int!
+  alias: String
+}
+
+type _ValidationMessage {
+  text: String!
+}
+
+input ArticleUpdateInput {
+  title: String
+  author: ArticleUpdateAuthorEntityRelationInput
+  _dummy_field_: Boolean
+}
+
+input ArticleUpdateAuthorEntityRelationInput {
+  connect: AuthorUniqueWhere
+  update: AuthorUpdateInput
+  disconnect: Boolean
+}
+
+input AuthorUniqueWhere {
+  id: UUID
+}
+
+input AuthorUpdateInput {
+  secret: String
+  _dummy_field_: Boolean
+}
+
+type AuthorConnection {
+  pageInfo: PageInfo!
+  edges: [AuthorEdge!]!
+}
+
+type AuthorEdge {
+  node: Author!
+}
+
+type QueryTransaction {
+  getArticle(by: ArticleUniqueWhere!, filter: ArticleWhere): Article
+  listArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], offset: Int, limit: Int): [Article!]!
+  paginateArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], skip: Int, first: Int): ArticleConnection!
+  validateUpdateArticle(by: ArticleUniqueWhere!, data: ArticleUpdateInput!): _ValidationResult!
+  getAuthor(by: AuthorUniqueWhere!, filter: AuthorWhere): Author
+  listAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], offset: Int, limit: Int): [Author!]!
+  paginateAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], skip: Int, first: Int): AuthorConnection!
+  validateUpdateAuthor(by: AuthorUniqueWhere!, data: AuthorUpdateInput!): _ValidationResult!
+}
+
+type Info {
+  description: String
+}
+
+type Mutation {
+  updateArticle(by: ArticleUniqueWhere!, filter: ArticleWhere, data: ArticleUpdateInput!): ArticleUpdateResult!
+  transaction(options: MutationTransactionOptions): MutationTransaction!
+  query: Query!
+}
+
+type ArticleUpdateResult implements MutationResult {
+  ok: Boolean!
+  errorMessage: String
+  errors: [_MutationError!]!
+  node: Article
+  validation: _ValidationResult!
+}
+
+interface MutationResult {
+  ok: Boolean!
+  errorMessage: String
+  errors: [_MutationError!]!
+}
+
+type _MutationError {
+  path: [_PathFragment!]! @deprecated(reason: "Use `paths`.")
+  paths: [[_PathFragment!]!]!
+  type: _MutationErrorType!
+  message: String
+}
+
+enum _MutationErrorType {
+  NotNullConstraintViolation
+  UniqueConstraintViolation
+  ForeignKeyConstraintViolation
+  NotFoundOrDenied
+  NonUniqueWhereInput
+  InvalidDataInput
+  SqlError
+}
+
+type MutationTransaction {
+  ok: Boolean!
+  errorMessage: String
+  errors: [_MutationError!]!
+  validation: _ValidationResult!
+  updateArticle(by: ArticleUniqueWhere!, filter: ArticleWhere, data: ArticleUpdateInput!): ArticleUpdateResult!
+  query: Query
+}
+
+input MutationTransactionOptions {
+  deferForeignKeyConstraints: Boolean
+  deferUniqueConstraints: Boolean
+}

--- a/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-not-null-through.gql
+++ b/packages/engine-content-api/tests/cases/integration/graphQlSchema/schema-not-null-through.gql
@@ -1,0 +1,201 @@
+type Query {
+  getArticle(by: ArticleUniqueWhere!, filter: ArticleWhere): Article
+  listArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], offset: Int, limit: Int): [Article!]!
+  paginateArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], skip: Int, first: Int): ArticleConnection!
+  getAuthor(by: AuthorUniqueWhere!, filter: AuthorWhere): Author
+  listAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], offset: Int, limit: Int): [Author!]!
+  paginateAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], skip: Int, first: Int): AuthorConnection!
+  transaction: QueryTransaction
+  _info: Info
+}
+
+type Article {
+  _meta: ArticleMeta
+  id: UUID!
+  title: String!
+  author(filter: AuthorWhere): Author
+  image(filter: ImageWhere): Image
+}
+
+type ArticleMeta {
+  id: FieldMeta
+  title: FieldMeta
+  author: FieldMeta
+  image: FieldMeta
+}
+
+type FieldMeta {
+  readable: Boolean
+  updatable: Boolean
+}
+
+scalar UUID
+
+type Author {
+  _meta: AuthorMeta
+  id: UUID!
+  name: String!
+  secret: String
+  classified: String
+}
+
+type AuthorMeta {
+  id: FieldMeta
+  name: FieldMeta
+  secret: FieldMeta
+  classified: FieldMeta
+}
+
+input AuthorWhere {
+  id: UUIDCondition
+  name: StringCondition
+  secret: StringCondition
+  classified: StringCondition
+  and: [AuthorWhere]
+  or: [AuthorWhere]
+  not: AuthorWhere
+}
+
+input UUIDCondition {
+  and: [UUIDCondition!]
+  or: [UUIDCondition!]
+  not: UUIDCondition
+  null: Boolean
+  isNull: Boolean
+  eq: UUID
+  notEq: UUID
+  in: [UUID!]
+  notIn: [UUID!]
+  lt: UUID
+  lte: UUID
+  gt: UUID
+  gte: UUID
+}
+
+input StringCondition {
+  and: [StringCondition!]
+  or: [StringCondition!]
+  not: StringCondition
+  null: Boolean
+  isNull: Boolean
+  eq: String
+  notEq: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  containsCI: String
+  startsWithCI: String
+  endsWithCI: String
+  similar: String
+  wordSimilar: String
+}
+
+type Image {
+  _meta: ImageMeta
+  id: UUID!
+  url: String!
+}
+
+type ImageMeta {
+  id: FieldMeta
+  url: FieldMeta
+}
+
+input ImageWhere {
+  id: UUIDCondition
+  url: StringCondition
+  and: [ImageWhere]
+  or: [ImageWhere]
+  not: ImageWhere
+}
+
+input ArticleUniqueWhere {
+  id: UUID
+}
+
+input ArticleWhere {
+  id: UUIDCondition
+  title: StringCondition
+  author: AuthorWhere
+  image: ImageWhere
+  and: [ArticleWhere]
+  or: [ArticleWhere]
+  not: ArticleWhere
+}
+
+input ArticleOrderBy {
+  _random: Boolean
+  _randomSeeded: Int
+  id: OrderDirection
+  title: OrderDirection
+  author: AuthorOrderBy
+  image: ImageOrderBy
+}
+
+enum OrderDirection {
+  asc
+  desc
+  ascNullsFirst
+  descNullsLast
+}
+
+input AuthorOrderBy {
+  _random: Boolean
+  _randomSeeded: Int
+  id: OrderDirection
+  name: OrderDirection
+  secret: OrderDirection
+  classified: OrderDirection
+}
+
+input ImageOrderBy {
+  _random: Boolean
+  _randomSeeded: Int
+  id: OrderDirection
+  url: OrderDirection
+}
+
+type ArticleConnection {
+  pageInfo: PageInfo!
+  edges: [ArticleEdge!]!
+}
+
+type PageInfo {
+  totalCount: Int!
+}
+
+type ArticleEdge {
+  node: Article!
+}
+
+input AuthorUniqueWhere {
+  id: UUID
+}
+
+type AuthorConnection {
+  pageInfo: PageInfo!
+  edges: [AuthorEdge!]!
+}
+
+type AuthorEdge {
+  node: Author!
+}
+
+type QueryTransaction {
+  getArticle(by: ArticleUniqueWhere!, filter: ArticleWhere): Article
+  listArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], offset: Int, limit: Int): [Article!]!
+  paginateArticle(filter: ArticleWhere, orderBy: [ArticleOrderBy!], skip: Int, first: Int): ArticleConnection!
+  getAuthor(by: AuthorUniqueWhere!, filter: AuthorWhere): Author
+  listAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], offset: Int, limit: Int): [Author!]!
+  paginateAuthor(filter: AuthorWhere, orderBy: [AuthorOrderBy!], skip: Int, first: Int): AuthorConnection!
+}
+
+type Info {
+  description: String
+}

--- a/packages/engine-content-api/tests/cases/unit/permissionMerger.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/permissionMerger.test.ts
@@ -1028,3 +1028,916 @@ describe('Contextual permission merger', () => {
 		})
 	})
 })
+
+describe('Contextual permission merger - through bucket', () => {
+	// Returns the raw projections, so a test can assert which operation keys exist: `toEqual` treats an
+	// explicitly `undefined` key as absent, which is the one distinction the three-state flags need.
+	const buildContextual = (acl: Acl.Schema, roles: string[]) => {
+		const model: Model.Schema = new SchemaBuilder()
+			.entity('Entity1', e => e.column('lorem').column('bar'))
+			.entity('Entity2', e => e.oneHasOne('xyz', r => r.target('Entity1')))
+			.buildSchema()
+		return new PermissionFactory().createContextual({ ...emptySchema, model, acl }, roles)
+	}
+
+	it('single role: root and through grants on the same operation compose', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {
+									rootPred: { lorem: { eq: 'root' } },
+									throughPred: { bar: { eq: 'through' } },
+								},
+								operations: {
+									read: { title: 'rootPred' },
+									through: {
+										read: { content: 'throughPred' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			// The scope projection runs per role, so a single role's through grant never leaks into its root set.
+			rootResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'rootPred',
+							id: 'rootPred',
+						},
+					},
+					// The shared predicate map is handed over untouched, so the unreferenced through predicate stays in it.
+					predicates: {
+						rootPred: { lorem: { eq: 'root' } },
+						throughPred: { bar: { eq: 'through' } },
+					},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'rootPred',
+							content: 'throughPred',
+							id: '__merge__rootPred__throughPred',
+						},
+					},
+					predicates: {
+						rootPred: { lorem: { eq: 'root' } },
+						throughPred: { bar: { eq: 'through' } },
+						__merge__rootPred__throughPred: {
+							or: [{ lorem: { eq: 'root' } }, { bar: { eq: 'through' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('single role: a through-only entity keeps an empty root entry', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									through: {
+										read: { title: true },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			rootResult: {
+				Entity1: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('two roles: through predicates merge in all, root stays empty', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { throughA: { lorem: { eq: 'a' } } },
+								operations: {
+									through: {
+										read: { title: 'throughA' },
+									},
+								},
+							},
+						},
+					},
+					role2: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { throughB: { lorem: { eq: 'b' } } },
+								operations: {
+									through: {
+										read: { title: 'throughB' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1', 'role2'],
+			rootResult: {
+				Entity1: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: '__merge__throughA__throughB',
+							id: '__merge__throughA__throughB',
+						},
+					},
+					predicates: {
+						__merge__throughA__throughB: {
+							or: [{ lorem: { eq: 'a' } }, { lorem: { eq: 'b' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('two roles: a root predicate and a through predicate on the same field', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					throughRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { thr: { lorem: { eq: 'through' } } },
+								operations: {
+									through: {
+										read: { title: 'thr' },
+									},
+								},
+							},
+						},
+					},
+					rootRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { rt: { lorem: { eq: 'root' } } },
+								operations: {
+									read: { title: 'rt' },
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['throughRole', 'rootRole'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'rt',
+							id: 'rt',
+						},
+					},
+					predicates: {
+						rt: { lorem: { eq: 'root' } },
+					},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: '__merge__thr__rt',
+							id: '__merge__thr__rt',
+						},
+					},
+					predicates: {
+						__merge__thr__rt: {
+							or: [{ lorem: { eq: 'through' } }, { lorem: { eq: 'root' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('inherits: a through grant on the parent stays through-only in the child', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					base: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { thr: { lorem: { eq: 'inherited' } } },
+								operations: {
+									through: {
+										read: { title: 'thr' },
+									},
+								},
+							},
+						},
+					},
+					child: {
+						variables: {},
+						inherits: ['base'],
+						entities: {
+							Entity1: {
+								predicates: { own: { bar: { eq: 'own' } } },
+								operations: {
+									read: { description: 'own' },
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['child'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						read: {
+							description: 'own',
+							id: 'own',
+						},
+					},
+					predicates: {
+						own: { bar: { eq: 'own' } },
+					},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'thr',
+							description: 'own',
+							id: '__merge__thr__own',
+						},
+					},
+					predicates: {
+						thr: { lorem: { eq: 'inherited' } },
+						own: { bar: { eq: 'own' } },
+						__merge__thr__own: {
+							or: [{ lorem: { eq: 'inherited' } }, { bar: { eq: 'own' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('inherits: a through grant on the child does not affect the inherited root grant', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					base: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { rt: { lorem: { eq: 'inherited' } } },
+								operations: {
+									read: { title: 'rt' },
+								},
+							},
+						},
+					},
+					child: {
+						variables: {},
+						inherits: ['base'],
+						entities: {
+							Entity1: {
+								predicates: { thr: { bar: { eq: 'own' } } },
+								operations: {
+									through: {
+										read: { description: 'thr' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['child'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'rt',
+							id: 'rt',
+						},
+					},
+					predicates: {
+						rt: { lorem: { eq: 'inherited' } },
+					},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'rt',
+							description: 'thr',
+							id: '__merge__rt__thr',
+						},
+					},
+					predicates: {
+						rt: { lorem: { eq: 'inherited' } },
+						thr: { bar: { eq: 'own' } },
+						__merge__rt__thr: {
+							or: [{ lorem: { eq: 'inherited' } }, { bar: { eq: 'own' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('through delete: true is granted under a relation only', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									read: { title: true },
+									through: {
+										delete: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: true,
+							id: true,
+						},
+						delete: true,
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('through delete: a predicate delete composes with the root one', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {
+									rootDel: { lorem: { eq: 'root' } },
+									throughDel: { bar: { eq: 'through' } },
+								},
+								operations: {
+									delete: 'rootDel',
+									through: {
+										delete: 'throughDel',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						delete: 'rootDel',
+					},
+					predicates: {
+						rootDel: { lorem: { eq: 'root' } },
+						throughDel: { bar: { eq: 'through' } },
+					},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						delete: '__merge__rootDel__throughDel',
+					},
+					predicates: {
+						__merge__rootDel__throughDel: {
+							or: [{ lorem: { eq: 'root' } }, { bar: { eq: 'through' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('customPrimary and refreshMaterializedView survive the scope projection of an entity with a through bucket', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									customPrimary: true,
+									refreshMaterializedView: true,
+									read: { title: true },
+									through: {
+										read: { content: true },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						customPrimary: true,
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						customPrimary: true,
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							content: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('customPrimary and refreshMaterializedView survive the scope projection that short-circuits without a through bucket', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									customPrimary: true,
+									refreshMaterializedView: true,
+									read: { title: true },
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						customPrimary: true,
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						customPrimary: true,
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('two roles: refreshMaterializedView is granted if any role grants it', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					viewRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									refreshMaterializedView: true,
+									read: { title: true },
+								},
+							},
+						},
+					},
+					otherRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									read: { description: true },
+									through: {
+										read: { content: true },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['viewRole', 'otherRole'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							description: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							description: true,
+							content: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('an explicit customPrimary and refreshMaterializedView denial survives the scope projection', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									customPrimary: false,
+									refreshMaterializedView: false,
+									read: { title: true },
+									through: {
+										read: { content: true },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			// A dropped `false` would not stay denied: Authorizator resolves the flags with `??`, so an absent
+			// key falls back to the role-level default instead of denying.
+			rootResult: {
+				Entity1: {
+					operations: {
+						customPrimary: false,
+						refreshMaterializedView: false,
+						read: {
+							title: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						customPrimary: false,
+						refreshMaterializedView: false,
+						read: {
+							title: true,
+							content: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('two roles: an explicit denial loses to another role granting the flag', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					denyingRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									customPrimary: false,
+									refreshMaterializedView: false,
+									read: { title: true },
+								},
+							},
+						},
+					},
+					grantingRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {},
+								operations: {
+									customPrimary: true,
+									refreshMaterializedView: true,
+									read: { description: true },
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['denyingRole', 'grantingRole'],
+			rootResult: {
+				Entity1: {
+					operations: {
+						customPrimary: true,
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							description: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						customPrimary: true,
+						refreshMaterializedView: true,
+						read: {
+							title: true,
+							description: true,
+							id: true,
+						},
+					},
+					predicates: {},
+				},
+			},
+		})
+	})
+
+	it('flags no role states stay absent, leaving the role-level default in charge', () => {
+		const { root, all } = buildContextual({
+			roles: {
+				role1: {
+					variables: {},
+					entities: {
+						Entity1: {
+							predicates: {},
+							operations: {
+								read: { title: true },
+							},
+						},
+					},
+				},
+				role2: {
+					variables: {},
+					entities: {
+						Entity1: {
+							predicates: {},
+							operations: {
+								read: { description: true },
+								through: {
+									read: { content: true },
+								},
+							},
+						},
+					},
+				},
+			},
+		}, ['role1', 'role2'])
+
+		// Asserted on the key list, because a `customPrimary: undefined` would compare equal to an absent one.
+		assert.deepStrictEqual(Object.keys(root.Entity1.operations), ['read'])
+		assert.deepStrictEqual(Object.keys(all.Entity1.operations), ['read'])
+		assert.deepStrictEqual(root.Entity1.operations.read, { title: true, description: true, id: true })
+		assert.deepStrictEqual(all.Entity1.operations.read, { title: true, description: true, content: true, id: true })
+	})
+
+	it('primary predicate is the union of the fields readable in that scope', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					role1: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: {
+									pA: { lorem: { eq: 'a' } },
+									pB: { bar: { eq: 'b' } },
+									pC: { lorem: { eq: 'c' } },
+								},
+								operations: {
+									read: { title: 'pA', description: 'pB' },
+									through: {
+										read: { content: 'pC' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['role1'],
+			// makePrimaryPredicatesUnionOfAllFields runs once per scope, so root unions only the root fields.
+			rootResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'pA',
+							description: 'pB',
+							id: '__merge__pA__pB',
+						},
+					},
+					predicates: {
+						pA: { lorem: { eq: 'a' } },
+						pB: { bar: { eq: 'b' } },
+						pC: { lorem: { eq: 'c' } },
+						__merge__pA__pB: {
+							or: [{ lorem: { eq: 'a' } }, { bar: { eq: 'b' } }],
+						},
+					},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: 'pA',
+							description: 'pB',
+							content: 'pC',
+							id: '__merge____merge__pA__pB__pC',
+						},
+					},
+					predicates: {
+						pA: { lorem: { eq: 'a' } },
+						pB: { bar: { eq: 'b' } },
+						pC: { lorem: { eq: 'c' } },
+						__merge__pA__pB: {
+							or: [{ lorem: { eq: 'a' } }, { bar: { eq: 'b' } }],
+						},
+						__merge____merge__pA__pB__pC: {
+							or: [
+								{ or: [{ lorem: { eq: 'a' } }, { bar: { eq: 'b' } }] },
+								{ lorem: { eq: 'c' } },
+							],
+						},
+					},
+				},
+			},
+		})
+	})
+
+	it('legacy noRoot and the new through bucket merge into one nested set', () => {
+		executeContextual({
+			acl: {
+				roles: {
+					legacyRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { legacyPred: { lorem: { eq: 'legacy' } } },
+								operations: {
+									read: { title: 'legacyPred' },
+									noRoot: ['read'],
+								},
+							},
+						},
+					},
+					throughRole: {
+						variables: {},
+						entities: {
+							Entity1: {
+								predicates: { newPred: { bar: { eq: 'new' } } },
+								operations: {
+									through: {
+										read: { title: 'newPred' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			roles: ['legacyRole', 'throughRole'],
+			rootResult: {
+				Entity1: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
+				Entity1: {
+					operations: {
+						read: {
+							title: '__merge__legacyPred__newPred',
+							id: '__merge__legacyPred__newPred',
+						},
+					},
+					predicates: {
+						__merge__legacyPred__newPred: {
+							or: [{ lorem: { eq: 'legacy' } }, { bar: { eq: 'new' } }],
+						},
+					},
+				},
+			},
+		})
+	})
+})

--- a/packages/engine-content-api/tests/cases/unit/permissionMerger.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/permissionMerger.test.ts
@@ -571,7 +571,7 @@ describe('Permission merger', () => {
 	})
 
 	it('merge noRootOperations', () => {
-		execute({
+		executeContextual({
 			acl: {
 				roles: {
 					role1: {
@@ -608,7 +608,14 @@ describe('Permission merger', () => {
 				},
 			},
 			roles: ['role1', 'role2'],
-			result: {
+			// Every grant here is through-only, so nothing is reachable at the root.
+			rootResult: {
+				Entity2: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
 				Entity2: {
 					operations: {
 						update: {
@@ -619,7 +626,6 @@ describe('Permission merger', () => {
 							id: true,
 							title: true,
 						},
-						noRoot: ['read', 'update'],
 					},
 					predicates: {},
 				},
@@ -628,7 +634,7 @@ describe('Permission merger', () => {
 	})
 
 	it('merge delete #1', () => {
-		execute({
+		executeContextual({
 			acl: {
 				roles: {
 					role1: {
@@ -655,11 +661,16 @@ describe('Permission merger', () => {
 				},
 			},
 			roles: ['role1', 'role2'],
-			result: {
+			rootResult: {
+				Entity2: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
 				Entity2: {
 					operations: {
 						delete: true,
-						noRoot: ['delete'],
 					},
 					predicates: {},
 				},
@@ -708,8 +719,8 @@ describe('Permission merger', () => {
 		})
 	})
 
-	it('merge delete #2', () => {
-		execute({
+	it('merge delete #3', () => {
+		executeContextual({
 			acl: {
 				roles: {
 					role1: {
@@ -736,11 +747,16 @@ describe('Permission merger', () => {
 				},
 			},
 			roles: ['role1', 'role2'],
-			result: {
+			rootResult: {
+				Entity2: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
 				Entity2: {
 					operations: {
 						delete: true,
-						noRoot: ['delete'],
 					},
 					predicates: {},
 				},
@@ -807,7 +823,7 @@ describe('Permission merger', () => {
 	})
 
 	it('merge permissions with no root', () => {
-		execute({
+		executeContextual({
 			acl: {
 				roles: {
 					role1: {
@@ -845,10 +861,15 @@ describe('Permission merger', () => {
 				},
 			},
 			roles: ['role1', 'role2'],
-			result: {
+			rootResult: {
+				Entity2: {
+					operations: {},
+					predicates: {},
+				},
+			},
+			allResult: {
 				Entity2: {
 					operations: {
-						noRoot: ['read'],
 						read: {
 							title: '__merge__foo__foo',
 							id: '__merge__foo__foo',

--- a/packages/engine-content-api/tests/cases/unit/predicatesFactory.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesFactory.test.ts
@@ -100,7 +100,7 @@ describe('Predicates factory', () => {
 		const predicateFactory = new PredicateFactory(permissions, schema, new VariableInjector(schema, {}))
 		const image = schema.entities['Image']
 		const authorRelation = image.fields['authors'] as Model.OneHasManyRelation
-		const predicate = predicateFactory.create(image, Acl.Operation.read, undefined, {
+		const predicate = predicateFactory.create(image, Acl.Operation.read, 'root', undefined, {
 			type: 'manyHasOne',
 			entity: schema.entities.Author,
 			relation: schema.entities.Author.fields.image as Model.ManyHasOneRelation,
@@ -123,25 +123,16 @@ describe('Predicates factory', () => {
 		})
 	})
 
-	it('uses root permissions when isRoot is true', () => {
+	it('uses root permissions in the root scope', () => {
 		const predicateFactory = new PredicateFactory(permissions, schema, new VariableInjector(schema, {}), throughPermissions)
 		const author = schema.entities['Author']
-		const predicate = predicateFactory.create(author, Acl.Operation.read, ['name'], undefined, true)
+		const predicate = predicateFactory.create(author, Acl.Operation.read, 'root', ['name'])
 		assert.deepStrictEqual(predicate, {
 			isPublic: { eq: true },
 		})
 	})
 
-	it('uses root permissions when isRoot is undefined', () => {
-		const predicateFactory = new PredicateFactory(permissions, schema, new VariableInjector(schema, {}), throughPermissions)
-		const author = schema.entities['Author']
-		const predicate = predicateFactory.create(author, Acl.Operation.read, ['name'], undefined, undefined)
-		assert.deepStrictEqual(predicate, {
-			isPublic: { eq: true },
-		})
-	})
-
-	it('uses allPermissions when isRoot is false', () => {
+	it('uses the nested permission set in the nested scope', () => {
 		const allPerms: Acl.Permissions = {
 			...permissions,
 			Author: {
@@ -161,16 +152,16 @@ describe('Predicates factory', () => {
 		}
 		const predicateFactory = new PredicateFactory(permissions, schema, new VariableInjector(schema, {}), allPerms)
 		const author = schema.entities['Author']
-		const predicate = predicateFactory.create(author, Acl.Operation.read, ['name'], undefined, false)
+		const predicate = predicateFactory.create(author, Acl.Operation.read, 'nested', ['name'])
 		assert.deepStrictEqual(predicate, {
 			name: { eq: 'all' },
 		})
 	})
 
-	it('falls back to root permissions when allPermissions is not provided', () => {
+	it('falls back to root permissions in the nested scope when no nested set is provided', () => {
 		const predicateFactory = new PredicateFactory(permissions, schema, new VariableInjector(schema, {}))
 		const author = schema.entities['Author']
-		const predicate = predicateFactory.create(author, Acl.Operation.read, ['name'], undefined, false)
+		const predicate = predicateFactory.create(author, Acl.Operation.read, 'nested', ['name'])
 		assert.deepStrictEqual(predicate, {
 			isPublic: { eq: true },
 		})

--- a/packages/engine-content-api/tests/src/test.ts
+++ b/packages/engine-content-api/tests/src/test.ts
@@ -17,6 +17,8 @@ export interface Test {
 	settings?: Settings.Schema
 	validation?: Validation.Schema
 	permissions?: Acl.Permissions
+	/** Permission set effective under a relation (root grants plus `through` ones). Defaults to `permissions`. */
+	nestedPermissions?: Acl.Permissions
 	variables?: Acl.VariablesMap
 	query: string
 	queryVariables?: Record<string, any>
@@ -76,8 +78,10 @@ export const failedTransaction = (executes: SqlQuery[]): SqlQuery[] => {
 
 export const execute = async (test: Test) => {
 	const permissions: Acl.Permissions = test.permissions || new AllowAllPermissionFactory().create(test.schema)
-	const authorizator = new Authorizator(permissions, false, false)
-	const builder = new GraphQlSchemaBuilderFactory().create(test.schema, authorizator)
+	const nestedPermissions: Acl.Permissions = test.nestedPermissions ?? permissions
+	const authorizator = new Authorizator(nestedPermissions, false, false)
+	const rootAuthorizator = new Authorizator(permissions, false, false)
+	const builder = new GraphQlSchemaBuilderFactory().create(test.schema, authorizator, rootAuthorizator)
 	const graphQLSchema = builder.build()
 
 	const connection = createConnectionMock(test.executes)
@@ -103,6 +107,7 @@ export const execute = async (test: Test) => {
 			executionContainer: executionContainerFactory
 				.create({
 					permissions,
+					allPermissions: nestedPermissions,
 					schema,
 					schemaMeta: {
 						id: 1,

--- a/packages/engine-http/src/content/GraphQlSchemaFactory.ts
+++ b/packages/engine-http/src/content/GraphQlSchemaFactory.ts
@@ -36,12 +36,13 @@ export class GraphQlSchemaFactory {
 		return this.cache.fetch(schema, cacheKey, () => {
 			const { root: permissions, all: allPermissions } = this.permissionFactory.createContextual(schema, identity.projectRoles)
 
-			const authorizator = new Authorizator(
-				allPermissions,
-				schema.acl.customPrimary ?? false,
-				Object.values(schema.acl.roles).some(it => it.content?.refreshMaterializedView),
-			)
-			const dataSchemaBuilder = this.graphqlSchemaBuilderFactory.create(schema.model, authorizator)
+			const customPrimary = schema.acl.customPrimary ?? false
+			const refreshMaterializedView = Object.values(schema.acl.roles).some(it => it.content?.refreshMaterializedView)
+			// Types are shaped by the nested set, so a field granted only through a relation still exists
+			// on the shared type; the root query and mutation fields are gated on the root set alone.
+			const authorizator = new Authorizator(allPermissions, customPrimary, refreshMaterializedView)
+			const rootAuthorizator = new Authorizator(permissions, customPrimary, refreshMaterializedView)
+			const dataSchemaBuilder = this.graphqlSchemaBuilderFactory.create(schema.model, authorizator, rootAuthorizator)
 			const introspectionSchemaFactory = new IntrospectionSchemaDefinitionFactory(
 				new IntrospectionSchemaFactory(
 					schema.model,

--- a/packages/schema-definition/src/acl/builder/PermissionOverrider.ts
+++ b/packages/schema-definition/src/acl/builder/PermissionOverrider.ts
@@ -33,6 +33,14 @@ export default class PermissionOverrider {
 					: {
 						customPrimary: overrides.operations.customPrimary ?? original.operations.customPrimary,
 					}),
+				...(original.operations.through || overrides.operations.through
+					? {
+						through: this.overrideThroughOperations(
+							original.operations.through ?? {},
+							overrides.operations.through ?? {},
+						),
+					}
+					: {}),
 				...(original.operations.noRoot || overrides.operations.noRoot
 					? {
 						noRoot: [
@@ -42,6 +50,22 @@ export default class PermissionOverrider {
 					}
 					: {}),
 			},
+		}
+	}
+
+	private overrideThroughOperations(
+		original: Acl.ThroughOperations,
+		overrides: Acl.ThroughOperations,
+	): Acl.ThroughOperations {
+		return {
+			create: { ...(original.create || {}), ...(overrides.create || {}) },
+			read: { ...(original.read || {}), ...(overrides.read || {}) },
+			update: { ...(original.update || {}), ...(overrides.update || {}) },
+			...(original.delete === undefined && overrides.delete === undefined
+				? {}
+				: {
+					delete: overrides.delete ?? original.delete,
+				}),
 		}
 	}
 }

--- a/packages/schema-definition/src/acl/builder/PermissionOverrider.ts
+++ b/packages/schema-definition/src/acl/builder/PermissionOverrider.ts
@@ -1,4 +1,4 @@
-import { Acl } from '@contember/schema'
+import { Acl, Writable } from '@contember/schema'
 import { tuple } from '../../utils/index.js'
 
 export default class PermissionOverrider {
@@ -53,19 +53,24 @@ export default class PermissionOverrider {
 		}
 	}
 
+	/**
+	 * An operation neither side declares stays absent - an empty map would read as "the through bucket
+	 * already grants this operation" and shadow a legacy `noRoot` grant in `splitEntityPermissions`.
+	 */
 	private overrideThroughOperations(
 		original: Acl.ThroughOperations,
 		overrides: Acl.ThroughOperations,
 	): Acl.ThroughOperations {
-		return {
-			create: { ...(original.create || {}), ...(overrides.create || {}) },
-			read: { ...(original.read || {}), ...(overrides.read || {}) },
-			update: { ...(original.update || {}), ...(overrides.update || {}) },
-			...(original.delete === undefined && overrides.delete === undefined
-				? {}
-				: {
-					delete: overrides.delete ?? original.delete,
-				}),
+		const result: Writable<Acl.ThroughOperations> = {}
+		for (const operation of ['create', 'read', 'update'] as const) {
+			if (original[operation] === undefined && overrides[operation] === undefined) {
+				continue
+			}
+			result[operation] = { ...(original[operation] || {}), ...(overrides[operation] || {}) }
 		}
+		if (original.delete !== undefined || overrides.delete !== undefined) {
+			result.delete = overrides.delete ?? original.delete
+		}
+		return result
 	}
 }

--- a/packages/schema-definition/src/acl/definition/internal/AclFactory.ts
+++ b/packages/schema-definition/src/acl/definition/internal/AclFactory.ts
@@ -61,55 +61,51 @@ export class AclFactory {
 		)
 	}
 
+	/**
+	 * A `through: true` grant lands in its own bucket instead of flipping a per-operation flag, so
+	 * root and through grants on the same entity and operation compose instead of conflicting.
+	 */
 	private createPermissionsFromAllow(rolePermissions: PermissionsByEntity, entity: Model.Entity): Acl.EntityPermissions {
 		const predicatesResolver = EntityPredicatesResolver.create(rolePermissions, this.model, entity)
+		const definitions = rolePermissions.get(entity.name)?.definitions ?? []
 
-		const entityOperations: Writable<Acl.EntityOperations> = {}
-		const noRootOptions = this.getNoRootOptions(entity, rolePermissions.get(entity.name))
-		if (noRootOptions?.length) {
-			entityOperations.noRoot = noRootOptions
+		const entityOperations: Writable<Acl.EntityOperations> = {
+			...this.createOperations(entity, predicatesResolver, definitions.filter(it => it.through !== true)),
 		}
-		for (const op of ['create', 'update', 'read'] as const) {
-			const fieldPermissions: Writable<Acl.FieldPermissions> = {}
-			for (const field of Object.keys(entity.fields)) {
-				const predicate = predicatesResolver.createFieldPredicate(op, field, field === entity.primary)
-				if (predicate !== undefined) {
-					fieldPermissions[field] = predicate
-				}
-			}
-			if (Object.keys(fieldPermissions).length > 0) {
-				entityOperations[op] = fieldPermissions
-			}
+		const throughOperations = this.createOperations(entity, predicatesResolver, definitions.filter(it => it.through === true))
+		if (Object.keys(throughOperations).length > 0) {
+			entityOperations.through = throughOperations
 		}
-		const delPredicate = predicatesResolver.createFieldPredicate('delete', '', false)
-		if (delPredicate !== undefined) {
-			entityOperations.delete = delPredicate
-		}
+
 		return {
 			predicates: predicatesResolver.getUsedPredicates(),
 			operations: entityOperations,
 		}
 	}
 
-	getNoRootOptions(entity: Model.Entity, permissions?: EntityPermissions): Acl.EntityOperations['noRoot'] {
-		const allowedRoot = new Set<Acl.Operation>()
-		const disallowedRoot = new Set<Acl.Operation>()
-		for (const def of permissions?.definitions ?? []) {
-			const noRoot = def.through === true
-			for (const op of ['create', 'read', 'update', 'delete'] as const) {
-				if (def[op]) {
-					const currentSet = noRoot ? disallowedRoot : allowedRoot
-					currentSet.add(op as Acl.Operation)
-
-					const otherSet = noRoot ? allowedRoot : disallowedRoot
-
-					if (otherSet.has(op as Acl.Operation)) {
-						throw new Error(`Operation ${op} cannot be both allowed and disallowed on root on entity ${entity.name}`)
-					}
+	private createOperations(
+		entity: Model.Entity,
+		predicatesResolver: EntityPredicatesResolver,
+		definitions: AllowDefinition<any>[],
+	): Acl.ThroughOperations {
+		const operations: Writable<Acl.ThroughOperations> = {}
+		for (const op of ['create', 'update', 'read'] as const) {
+			const fieldPermissions: Writable<Acl.FieldPermissions> = {}
+			for (const field of Object.keys(entity.fields)) {
+				const predicate = predicatesResolver.createFieldPredicate(op, field, field === entity.primary, definitions)
+				if (predicate !== undefined) {
+					fieldPermissions[field] = predicate
 				}
 			}
+			if (Object.keys(fieldPermissions).length > 0) {
+				operations[op] = fieldPermissions
+			}
 		}
-		return [...disallowedRoot.values()]
+		const delPredicate = predicatesResolver.createFieldPredicate('delete', '', false, definitions)
+		if (delPredicate !== undefined) {
+			operations.delete = delPredicate
+		}
+		return operations
 	}
 
 	private createVariables(role: Role, variables: VariableDefinition[]): Acl.Variables {

--- a/packages/schema-definition/src/acl/definition/internal/EntityPredicateResolver.ts
+++ b/packages/schema-definition/src/acl/definition/internal/EntityPredicateResolver.ts
@@ -62,8 +62,18 @@ export class EntityPredicatesResolver {
 		return new EntityPredicatesResolver(aclDefinitions, predicates, predicateNamesMap, generatedNames)
 	}
 
-	createFieldPredicate(op: 'create' | 'update' | 'read' | 'delete', field: string, isPrimary: boolean): true | undefined | string {
-		const fieldWhens = EntityPredicatesResolver.getMatchingWhens(this.aclDefinitions, op, field, isPrimary)
+	/**
+	 * `definitions` narrows the grants considered - `AclFactory` passes the root and the `through`
+	 * partition separately so each ends up in its own bucket, while the predicate map and the
+	 * used-predicate accounting stay shared across both.
+	 */
+	createFieldPredicate(
+		op: 'create' | 'update' | 'read' | 'delete',
+		field: string,
+		isPrimary: boolean,
+		definitions: AllowDefinition<any>[] = this.aclDefinitions,
+	): true | undefined | string {
+		const fieldWhens = EntityPredicatesResolver.getMatchingWhens(definitions, op, field, isPrimary)
 		if (fieldWhens.length === 0) {
 			return undefined
 		}

--- a/packages/schema-definition/tests/cases/unit/permissionOverrider.test.ts
+++ b/packages/schema-definition/tests/cases/unit/permissionOverrider.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from 'bun:test'
+import { Acl } from '@contember/schema'
+import PermissionOverrider from '../../../src/acl/builder/PermissionOverrider.js'
+
+const overrider = new PermissionOverrider()
+
+test('neither side has a through bucket - the result has no through key at all', () => {
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { read: { title: true } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { update: { title: true } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations).not.toHaveProperty('through')
+	expect(result.Book.operations.read).toEqual({ title: true })
+	expect(result.Book.operations.update).toEqual({ title: true })
+})
+
+test('only the original has a through bucket - it is carried over unchanged', () => {
+	const original: Acl.Permissions = {
+		Book: {
+			predicates: {},
+			operations: { read: { title: true }, through: { read: { secret: true } } },
+		},
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { update: { title: true } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.read).toEqual({ secret: true })
+})
+
+test('only the overrides have a through bucket - it is carried over unchanged', () => {
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { read: { title: true } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: {
+			predicates: {},
+			operations: { update: { title: true }, through: { read: { secret: true } } },
+		},
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.read).toEqual({ secret: true })
+})
+
+test('both sides have a through bucket - per-operation field maps merge, overrides wins on conflict', () => {
+	const original: Acl.Permissions = {
+		Book: {
+			predicates: {},
+			operations: { through: { read: { a: 'predA', common: 'predOriginal' } } },
+		},
+	}
+	const overrides: Acl.Permissions = {
+		Book: {
+			predicates: {},
+			operations: { through: { read: { b: 'predB', common: 'predOverride' } } },
+		},
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.read).toEqual({ a: 'predA', b: 'predB', common: 'predOverride' })
+})
+
+test('through.delete on neither side - the delete key is absent, not undefined', () => {
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { read: { a: true } } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { read: { b: true } } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.read).toEqual({ a: true, b: true })
+	expect(result.Book.operations.through).not.toHaveProperty('delete')
+})
+
+test('through.delete only on the original - carried over', () => {
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { delete: 'originalDeletePred' } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { read: { b: true } } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.delete).toBe('originalDeletePred')
+	expect(result.Book.operations.through?.read).toEqual({ b: true })
+})
+
+test('through.delete only on the overrides - carried over', () => {
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { read: { a: true } } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { delete: 'overrideDeletePred' } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.delete).toBe('overrideDeletePred')
+	expect(result.Book.operations.through?.read).toEqual({ a: true })
+})
+
+test('through.delete on both sides - the overrides value wins', () => {
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { delete: 'originalDeletePred' } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { delete: 'overrideDeletePred' } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through?.delete).toBe('overrideDeletePred')
+})
+
+test('a through bucket does not disturb how the root path merges', () => {
+	const original: Acl.Permissions = {
+		Book: {
+			predicates: { p1: { foo: { eq: 1 } } },
+			operations: {
+				read: { title: 'rootPredOriginal', extraOriginal: 'rootPredOriginal' },
+				through: { read: { secret: 'throughPredOriginal' } },
+			},
+		},
+	}
+	const overrides: Acl.Permissions = {
+		Book: {
+			predicates: { p2: { foo: { eq: 2 } } },
+			operations: {
+				read: { title: 'rootPredOverride', extraOverride: 'rootPredOverride' },
+				through: { update: { secret: 'throughPredOverride' } },
+			},
+		},
+	}
+
+	const result = overrider.override(original, overrides)
+
+	// root 'read' merges and resolves the 'title' conflict exactly like it did before through existed
+	expect(result.Book.operations.read).toEqual({
+		title: 'rootPredOverride',
+		extraOriginal: 'rootPredOriginal',
+		extraOverride: 'rootPredOverride',
+	})
+	expect(result.Book.operations.through?.read).toEqual({ secret: 'throughPredOriginal' })
+	expect(result.Book.operations.through?.update).toEqual({ secret: 'throughPredOverride' })
+	expect(result.Book.predicates).toStrictEqual({
+		p1: { foo: { eq: 1 } },
+		p2: { foo: { eq: 2 } },
+	})
+})
+
+test('through omits create/update when neither side declares them', () => {
+	// An operation nobody declares must stay absent, exactly like `delete` already does. An empty map is
+	// indistinguishable from a real grant for anything reading a stored schema back, and it used to make
+	// `splitEntityPermissions` treat the through bucket as the owner of the operation.
+	const original: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { read: { a: true } } } },
+	}
+	const overrides: Acl.Permissions = {
+		Book: { predicates: {}, operations: { through: { read: { b: true } } } },
+	}
+
+	const result = overrider.override(original, overrides)
+
+	expect(result.Book.operations.through).toStrictEqual({ read: { a: true, b: true } })
+	expect(result.Book.operations.through).not.toHaveProperty('create')
+	expect(result.Book.operations.through).not.toHaveProperty('update')
+})

--- a/packages/schema-definition/tests/cases/unit/readAclDefinitions.test.ts
+++ b/packages/schema-definition/tests/cases/unit/readAclDefinitions.test.ts
@@ -584,12 +584,13 @@ test('no root - valid', () => {
 	const schema = createSchema(NoRoot)
 	expect(schema.acl.roles.public.entities.Book).toStrictEqual({
 		operations: {
-			noRoot: [Acl.Operation.update],
 			read: {
 				id: true,
 			},
-			update: {
-				id: 'or_foo_eq_1_foo_eq_2',
+			through: {
+				update: {
+					id: 'or_foo_eq_1_foo_eq_2',
+				},
 			},
 		},
 		predicates: {
@@ -611,7 +612,7 @@ test('no root - valid', () => {
 	})
 })
 
-namespace NoRootInvalid {
+namespace RootAndThroughCombined {
 	export const publicRole = c.createRole('public')
 
 	@c.Allow(publicRole, {
@@ -629,8 +630,34 @@ namespace NoRootInvalid {
 	}
 }
 
-test('no root - invalid combo', () => {
-	expect(() => createSchema(NoRootInvalid)).toThrow('Operation update cannot be both allowed and disallowed on root on entity Book')
+// Used to throw: "Operation update cannot be both allowed and disallowed on root". Each grant now
+// lands in its own bucket, so the two compose instead of conflicting.
+test('root and through grants on the same operation', () => {
+	const schema = createSchema(RootAndThroughCombined)
+	expect(schema.acl.roles.public.entities.Book).toStrictEqual({
+		operations: {
+			update: {
+				id: 'foo_eq_1',
+			},
+			through: {
+				update: {
+					id: 'foo_eq_2',
+				},
+			},
+		},
+		predicates: {
+			foo_eq_1: {
+				foo: {
+					eq: 1,
+				},
+			},
+			foo_eq_2: {
+				foo: {
+					eq: 2,
+				},
+			},
+		},
+	})
 })
 
 namespace AllowFactoryModel {

--- a/packages/schema-migrations/src/modifications/utils/schemaUpdateUtils.ts
+++ b/packages/schema-migrations/src/modifications/utils/schemaUpdateUtils.ts
@@ -92,29 +92,35 @@ type EntityAclFieldPermissionsUpdater = (
 	entityName: string,
 	operation: Acl.Operation,
 ) => Acl.FieldPermissions
-type EntityOperationHandler = {
-	[K in keyof Required<Acl.EntityOperations>]: (
-		value: Exclude<Acl.EntityOperations[K], undefined>,
-	) => Acl.EntityOperations[K]
-}
-
 export const updateAclFieldPermissions =
 	(updater: EntityAclFieldPermissionsUpdater): AclEntityPermissionsUpdater => ({ entityPermissions, entityName }) => {
-		const operations: Writable<Acl.EntityOperations> = {}
-		const handlers: EntityOperationHandler = {
-			create: value => updater(value, entityName, Acl.Operation.create),
-			update: value => updater(value, entityName, Acl.Operation.update),
-			read: value => updater(value, entityName, Acl.Operation.read),
-			delete: value => value,
-			customPrimary: value => value,
-			refreshMaterializedView: value => value,
-			noRoot: value => value,
+		const source = entityPermissions.operations
+		const updateFields = (value: Acl.FieldPermissions, operation: Acl.Operation) => updater(value, entityName, operation)
+		// Carry every key over untouched by default, then rewrite the ones holding field names. An
+		// operation key that is not handled here must survive rather than disappear - the previous
+		// allow-list shape silently dropped `refreshMaterializedView` on every field rename.
+		const operations: Writable<Acl.EntityOperations> = { ...source }
+		if (source.create !== undefined) {
+			operations.create = updateFields(source.create, Acl.Operation.create)
 		}
-		const types: (keyof Acl.EntityOperations)[] = ['create', 'update', 'read', 'delete', 'customPrimary', 'noRoot']
-		for (const key of types) {
-			if (key in entityPermissions.operations) {
-				operations[key] = handlers[key](entityPermissions.operations[key] as any) as any
+		if (source.update !== undefined) {
+			operations.update = updateFields(source.update, Acl.Operation.update)
+		}
+		if (source.read !== undefined) {
+			operations.read = updateFields(source.read, Acl.Operation.read)
+		}
+		if (source.through !== undefined) {
+			const through: Writable<Acl.ThroughOperations> = { ...source.through }
+			if (source.through.create !== undefined) {
+				through.create = updateFields(source.through.create, Acl.Operation.create)
 			}
+			if (source.through.update !== undefined) {
+				through.update = updateFields(source.through.update, Acl.Operation.update)
+			}
+			if (source.through.read !== undefined) {
+				through.read = updateFields(source.through.read, Acl.Operation.read)
+			}
+			operations.through = through
 		}
 
 		return {

--- a/packages/schema-migrations/tests/cases/integration/updateFieldName.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/updateFieldName.test.ts
@@ -264,3 +264,71 @@ describe('rename a field carrying per-column index options', () =>
 		sql: SQL``,
 		noDiff: true,
 	}))
+
+// A field rename has to reach into the `through` bucket as well, and must not drop operation keys it
+// does not rewrite - the previous allow-list shape silently discarded `refreshMaterializedView`.
+describe('rename a field referenced by a through grant', () =>
+	testMigrations({
+		original: {
+			model: new SchemaBuilder()
+				.entity('Post', e => e.column('title'))
+				.buildSchema(),
+			acl: {
+				roles: {
+					editor: {
+						variables: {},
+						stages: '*',
+						entities: {
+							Post: {
+								predicates: {},
+								operations: {
+									read: { title: true },
+									refreshMaterializedView: true,
+									through: {
+										read: { title: true },
+										update: { title: true },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		updated: {
+			model: new SchemaBuilder()
+				.entity('Post', e => e.column('heading', c => c.type(Model.ColumnType.String).columnName('title')))
+				.buildSchema(),
+			acl: {
+				roles: {
+					editor: {
+						variables: {},
+						stages: '*',
+						entities: {
+							Post: {
+								predicates: {},
+								operations: {
+									read: { heading: true },
+									refreshMaterializedView: true,
+									through: {
+										read: { heading: true },
+										update: { heading: true },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		diff: [
+			{
+				modification: 'updateFieldName',
+				entityName: 'Post',
+				fieldName: 'title',
+				newFieldName: 'heading',
+			},
+		],
+		sql: SQL``,
+		noDiff: true,
+	}))

--- a/packages/schema-utils/src/acl/index.ts
+++ b/packages/schema-utils/src/acl/index.ts
@@ -1,3 +1,4 @@
 export * from './AllowAllPermissionFactory.js'
 export * from './PredicateDefinitionProcessor.js'
 export * from './schemaUtils.js'
+export * from './throughOperations.js'

--- a/packages/schema-utils/src/acl/throughOperations.ts
+++ b/packages/schema-utils/src/acl/throughOperations.ts
@@ -1,0 +1,55 @@
+import { Acl, Writable } from '@contember/schema'
+
+const FIELD_OPERATIONS = ['read', 'create', 'update'] as const
+
+/**
+ * Splits an entity's grants into the ones that apply at the query/mutation root and the ones that
+ * apply only when the entity is reached through a relation.
+ *
+ * The two sets are returned separately, sharing one predicate map, so the caller can merge them
+ * with its usual predicate-aware merge - `through` grants are additive to the root ones, not a
+ * replacement for them.
+ *
+ * The legacy `noRoot` flag is understood as well: it marked a whole operation as through-only, and
+ * schemas migrated before `through` existed still carry it (stored migrations keep patching it).
+ */
+export const splitEntityPermissions = (permissions: Acl.EntityPermissions): {
+	root: Acl.EntityPermissions
+	through: Acl.EntityPermissions
+} => {
+	const { through: declaredThrough, noRoot, ...rootOperations } = permissions.operations
+	const legacyThroughOperations = noRoot ?? []
+
+	if (declaredThrough === undefined && legacyThroughOperations.length === 0) {
+		return {
+			root: { predicates: permissions.predicates, operations: rootOperations },
+			through: { predicates: permissions.predicates, operations: {} },
+		}
+	}
+
+	const root: Writable<Acl.EntityOperations> = { ...rootOperations }
+	const through: Writable<Acl.ThroughOperations> = { ...declaredThrough }
+
+	for (const operation of FIELD_OPERATIONS) {
+		if (!legacyThroughOperations.includes(operation)) {
+			continue
+		}
+		const grant = root[operation]
+		delete root[operation]
+		if (grant !== undefined && through[operation] === undefined) {
+			through[operation] = grant
+		}
+	}
+	if (legacyThroughOperations.includes('delete')) {
+		const grant = root.delete
+		delete root.delete
+		if (grant !== undefined && through.delete === undefined) {
+			through.delete = grant
+		}
+	}
+
+	return {
+		root: { predicates: permissions.predicates, operations: root },
+		through: { predicates: permissions.predicates, operations: through },
+	}
+}

--- a/packages/schema-utils/src/acl/throughOperations.ts
+++ b/packages/schema-utils/src/acl/throughOperations.ts
@@ -11,7 +11,9 @@ const FIELD_OPERATIONS = ['read', 'create', 'update'] as const
  * replacement for them.
  *
  * The legacy `noRoot` flag is understood as well: it marked a whole operation as through-only, and
- * schemas migrated before `through` existed still carry it (stored migrations keep patching it).
+ * schemas migrated before `through` existed still carry it (stored migrations keep patching it). A
+ * legacy grant and a declared `through` grant for the same operation are merged, never discarded -
+ * the declared one wins on a field both of them name.
  */
 export const splitEntityPermissions = (permissions: Acl.EntityPermissions): {
 	root: Acl.EntityPermissions
@@ -36,13 +38,17 @@ export const splitEntityPermissions = (permissions: Acl.EntityPermissions): {
 		}
 		const grant = root[operation]
 		delete root[operation]
-		if (grant !== undefined && through[operation] === undefined) {
-			through[operation] = grant
+		if (grant === undefined) {
+			continue
 		}
+		// Both grants belong to the through scope, so merge them field-wise instead of picking one - an
+		// already declared `through` grant is the current format, so it wins on a field both of them name.
+		through[operation] = { ...grant, ...through[operation] }
 	}
 	if (legacyThroughOperations.includes('delete')) {
 		const grant = root.delete
 		delete root.delete
+		// A single predicate has no empty shape, so an undeclared `through.delete` is exactly `undefined`.
 		if (grant !== undefined && through.delete === undefined) {
 			through.delete = grant
 		}

--- a/packages/schema-utils/src/definition-generator/AclDefinitionCodeGenerator.ts
+++ b/packages/schema-utils/src/definition-generator/AclDefinitionCodeGenerator.ts
@@ -1,4 +1,4 @@
-import { PredicateDefinitionProcessor } from '../acl/index.js'
+import { PredicateDefinitionProcessor, splitEntityPermissions } from '../acl/index.js'
 import { IndentDecider, Literal, printJsValue } from '../utils/printJsValue.js'
 import { Acl, Model, Schema } from '@contember/schema'
 import { DefinitionNamingConventions } from './DefinitionNamingConventions.js'
@@ -61,37 +61,57 @@ export class AclDefinitionCodeGenerator {
 				continue
 			}
 			const roleVarName = this.definitionNamingConventions.roleVarName(roleName)
+			// the `through` bucket is a separate grant set, so it needs its own `@c.Allow` block - merging it into the root one would widen it to the root scope
+			// splitting also folds the legacy `noRoot` flag into that bucket, so an old stored schema does not regenerate as a plain root grant
+			const { root, through } = splitEntityPermissions(entityPermission)
 			for (const [predicateName, predicateDefinition] of Object.entries(entityPermission.predicates)) {
 				const operations = this.getMatchingOperations({
 					predicate: predicateName,
-					operations: entityPermission.operations,
+					operations: root.operations,
 					numberOfEntityFieldsWithoutId,
 				})
+				const throughOperations = this.getMatchingOperations({
+					predicate: predicateName,
+					operations: through.operations,
+					numberOfEntityFieldsWithoutId,
+				})
+				if (Object.keys(operations).length === 0 && Object.keys(throughOperations).length === 0) {
+					continue
+				}
+				const processor = new PredicateDefinitionProcessor(schema.model)
+				const when = processor.process(entity, predicateDefinition, {
+					handleColumn: ctx => {
+						if (typeof ctx.value === 'string' && ctx.value in roleDefinition.variables) {
+							return new Literal(this.definitionNamingConventions.variableVarName(roleName, ctx.value))
+						}
+						return ctx.value
+					},
+					handleRelation: ctx => {
+						return ctx.value
+					},
+				})
 				if (Object.keys(operations).length > 0) {
-					const processor = new PredicateDefinitionProcessor(schema.model)
-					const when = processor.process(entity, predicateDefinition, {
-						handleColumn: ctx => {
-							if (typeof ctx.value === 'string' && ctx.value in roleDefinition.variables) {
-								return new Literal(this.definitionNamingConventions.variableVarName(roleName, ctx.value))
-							}
-							return ctx.value
-						},
-						handleRelation: ctx => {
-							return ctx.value
-						},
-					})
-					const aclDefinition = printJsValue({ when, ...operations }, indentFirstLevel)
-					aclOutput.push(`@c.Allow(${roleVarName}, ${aclDefinition})\n`)
+					aclOutput.push(`@c.Allow(${roleVarName}, ${printJsValue({ when, ...operations }, indentFirstLevel)})\n`)
+				}
+				if (Object.keys(throughOperations).length > 0) {
+					aclOutput.push(`@c.Allow(${roleVarName}, ${printJsValue({ when, through: true, ...throughOperations }, indentFirstLevel)})\n`)
 				}
 			}
 			const trueOperations = this.getMatchingOperations({
 				predicate: true,
-				operations: entityPermission.operations,
+				operations: root.operations,
 				numberOfEntityFieldsWithoutId,
 			})
 			if (Object.keys(trueOperations).length > 0) {
-				const aclDefinition = printJsValue({ ...trueOperations }, indentFirstLevel)
-				aclOutput.push(`@c.Allow(${roleVarName}, ${aclDefinition})\n`)
+				aclOutput.push(`@c.Allow(${roleVarName}, ${printJsValue({ ...trueOperations }, indentFirstLevel)})\n`)
+			}
+			const trueThroughOperations = this.getMatchingOperations({
+				predicate: true,
+				operations: through.operations,
+				numberOfEntityFieldsWithoutId,
+			})
+			if (Object.keys(trueThroughOperations).length > 0) {
+				aclOutput.push(`@c.Allow(${roleVarName}, ${printJsValue({ through: true, ...trueThroughOperations }, indentFirstLevel)})\n`)
 			}
 		}
 

--- a/packages/schema-utils/src/type-schema/acl.ts
+++ b/packages/schema-utils/src/type-schema/acl.ts
@@ -93,11 +93,21 @@ const predicatesSchema = Typesafe.record(
 
 const predicatesSchemaCheck: Typesafe.Equals<Acl.PredicateMap, ReturnType<typeof predicatesSchema>> = true
 
+const throughOperationsSchema = Typesafe.partial({
+	read: fieldPermissionsSchema,
+	create: fieldPermissionsSchema,
+	update: fieldPermissionsSchema,
+	delete: Typesafe.union(Typesafe.string, Typesafe.boolean),
+})
+
+const throughOpSchemaCheck: Typesafe.Equals<Acl.ThroughOperations, ReturnType<typeof throughOperationsSchema>> = true
+
 const entityOperationsSchema = Typesafe.partial({
 	read: fieldPermissionsSchema,
 	create: fieldPermissionsSchema,
 	update: fieldPermissionsSchema,
 	delete: Typesafe.union(Typesafe.string, Typesafe.boolean),
+	through: throughOperationsSchema,
 	customPrimary: Typesafe.boolean,
 	refreshMaterializedView: Typesafe.boolean,
 	noRoot: Typesafe.array(Typesafe.enumeration('create', 'read', 'update', 'delete')),

--- a/packages/schema-utils/src/validation/AclValidator.ts
+++ b/packages/schema-utils/src/validation/AclValidator.ts
@@ -168,6 +168,10 @@ export class AclValidator {
 				this.validateFieldPermissions(operation, entity, predicates, errorBuilder.for(op))
 			}
 		}
+		if (operations.through !== undefined) {
+			// through grants reference the same fields and the same predicate map, so the same rules apply
+			this.validateOperations(operations.through, entity, predicates, errorBuilder.for('through'))
+		}
 	}
 
 	private validateFieldPermissions(

--- a/packages/schema-utils/tests/cases/unit/aclThroughOperations.test.ts
+++ b/packages/schema-utils/tests/cases/unit/aclThroughOperations.test.ts
@@ -92,3 +92,80 @@ test('a noRoot entry for an operation with no grant drops nothing', () => {
 	expect(root.operations).toStrictEqual({ read: { id: true } })
 	expect(through.operations).toStrictEqual({})
 })
+
+test('a legacy noRoot grant survives an empty declared through bucket for the same operation', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { title: true, content: true },
+			noRoot: ['read'],
+			through: { read: {} },
+		},
+	})
+
+	expect(root.operations).toStrictEqual({})
+	expect(through.operations).toStrictEqual({ read: { title: true, content: true } })
+})
+
+test('a legacy noRoot grant merges with a populated declared through bucket', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { title: true, content: true },
+			noRoot: ['read'],
+			through: { read: { secret: 'throughPredicate' } },
+		},
+	})
+
+	expect(root.operations).toStrictEqual({})
+	expect(through.operations).toStrictEqual({
+		read: { title: true, content: true, secret: 'throughPredicate' },
+	})
+})
+
+test('the declared through grant wins on a field both grants name', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { title: true, content: 'rootPredicate' },
+			noRoot: ['read'],
+			through: { read: { title: 'throughPredicate' } },
+		},
+	})
+
+	expect(root.operations).toStrictEqual({})
+	expect(through.operations).toStrictEqual({
+		read: { title: 'throughPredicate', content: 'rootPredicate' },
+	})
+})
+
+test('a legacy noRoot delete survives a through bucket that does not declare delete', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			delete: 'rootPredicate',
+			noRoot: ['delete'],
+			through: { read: { secret: 'throughPredicate' } },
+		},
+	})
+
+	expect(root.operations).toStrictEqual({})
+	expect(through.operations).toStrictEqual({
+		read: { secret: 'throughPredicate' },
+		delete: 'rootPredicate',
+	})
+})
+
+test('a declared through delete wins over a legacy noRoot delete', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			delete: 'rootPredicate',
+			noRoot: ['delete'],
+			through: { delete: 'throughPredicate' },
+		},
+	})
+
+	expect(root.operations).toStrictEqual({})
+	expect(through.operations).toStrictEqual({ delete: 'throughPredicate' })
+})

--- a/packages/schema-utils/tests/cases/unit/aclThroughOperations.test.ts
+++ b/packages/schema-utils/tests/cases/unit/aclThroughOperations.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from 'bun:test'
+import { splitEntityPermissions } from '../../../src/index.js'
+import { Acl } from '@contember/schema'
+
+const predicates: Acl.PredicateMap = {
+	rootPredicate: { isPublic: { eq: true } },
+	throughPredicate: { isArchived: { eq: false } },
+}
+
+test('an entity without through grants splits into itself and nothing', () => {
+	const permissions: Acl.EntityPermissions = {
+		predicates,
+		operations: {
+			read: { id: true, title: true },
+			delete: 'rootPredicate',
+			customPrimary: true,
+		},
+	}
+	const { root, through } = splitEntityPermissions(permissions)
+
+	expect(root.operations).toStrictEqual(permissions.operations)
+	expect(through.operations).toStrictEqual({})
+	expect(root.predicates).toBe(predicates)
+	expect(through.predicates).toBe(predicates)
+})
+
+test('root and through grants on the same operation stay separate', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { id: 'rootPredicate', title: 'rootPredicate' },
+			through: {
+				read: { secret: 'throughPredicate' },
+				update: { secret: 'throughPredicate' },
+			},
+		},
+	})
+
+	expect(root.operations).toStrictEqual({ read: { id: 'rootPredicate', title: 'rootPredicate' } })
+	expect(through.operations).toStrictEqual({
+		read: { secret: 'throughPredicate' },
+		update: { secret: 'throughPredicate' },
+	})
+})
+
+test('legacy noRoot moves the whole operation into the through bucket', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { id: true, title: true },
+			update: { title: 'rootPredicate' },
+			delete: 'rootPredicate',
+			noRoot: ['update', 'delete'],
+			refreshMaterializedView: true,
+		},
+	})
+
+	expect(root.operations).toStrictEqual({
+		read: { id: true, title: true },
+		refreshMaterializedView: true,
+	})
+	expect(through.operations).toStrictEqual({
+		update: { title: 'rootPredicate' },
+		delete: 'rootPredicate',
+	})
+})
+
+test('splitting is idempotent over its own root output', () => {
+	const once = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { id: true },
+			update: { title: 'rootPredicate' },
+			noRoot: ['update'],
+		},
+	})
+	const twice = splitEntityPermissions(once.root)
+
+	expect(twice.root.operations).toStrictEqual(once.root.operations)
+	expect(twice.through.operations).toStrictEqual({})
+})
+
+test('a noRoot entry for an operation with no grant drops nothing', () => {
+	const { root, through } = splitEntityPermissions({
+		predicates,
+		operations: {
+			read: { id: true },
+			noRoot: ['update'],
+		},
+	})
+
+	expect(root.operations).toStrictEqual({ read: { id: true } })
+	expect(through.operations).toStrictEqual({})
+})

--- a/packages/schema-utils/tests/cases/unit/aclValidator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/aclValidator.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from 'bun:test'
+import { Acl } from '@contember/schema'
+import { AclValidator } from '../../../src/index.js'
+import { c, createSchema } from '@contember/schema-definition'
+
+namespace ThroughAclSchema {
+	export const editorRole = c.createRole('editor', { stages: '*' })
+
+	@c.Allow(editorRole, { read: ['title'] })
+	@c.Allow(editorRole, {
+		through: true,
+		when: { archived: { eq: false } },
+		read: ['internalNote'],
+		update: ['internalNote'],
+		delete: true,
+	})
+	export class Article {
+		title = c.stringColumn()
+		internalNote = c.stringColumn()
+		archived = c.boolColumn().notNull()
+	}
+}
+
+const schema = createSchema(ThroughAclSchema)
+
+const aclWith = (operations: Acl.EntityOperations, predicates: Acl.PredicateMap = {}): Acl.Schema => ({
+	roles: {
+		editor: {
+			variables: {},
+			entities: {
+				Article: { predicates, operations },
+			},
+		},
+	},
+})
+
+const validate = (acl: Acl.Schema): ReturnType<AclValidator['validate']> => new AclValidator(schema.model).validate(acl)
+
+const operationsPath = ['acl', 'editor', 'entities', 'Article', 'operations']
+
+test('a valid through bucket produces no errors', () => {
+	expect(validate(schema.acl)).toStrictEqual([])
+})
+
+test('through.read on a field that does not exist on the entity', () => {
+	const errors = validate(aclWith({
+		read: { title: true },
+		through: { read: { nonExisting: true } },
+	}))
+
+	expect(errors).toStrictEqual([
+		{
+			code: 'ACL_UNDEFINED_FIELD',
+			message: 'Field nonExisting not found on entity Article',
+			path: [...operationsPath, 'through', 'read'],
+		},
+	])
+})
+
+test('through.update referencing an undefined predicate', () => {
+	const errors = validate(aclWith({
+		through: { update: { internalNote: 'missingPredicate' } },
+	}))
+
+	expect(errors).toStrictEqual([
+		{
+			code: 'ACL_UNDEFINED_PREDICATE',
+			message: 'Predicate missingPredicate not found',
+			path: [...operationsPath, 'through', 'update', 'internalNote'],
+		},
+	])
+})
+
+test('through.delete referencing an undefined predicate', () => {
+	const errors = validate(aclWith({
+		through: { delete: 'missingPredicate' },
+	}))
+
+	expect(errors).toStrictEqual([
+		{
+			code: 'ACL_UNDEFINED_PREDICATE',
+			message: 'Predicate missingPredicate not found',
+			path: [...operationsPath, 'through', 'delete'],
+		},
+	])
+})
+
+test('through.create on a field that does not exist and with an undefined predicate', () => {
+	const errors = validate(aclWith({
+		through: { create: { nonExisting: 'missingPredicate' } },
+	}))
+
+	expect(errors).toStrictEqual([
+		{
+			code: 'ACL_UNDEFINED_FIELD',
+			message: 'Field nonExisting not found on entity Article',
+			path: [...operationsPath, 'through', 'create'],
+		},
+		{
+			code: 'ACL_UNDEFINED_PREDICATE',
+			message: 'Predicate missingPredicate not found',
+			path: [...operationsPath, 'through', 'create', 'nonExisting'],
+		},
+	])
+})
+
+test('root operations keep reporting undefined fields and predicates', () => {
+	const errors = validate(aclWith({
+		read: { nonExisting: true },
+		update: { internalNote: 'missingPredicate' },
+		delete: 'missingPredicate',
+	}))
+
+	expect(errors).toStrictEqual([
+		{
+			code: 'ACL_UNDEFINED_PREDICATE',
+			message: 'Predicate missingPredicate not found',
+			path: [...operationsPath, 'delete'],
+		},
+		{
+			code: 'ACL_UNDEFINED_FIELD',
+			message: 'Field nonExisting not found on entity Article',
+			path: [...operationsPath, 'read'],
+		},
+		{
+			code: 'ACL_UNDEFINED_PREDICATE',
+			message: 'Predicate missingPredicate not found',
+			path: [...operationsPath, 'update', 'internalNote'],
+		},
+	])
+})
+
+test('operation flags and legacy noRoot are not mistaken for grants', () => {
+	const errors = validate(aclWith({
+		read: { title: 'published' },
+		update: { title: 'published' },
+		delete: 'published',
+		through: { read: { internalNote: 'published' } },
+		noRoot: ['update', 'delete'],
+		customPrimary: true,
+		refreshMaterializedView: true,
+	}, { published: { archived: { eq: false } } }))
+
+	expect(errors).toStrictEqual([])
+})

--- a/packages/schema-utils/tests/cases/unit/schemas/acl.ts
+++ b/packages/schema-utils/tests/cases/unit/schemas/acl.ts
@@ -22,6 +22,17 @@ export class Article {
 }
 
 @c.Allow(editorRole, {
+	through: true,
+	read: ['fileName'],
+	delete: true,
+})
+export class Attachment {
+	fileName = c.stringColumn()
+	size = c.intColumn()
+	comment = c.manyHasOne(Comment)
+}
+
+@c.Allow(editorRole, {
 	read: true,
 })
 @c.Allow(readerRole, {
@@ -29,4 +40,19 @@ export class Article {
 })
 export class Category {
 	name = c.stringColumn()
+}
+
+@c.Allow(editorRole, {
+	when: { article: { category: { id: categoryEditorVariable } } },
+	through: true,
+	read: true,
+	update: ['note'],
+})
+@c.Allow(editorRole, {
+	read: ['content'],
+})
+export class Comment {
+	content = c.stringColumn()
+	note = c.stringColumn()
+	article = c.manyHasOne(Article)
 }

--- a/packages/schema-utils/tests/cases/unit/tsDefinitionGenerator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/tsDefinitionGenerator.test.ts
@@ -12,6 +12,7 @@ import { join } from 'path'
 import { DefinitionCodeGenerator } from '../../../src/definition-generator/DefinitionCodeGenerator.js'
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { Acl } from '@contember/schema'
 
 const tests = [
 	['basic', basic],
@@ -72,4 +73,70 @@ test('definition generator round-trips per-column index options', () => {
 	const generated = generator.generate(createSchema(IndexColumnOptionsGenSchema))
 	expect(generated).toContain(`@c.Index({ fields: ['title', { field: 'rank', order: 'desc', nulls: 'last' }] })`)
 	expect(generated).toContain(`@c.Index({ fields: [{ field: 'title', opClass: 'text_pattern_ops' }] })`)
+})
+
+namespace LegacyAclModel {
+	export class Attachment {
+		fileName = c.stringColumn()
+		size = c.intColumn()
+	}
+}
+
+// `noRoot` cannot be expressed through `@c.Allow` - it only appears in schemas stored before `through` existed, so the acl is hand-written here
+const legacyNoRootAcl: Acl.Schema = {
+	roles: {
+		editor: {
+			stages: '*',
+			variables: {},
+			entities: {
+				Attachment: {
+					predicates: {},
+					operations: {
+						read: { fileName: true, size: true },
+						update: { fileName: true },
+						noRoot: ['read'],
+					},
+				},
+			},
+		},
+	},
+}
+
+test('definition generator keeps a legacy noRoot grant out of the root scope', () => {
+	const generator = new DefinitionCodeGenerator()
+	const generated = generator.generate({ ...createSchema(LegacyAclModel), acl: legacyNoRootAcl })
+	// regression: `noRoot` used to be ignored, so a through-only grant was regenerated as a full root grant - an escalation, not just a loss
+	expect(generated).not.toContain(`@c.Allow(editorRole, {\n\tread: true,\n\tupdate: ['fileName'],\n})`)
+	expect(generated).toContain(`@c.Allow(editorRole, {\n\tupdate: ['fileName'],\n})\n@c.Allow(editorRole, {\n\tthrough: true,\n\tread: true,\n})\n`)
+})
+
+const legacyMixedAcl: Acl.Schema = {
+	roles: {
+		editor: {
+			stages: '*',
+			variables: {},
+			entities: {
+				Attachment: {
+					predicates: { small: { size: { lt: 100 } } },
+					operations: {
+						read: { fileName: 'small', size: 'small' },
+						update: { fileName: true },
+						delete: 'small',
+						noRoot: ['read', 'delete'],
+						through: { update: { size: true } },
+					},
+				},
+			},
+		},
+	},
+}
+
+test('definition generator combines a legacy noRoot grant with a declared through bucket', () => {
+	const generator = new DefinitionCodeGenerator()
+	const generated = generator.generate({ ...createSchema(LegacyAclModel), acl: legacyMixedAcl })
+	// regression: the predicate-gated noRoot grant was emitted as a root grant and the declared `through` bucket was dropped entirely
+	expect(generated).not.toContain(`@c.Allow(editorRole, {\n\twhen: { size: { lt: 100 } },\n\tread: true,\n\tdelete: true,\n})`)
+	expect(generated).toContain(`@c.Allow(editorRole, {\n\twhen: { size: { lt: 100 } },\n\tthrough: true,\n\tread: true,\n\tdelete: true,\n})`)
+	expect(generated).toContain(`@c.Allow(editorRole, {\n\tupdate: ['fileName'],\n})`)
+	expect(generated).toContain(`@c.Allow(editorRole, {\n\tthrough: true,\n\tupdate: ['size'],\n})`)
 })

--- a/packages/schema/src/schema/acl.ts
+++ b/packages/schema/src/schema/acl.ts
@@ -62,11 +62,25 @@ export namespace Acl {
 		delete = 'delete',
 	}
 
+	/**
+	 * Grants that apply only when the entity is reached through a relation, never at the query
+	 * or mutation root. Additive to the root grants - the effective nested permission set is
+	 * the union of both.
+	 */
+	export type ThroughOperations = {
+		readonly read?: FieldPermissions
+		readonly create?: FieldPermissions
+		readonly update?: FieldPermissions
+		readonly delete?: Predicate
+	}
+
 	export type EntityOperations = {
 		readonly read?: FieldPermissions
 		readonly create?: FieldPermissions
 		readonly update?: FieldPermissions
 		readonly delete?: Predicate
+		readonly through?: ThroughOperations
+		/** @deprecated superseded by `through`; still read for schemas migrated before it existed. */
 		readonly noRoot?: readonly `${Operation}`[]
 
 		readonly customPrimary?: boolean


### PR DESCRIPTION
`@c.Allow({ through: true })` promises "this grant applies only when the entity is reached over a relation, never at the root". It was implemented for reads only, could not be combined with a root grant, and leaked its own grants back into the root permission set for any role that didn't collide with another one.

## What was wrong

Each of these was reproduced against `main` before touching anything.

**1. It could not be combined — it threw.**

```ts
@c.Allow(editor, { read: ['title'] })
@c.Allow(editor, { through: true, read: ['secret'] })
export class Article { … }
```

```
Error: Operation read cannot be both allowed and disallowed on root on entity Article
```

That's the most natural use of the feature — "read `title` anywhere, `secret` only through a relation" — and `AclFactory` rejected it outright.

**2. `noRoot` is a lossy projection.** `through` is declared per `@c.Allow` block, i.e. per predicate and field set. It was stored as `Acl.EntityOperations.noRoot: Operation[]` — per entity *and operation*. Which fields and which predicate were through-only was discarded on the way in. That loss is exactly why (1) had to throw: the granularity the storage could express was coarser than the granularity the user could declare.

**3. For a single role the root and nested sets were identical.**

```
root === all (deep): true
```

`PermissionFactory.resolveNoRoot` only ran inside `mergeEntityPermissions`, which is reached only when an entity appears in two merged permission sets. With one role the raw object passed through untouched, so through-only grants stayed in the *root* set. The only thing hiding the data was the coarse `noRoot` check dropping the whole root query/mutation field.

**4. Only reads were context-aware.** `PredicateFactory.getPermissionsForContext(isRoot?)` was a tri-state with a silent `undefined → root` fallback, and seven call sites never passed it:

| Call site | Operation |
|---|---|
| `InsertBuilder.ts:41` | create |
| `UpdateBuilder.ts:54` | update |
| `JunctionTableManager.ts:112,115` | update |
| `DeleteExecutor.ts:219` | update |
| `DeleteExecutor.ts:132,190` | delete |
| `SelectBuilder.ts:99,100` | read (field predicates) |
| `MetaHandler.ts:39` | read/update meta |

`createDeletePredicate` said so in its own comment: *"Delete predicates are not context-aware — through-permission support is scoped to read operations only."*

The flag was also misnamed. It meant "is this the query's **root entity**", computed once in `PredicatesInjector.inject()` and passed down verbatim, so a nested target inside a root filter resolved against root permissions.

## Why the write path is in scope

Fixing (3) alone would have been a behaviour break. The `through: true, update: ['name']` shape documented in `acl.mdx` (example #5) works today **only because of the leak** — the write path reads the root set, and for a single role the root set still contains the through grant.

Neither pin is safe once the leak is closed:

- pin the write path to **root** → the documented shape stops working;
- pin it to **nested** → privilege escalation, because a root mutation still exists whenever *some other* field is root-writable, and the through-only grant would then apply there too.

So the scope has to be threaded. That's what makes this one change rather than two.

## What changed

**Schema.** `Acl.EntityOperations` gains a `through` bucket holding the grants that apply only under a relation. Predicate *definitions* stay in the single shared `predicates` map, so nothing is duplicated. Semantics are **additive**: the nested set is the root grants ∪ the through grants, which is what makes the combination in (1) meaningful instead of contradictory.

`noRoot` stays in the type and stays readable **forever**. Nothing rewrites stored migration JSON, so the RFC6902 patches in `PatchAclSchemaModification` that target `/operations/noRoot` keep applying; new schemas simply emit `through`. Legacy conversion lives in one pure function, `splitEntityPermissions`, consumed where the split is actually decided.

**Merging.** `resolveNoRoot` and the `includeThrough` parameter threaded through five methods are gone. `root` and `all` are now two projections of the same merge, reusing the existing predicate-aware `mergeFieldPermissions` / `mergePredicates`. This closes (3) as a side effect — the root set is built by projection instead of by a merge that only fires on collision.

**Scope.** `AclScope = 'root' | 'nested'`, a **required** argument on every `PredicateFactory` entry point. `PredicatesInjector` derives it per node from the ancestor path it already threads, instead of computing it once at the top — which makes the bug class from (4) unrepresentable rather than patched. It also subsumes the `effectiveIsRoot` fix from #923; the two merge cleanly (verified: 511 content-api tests pass on the merged tree).

**Write path.** `Mapper.insert/update/updateInternal/upsert/delete/connectJunction/disconnectJunction` take the scope and forward it to `Updater`, `Inserter`, `DeleteExecutor` and `JunctionTableManager`. The split needed no judgement: **4 root** call sites in `MutationResolver`, **62 nested** ones, all in `mapper/update/relations/` and `mapper/insert/relations/`. The compiler enumerated every one. Delete cascades inherit the originating scope through `DeleteState` rather than escalating.

**GraphQL surface.** A second `Authorizator` built from the root set gates the root query and mutation fields; `isRootOperationDisallowed` is deleted (in `QueryProvider` it collapsed into the `getEntityPermission` check already on the line above). Types keep coming from the nested set, so a field granted only via `through` still exists on the shared type and is denied at execution time — the same way a field behind a row-level predicate already behaves. Per-scope type families are not an option: GraphQL type names are global.

**Out of scope**, unchanged deliberately:

- `Mapper`'s read helpers (`fetchHasManyPrimaries`, `selectField`) still resolve against root. Passing them an ancestor path would also switch on back-reference simplification (`always: true`) over the owner's read predicate — and the owner here was resolved by the mutation, not through a read predicate, so that would widen the result set. Belongs with #923's change-set follow-up.
- Generalising `through: true` to `through: { via: [Category.products] }`.

## Verification

- **`schema-no-root-ops.gql` is byte-for-byte unchanged.** The two-authorizator wiring reproduces the old `noRoot` behaviour exactly for the pure through-only case.
- New `graphQlSchemaBuilder` fixture for the combination that used to throw: `getAuthor`/`listAuthor` present (root read of `name` is allowed), `Author.secret` present on the type, **no `updateAuthor` mutation** (its only update grant is `through`), and `AuthorUpdateInput.secret` reachable through `ArticleUpdateAuthorEntityRelationInput`.
- New mocked-SQL test proving the write path threads the scope: a nested update using a grant the root set does not carry. Verified in reverse — flipping one `'nested'` to `'root'` makes it fail with `where false`.
- `permissionMerger` cases that asserted the leak now assert both scopes: root empty, nested carrying the grants.
- New `splitEntityPermissions` unit tests covering the legacy `noRoot` conversion and its idempotence.
- New `schema-migrations` test renaming a field referenced only from a `through` bucket.
- 1012 pass / 0 fail across engine-content-api, schema, schema-utils, schema-definition, schema-migrations, engine-http. Full `bun run test`, `bun run ts:build`, `bun run lint` clean.

## Drive-by fix

`updateAclFieldPermissions` copied only a hand-written allow-list of operation keys and dropped everything else. `refreshMaterializedView` was in its handler map but **not** in that list, so every field rename silently discarded `@c.AllowRefreshMaterializedView`. It now carries every key over by default and rewrites only the ones holding field names — structurally immune to the same omission.

Also renames a duplicated `merge delete #2` test (two `it()` blocks shared the name and the body).
