### PR TITLE
feat(engine-tenant-api): compose the OIDC display name from given_name + family_name

### DIFF
--- a/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
+++ b/packages/engine-tenant-api/src/model/service/idp/providers/OIDCHelpers.ts
@@ -152,15 +152,45 @@ const normalizeClaims = (
 	// of whatever type, so OVERWRITE (don't conditionally add) with the mapped value when it is
 	// a string, otherwise `undefined` — a non-string claim must not leak through `...source`.
 	const email = getClaim(source, claimMapping?.email ?? 'email')
-	const name = getClaim(source, claimMapping?.name ?? 'name')
+	const name = resolveName(source, claimMapping)
 
 	return {
 		...source,
 		externalIdentifier,
 		email: typeof email === 'string' ? email : undefined,
-		name: typeof name === 'string' ? name : undefined,
+		name,
 		emailVerified,
 	}
+}
+
+/**
+ * Resolve the display name, falling back to `given_name` + `family_name` when there is no usable
+ * `name` claim.
+ *
+ * `name` is optional in OIDC core and plenty of providers omit it while sending the parts — Apereo
+ * CAS and Entra ID do, and so does Keycloak under its default mappers. Without the fallback,
+ * `CreatePersonCommand` lands on its own last-resort default and a federated person ends up named
+ * after the local part of their e-mail (`jan.novak`) despite the IdP having reported "Jan Novák".
+ * A single-path `claimMapping.name` cannot express this: the value has to be composed from two
+ * claims, not selected from one.
+ *
+ * An explicitly configured `claimMapping.name` is honoured as-is, fallback included — mapping a
+ * claim is a statement about where the name lives, and quietly substituting a different source
+ * would defeat it. A blank claim counts as absent: an empty string is not a display name, and
+ * treating it as one would keep the fallback (and `CreatePersonCommand`'s) from ever running.
+ */
+const resolveName = (source: Record<string, unknown>, claimMapping: OIDCClaimMapping | undefined): string | undefined => {
+	const mapped = getClaim(source, claimMapping?.name ?? 'name')
+	if (typeof mapped === 'string' && mapped.trim() !== '') {
+		return mapped
+	}
+	if (claimMapping?.name !== undefined) {
+		return undefined
+	}
+	const parts = [getClaim(source, 'given_name'), getClaim(source, 'family_name')]
+		.filter((part): part is string => typeof part === 'string' && part.trim() !== '')
+		.map(part => part.trim())
+	return parts.length > 0 ? parts.join(' ') : undefined
 }
 
 export const handleOIDCResponse = async (

--- a/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts
@@ -142,3 +142,57 @@ describe('handleOIDCResponse — non-string email/name do not leak', () => {
 		expect(result.email).toBeUndefined()
 	})
 })
