### PR TITLE
fix(engine-tenant-api): reject unknown IdP configuration keys at write time

### DIFF
--- a/packages/engine-tenant-api/src/model/service/idp/IDPManager.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/IDPManager.ts
@@ -26,7 +26,7 @@ export class IDPManager {
 		return await db.transaction(async (db): Promise<RegisterIDPResponse> => {
 			try {
 				const providerService = this.idpRegistry.getHandler(idp.type)
-				providerService.validateConfiguration(idp.configuration)
+				this.assertNoUnknownConfigurationKeys(providerService.validateConfiguration(idp.configuration), idp.configuration)
 				await this.assertValidClaimMapping(idp.configuration)
 			} catch (e) {
 				if (e instanceof IdentityProviderNotFoundError) {
@@ -88,7 +88,7 @@ export class IDPManager {
 				const type = data.type ?? existing.type
 				const providerService = this.idpRegistry.getHandler(type)
 				if (data.configuration !== undefined || type !== existing.type) {
-					providerService.validateConfiguration(newConfiguration)
+					this.assertNoUnknownConfigurationKeys(providerService.validateConfiguration(newConfiguration), newConfiguration)
 					await this.assertValidClaimMapping(newConfiguration)
 				}
 			} catch (e) {
@@ -107,6 +107,36 @@ export class IDPManager {
 
 			return new ResponseOk(null)
 		})
+	}
+
+	/**
+	 * Reject top-level `configuration` keys the provider does not recognise.
+	 *
+	 * Every provider configuration is parsed with `Typesafe.partial`, which silently DROPS unknown
+	 * properties. Without this check `addIDP` / `updateIDP` answer `ok` to a configuration the
+	 * provider will never act on — a typo like `fetchUserinfo` (lowercase i) reads as a successfully
+	 * applied setting while the option stays off, and an option that a given engine version does not
+	 * support yet looks indistinguishable from one that works.
+	 *
+	 * The parsed result carries exactly the keys the provider understood, so the difference against
+	 * the submitted object is the set of ignored keys. All of them are reported at once (rather than
+	 * the first, as `Typesafe.noExtraProps` would) so a configuration with several typos takes one
+	 * round trip to fix, matching {@link findRemovedRuleKeys}.
+	 *
+	 * Only the top level is checked: nested shapes that need strictness validate themselves
+	 * (`claimMapping` via {@link parseClaimMapping}). Reading a stored configuration is deliberately
+	 * left untouched — this runs at write time only, so a row written before this check keeps
+	 * authenticating instead of locking its users out.
+	 */
+	private assertNoUnknownConfigurationKeys(parsed: {}, submitted: Record<string, unknown>): void {
+		const known = new Set(Object.keys(parsed))
+		const unknown = Object.keys(submitted).filter(key => !known.has(key))
+		if (unknown.length > 0) {
+			throw new InvalidIDPConfigurationError(
+				`unknown configuration ${unknown.length === 1 ? 'property' : 'properties'} ${unknown.join(', ')}; `
+					+ `remove ${unknown.length === 1 ? 'it' : 'them'} or check the spelling — the provider would ignore ${unknown.length === 1 ? 'it' : 'them'}`,
+			)
+		}
 	}
 
 	/**

--- a/packages/engine-tenant-api/tests/cases/unit/idp/idpManagerUnknownConfigKeys.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/idpManagerUnknownConfigKeys.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import { IDPHandlerRegistry, IDPManager } from '../../../../src/model/service/idp/index.js'
+import { OIDCProvider } from '../../../../src/model/service/idp/providers/OIDCProvider.js'
+import { DatabaseContext } from '../../../../src/index.js'
+
+// Provider configurations are parsed with `Typesafe.partial`, which DROPS unknown properties. Without a
+// write-time guard, `addIDP` / `updateIDP` answer `ok` to a configuration the provider will never act on:
+// a typo such as `fetchUserinfo` (lowercase i) reads as an applied setting while the option stays off.
+// These pin the rejection. `OIDCProvider.validateConfiguration` is pure Typesafe parsing (no discovery,
+// no network), so the real provider can be used here rather than a pass-through double.
+
+const OIDC_BASE = { url: 'https://idp.example.com', clientId: 'client', clientSecret: 'secret' }
+const OPTIONS = { autoSignUp: false, exclusive: false, initReturnsConfig: false, requireVerifiedEmail: false, assumeEmailVerified: false }
+
+const makeManager = () => {
+	const registry = new IDPHandlerRegistry()
+	registry.registerHandler('oidc', new OIDCProvider())
+	return new IDPManager(registry, { getSchema: () => Promise.resolve(undefined) })
+}
+
+/** `existing` undefined ⇒ no IdP with that slug yet (the addIDP path). */
+const makeDb = (existing?: Record<string, unknown>) => {
+	const executed: unknown[] = []
+	const inner: any = {
+		queryHandler: {
+			fetch: async () => existing ? { id: 'idp-1', slug: 'sso', type: 'oidc', configuration: existing, disabledAt: null } : undefined,
+		},
+		commandBus: { execute: async (command: unknown) => void executed.push(command) },
+	}
+	inner.transaction = async (cb: (db: any) => Promise<unknown>) => cb(inner)
+	return { db: inner as unknown as DatabaseContext, executed }
+}
+
+describe('IDPManager — unknown configuration keys', () => {
+	test('addIDP rejects a key the provider would silently ignore', async () => {
+		const { db, executed } = makeDb()
+		const response = await makeManager().addIDP(db, {
+			slug: 'sso',
+			type: 'oidc',
+			// `fetchUserinfo` is a plausible typo of `fetchUserInfo`; before the guard this returned ok
+			// and left the option off.
+			configuration: { ...OIDC_BASE, fetchUserinfo: true },
+			options: OPTIONS,
+		})
+
+		expect(response.ok).toBe(false)
+		expect(response.ok === false && response.error).toBe('INVALID_CONFIGURATION')
+		expect(response.ok === false && response.errorMessage).toContain('fetchUserinfo')
+		// nothing was written
+		expect(executed).toHaveLength(0)
+	})
+
+	test('reports every unknown key at once, so several typos take one round trip', async () => {
+		const { db } = makeDb()
+		const response = await makeManager().addIDP(db, {
+			slug: 'sso',
+			type: 'oidc',
+			configuration: { ...OIDC_BASE, fetchUserinfo: true, tokenEndpointAuthMethd: 'client_secret_post' },
+			options: OPTIONS,
+		})
+
+		expect(response.ok).toBe(false)
+		const message = response.ok === false ? response.errorMessage ?? '' : ''
+		expect(message).toContain('fetchUserinfo')
+		expect(message).toContain('tokenEndpointAuthMethd')
+	})
+
+	test('a configuration the provider fully understands still passes', async () => {
+		const { db, executed } = makeDb()
+		const response = await makeManager().addIDP(db, {
+			slug: 'sso',
+			type: 'oidc',
+			configuration: { ...OIDC_BASE, scope: 'openid email', fetchUserInfo: true },
+			options: OPTIONS,
+		})
+
+		expect(response.ok).toBe(true)
+		expect(executed).toHaveLength(1)
+	})
+
+	test('updateIDP rejects an unknown key in the MERGED result, not just in the patch', async () => {
+		const { db, executed } = makeDb(OIDC_BASE)
+		const response = await makeManager().updateIDP(db, 'sso', { configuration: { fetchUserinfo: true } }, true)
+
+		expect(response.ok).toBe(false)
+		expect(response.ok === false && response.error).toBe('INVALID_CONFIGURATION')
+		expect(response.ok === false && response.errorMessage).toContain('fetchUserinfo')
+		expect(executed).toHaveLength(0)
+	})
+
+	test('an update that does not touch the configuration is not re-validated', async () => {
+		// A row written before this guard may hold keys the provider ignores. Toggling something else
+		// about it must not become impossible — the guard is a write-time check on a submitted
+		// configuration, not a re-validation of what is already stored.
+		const { db, executed } = makeDb({ ...OIDC_BASE, legacyIgnoredKey: true })
+		const response = await makeManager().updateIDP(db, 'sso', { options: { autoSignUp: true } }, false)
+
+		expect(response.ok).toBe(true)
+		expect(executed).toHaveLength(1)
+	})
+})


### PR DESCRIPTION
## Problem

Provider configurations are parsed with `Typesafe.partial`, which silently drops unknown properties. `addIDP` / `updateIDP` therefore answer `ok` to a configuration the provider will never act on.

Reproduction against `main`:

```ts
import { OIDCConfiguration } from './packages/engine-tenant-api/src/model/service/idp/providers/OIDCTypes.ts'

OIDCConfiguration({
  url: 'https://idp.example.com', clientId: 'c', clientSecret: 's',
  fetchUserinfo: true,                        // typo: lowercase i
  tokenEndpointAuthMethd: 'client_secret_post', // typo
}, ['configuration'])
// → { url, clientId, clientSecret }   — both typos dropped, no error
```

The mutation returns `ok: true`, the value is stored, and the option stays off. Two ways this bites:

- **A typo reads as success.** `fetchUserinfo` vs `fetchUserInfo` is a security-relevant option silently left disabled.
- **Version skew is invisible.** Configuring an option the running engine does not support yet looks exactly like configuring one it does. A successful `updateIDP` is not evidence the feature is active, and there is no way to tell from the outside.

I hit the second one while configuring an OIDC provider against an Apereo CAS deployment: an `updateIDP` carrying a config key the deployed engine predated was accepted, stored, and never acted on.

## Change

After the provider parses the configuration, compare the submitted top-level keys against the parsed result's. The parsed object carries exactly what the provider understood, so the difference is the set of keys that would be ignored — reject those with `INVALID_CONFIGURATION`.

Deliberate scoping:

- **Write time only.** `validateConfiguration` is shared with `IDPSignInManager`, `SignOutManager` and `IdpSessionRevalidator`. Tightening it there would reject stored configurations at sign-in and lock out users whose row predates the check. This runs in `IDPManager.addIDP` / `updateIDP` only, so existing rows keep authenticating; an update that does not submit a `configuration` is not re-validated (covered by a test).
- **All unknown keys at once**, rather than the first as `Typesafe.noExtraProps` would, so several typos take one round trip. Mirrors `findRemovedRuleKeys`.
- **Top level only.** Nested shapes that need strictness already validate themselves (`claimMapping` via `parseClaimMapping`).
- **Provider-agnostic** — driven purely by what each provider's parser keeps, so Apple/Facebook/OIDC are covered without per-provider changes. `IdPMock.validateConfiguration` returns its input verbatim, so existing tests built on it are unaffected.

`updateIDP` with `mergeConfiguration: true` validates the merged result, so a stray key already present in a stored row surfaces on the next configuration update. That is intentional: the error names the key and is actionable.

## Tests

`packages/engine-tenant-api/tests/cases/unit/idp/idpManagerUnknownConfigKeys.test.ts` — 5 cases covering the rejection on add and on merged update, the multi-key message, a fully-understood configuration still passing, and a non-configuration update not being re-validated. Uses the real `OIDCProvider` (its `validateConfiguration` is pure parsing, no network).

`bun test --conditions=typescript packages/engine-tenant-api` → 501 pass, 0 fail. Lint, dprint and `tsc --build packages/engine-tenant-api` clean.