+
+describe('handleOIDCResponse — display name', () => {
+	// `name` is optional in OIDC core and several providers (Apereo CAS, Entra ID, Keycloak under its
+	// default mappers) omit it while sending the parts. Without the fallback CreatePersonCommand lands
+	// on its own last-resort default and the person ends up named after their e-mail's local part.
+	test('composes the name from given_name + family_name when there is no `name` claim', async () => {
+		const client = stubClient({ sub: 's', email: 'jan@example.com', given_name: 'Jan', family_name: 'Novák' })
+		const result = await handleOIDCResponse(client, responseData)
+		expect(result.name).toBe('Jan Novák')
+	})
+
+	test('an explicit `name` claim still wins over the parts', async () => {
+		const client = stubClient({ sub: 's', name: 'Jan Novák ml.', given_name: 'Jan', family_name: 'Novák' })
+		const result = await handleOIDCResponse(client, responseData)
+		expect(result.name).toBe('Jan Novák ml.')
+	})
+
+	test('only one part present → that part alone, no stray whitespace', async () => {
+		expect((await handleOIDCResponse(stubClient({ sub: 's', given_name: 'Jan' }), responseData)).name).toBe('Jan')
+		expect((await handleOIDCResponse(stubClient({ sub: 's', family_name: 'Novák' }), responseData)).name).toBe('Novák')
+	})
+
+	test('blank / non-string parts are ignored rather than composed into whitespace', async () => {
+		expect((await handleOIDCResponse(stubClient({ sub: 's', given_name: '  ', family_name: '' }), responseData)).name)
+			.toBeUndefined()
+		expect((await handleOIDCResponse(stubClient({ sub: 's', given_name: ['Jan'], family_name: 3 }), responseData)).name)
+			.toBeUndefined()
+	})
+
+	test('a blank `name` claim falls back to the parts', async () => {
+		const client = stubClient({ sub: 's', name: '   ', given_name: 'Jan', family_name: 'Novák' })
+		expect((await handleOIDCResponse(client, responseData)).name).toBe('Jan Novák')
+	})
+
+	test('an explicitly mapped name claim is honoured as-is — no silent substitution', async () => {
+		// Mapping a claim states where the name lives; falling back to other claims would defeat that.
+		const client = stubClient({ sub: 's', displayName: 'Jan N.', given_name: 'Jan', family_name: 'Novák' })
+		expect((await handleOIDCResponse(client, responseData, { claimMapping: { name: 'displayName' } })).name).toBe('Jan N.')
+		const missing = stubClient({ sub: 's', given_name: 'Jan', family_name: 'Novák' })
+		expect((await handleOIDCResponse(missing, responseData, { claimMapping: { name: 'displayName' } })).name).toBeUndefined()
+	})
+
+	test('the parts are read after attributes-lifting, so a CAS-shaped userinfo works', async () => {
+		const client = stubClient(
+			{ sub: 's' },
+			{ sub: 's', attributes: { given_name: 'Jan', family_name: 'Novák' } },
+		)
+		const result = await handleOIDCResponse(client, responseData, {
+			fetchUserInfo: true,
+			claimMapping: { attributesKey: 'attributes' },
+		})
+		expect(result.name).toBe('Jan Novák')
+	})
+})


### PR DESCRIPTION
## Problem

`normalizeClaims` reads a single `name` claim:

```ts
const name = getClaim(source, claimMapping?.name ?? 'name')
```

But `name` is optional in OIDC core, and several providers omit it while sending the parts — Apereo CAS and Entra ID do, as does Keycloak under its default mappers. For those, `IDPResponse.name` is `undefined`, and `CreatePersonCommand` then applies its own last-resort default:

```ts
const name = this.data.name ?? this.data.email?.split('@')[0] ?? null
```

So a federated person ends up stored as `jan.novak` even though the IdP reported `given_name: "Jan"`, `family_name: "Novák"`.

`claimMapping.name` cannot work around it — it selects one claim path, and the value has to be composed from two.

Observed against an Apereo CAS deployment fronted by Entra ID, whose ID token carries `given_name` / `family_name` / `email` / `oid` but no `name`.

## Change

When there is no usable `name` claim, compose the display name from `given_name` + `family_name`. Read through `getClaim` on the already-lifted source, so a provider that nests its claims under an `attributes` object (CAS) is covered by the same path.

Deliberate behaviour:

- **An explicitly configured `claimMapping.name` is honoured as-is, fallback included.** Mapping a claim is a statement about where the name lives; quietly substituting a different source would defeat it. If the mapped claim is missing, the result stays `undefined`.
- **A blank claim counts as absent.** An empty string is not a display name, and treating it as one keeps both this fallback and `CreatePersonCommand`'s from ever running. This is the one small widening beyond the strict "claim missing" case.
- **Non-string parts are ignored**, consistent with how the existing code refuses to leak a non-string `name` through `...source`.
- Only one part present → that part alone, no stray whitespace.

No configuration surface is added, and providers that do send `name` are unaffected.

## Tests

7 cases appended to `packages/engine-tenant-api/tests/cases/unit/idp/oidcResponse.test.ts`: composition, `name` winning over the parts, single part, blank/non-string parts, a blank `name` falling through, an explicitly mapped claim not being substituted, and composition after attributes-lifting.

`bun test --conditions=typescript packages/engine-tenant-api` → 503 pass, 0 fail. Lint, dprint and `tsc --build packages/engine-tenant-api` clean.