### PR TITLE
fix(schema-utils): do not widen an ACL grant that names the primary key

### DIFF
--- a/packages/schema-utils/src/definition-generator/AclDefinitionCodeGenerator.ts
+++ b/packages/schema-utils/src/definition-generator/AclDefinitionCodeGenerator.ts
@@ -54,7 +54,7 @@ export class AclDefinitionCodeGenerator {
 
 	public generateEntityAcl({ entity, schema }: { entity: Model.Entity; schema: Schema }): string {
 		const aclOutput: string[] = []
-		const numberOfEntityFieldsWithoutId = Object.keys(entity.fields).length - 1
+		const nonPrimaryFields = Object.keys(entity.fields).filter(it => it !== entity.primary)
 		for (const [roleName, roleDefinition] of Object.entries(schema.acl.roles)) {
 			const entityPermission = roleDefinition.entities[entity.name]
 			if (!entityPermission) {
@@ -65,7 +65,8 @@ export class AclDefinitionCodeGenerator {
 				const operations = this.getMatchingOperations({
 					predicate: predicateName,
 					operations: entityPermission.operations,
-					numberOfEntityFieldsWithoutId,
+					entity,
+					nonPrimaryFields,
 				})
 				if (Object.keys(operations).length > 0) {
 					const processor = new PredicateDefinitionProcessor(schema.model)
@@ -87,7 +88,8 @@ export class AclDefinitionCodeGenerator {
 			const trueOperations = this.getMatchingOperations({
 				predicate: true,
 				operations: entityPermission.operations,
-				numberOfEntityFieldsWithoutId,
+				entity,
+				nonPrimaryFields,
 			})
 			if (Object.keys(trueOperations).length > 0) {
 				const aclDefinition = printJsValue({ ...trueOperations }, indentFirstLevel)
@@ -101,16 +103,17 @@ export class AclDefinitionCodeGenerator {
 		return `${aclOutput.join('')}`
 	}
 
-	private getMatchingOperations({ operations, predicate, numberOfEntityFieldsWithoutId }: {
+	private getMatchingOperations({ operations, predicate, entity, nonPrimaryFields }: {
 		operations: Acl.EntityOperations
 		predicate: Acl.Predicate
-		numberOfEntityFieldsWithoutId: number
+		entity: Model.Entity
+		nonPrimaryFields: string[]
 	}): { read?: string[] | true; create?: string[] | boolean; update?: string[] | boolean; delete?: true } {
 		const result: ReturnType<AclDefinitionCodeGenerator['getMatchingOperations']> = {}
 		for (const op of ['read', 'create', 'update'] as const) {
 			const fields = Object.entries(operations[op] ?? {}).filter(([, it]) => it === predicate).map(([it]) => it)
 			if (fields.length === 0) {
-			} else if (fields.length === numberOfEntityFieldsWithoutId) {
+			} else if (this.coversEveryNonPrimaryField(fields, entity, nonPrimaryFields)) {
 				result[op] = true
 			} else {
 				result[op] = fields
@@ -121,5 +124,18 @@ export class AclDefinitionCodeGenerator {
 		}
 
 		return result
+	}
+
+	/**
+	 * `read: true` re-parses as every field except the primary, so it may only stand in for a grant that
+	 * covers exactly that set. Comparing counts instead treated a grant naming the primary plus all but
+	 * one field as complete, and regenerating it silently granted the missing field.
+	 */
+	private coversEveryNonPrimaryField(fields: string[], entity: Model.Entity, nonPrimaryFields: string[]): boolean {
+		if (fields.includes(entity.primary)) {
+			return false
+		}
+		const granted = new Set(fields)
+		return nonPrimaryFields.every(it => granted.has(it))
 	}
 }

--- a/packages/schema-utils/tests/cases/unit/tsDefinitionGenerator.test.ts
+++ b/packages/schema-utils/tests/cases/unit/tsDefinitionGenerator.test.ts
@@ -73,3 +73,39 @@ test('definition generator round-trips per-column index options', () => {
 	expect(generated).toContain(`@c.Index({ fields: ['title', { field: 'rank', order: 'desc', nulls: 'last' }] })`)
 	expect(generated).toContain(`@c.Index({ fields: [{ field: 'title', opClass: 'text_pattern_ops' }] })`)
 })
+
+namespace ExplicitPrimaryReadModel {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: ['id', 'a'] })
+	export class Article {
+		a = c.stringColumn()
+		b = c.stringColumn()
+	}
+}
+
+test('definition generator does not widen a grant that names the primary key', () => {
+	const generator = new DefinitionCodeGenerator()
+	const generated = generator.generate(createSchema(ExplicitPrimaryReadModel))
+	// regression: the `read: true` collapse compared counts, and `fields` includes the primary while
+	// `numberOfEntityFieldsWithoutId` excludes it - so `{id, a}` on a two-column entity collapsed to
+	// `read: true`, which re-parses as `{a, b}` and grants `b`.
+	expect(generated).toContain(`@c.Allow(editorRole, {\n\tread: ['id', 'a'],\n})`)
+	expect(generated).not.toContain(`@c.Allow(editorRole, {\n\tread: true,\n})`)
+})
+
+namespace FullReadModel {
+	export const editorRole = c.createRole('editor')
+
+	@c.Allow(editorRole, { read: true })
+	export class Article {
+		a = c.stringColumn()
+		b = c.stringColumn()
+	}
+}
+
+test('definition generator still collapses a grant covering every non-primary field', () => {
+	const generator = new DefinitionCodeGenerator()
+	const generated = generator.generate(createSchema(FullReadModel))
+	expect(generated).toContain(`@c.Allow(editorRole, {\n\tread: true,\n})`)
+})


### PR DESCRIPTION
`AclDefinitionCodeGenerator.getMatchingOperations` decides whether a grant covers every field by comparing counts. `numberOfEntityFieldsWithoutId` excludes the primary key, but the matched `fields` include it whenever the grant names it, so the comparison is off by one.

## Reproduction

```ts
@c.Allow(editorRole, { read: ['id', 'a'] })   // entity Article { a, b }
```

```
stored:      read = { id: true, a: true }
regenerated: @c.Allow(editorRole, { read: true })
re-parsed:   read = { a: true, b: true }
```

`b` was never granted and becomes readable. Silent, and in the widening direction.

Reachable from an ordinary definition that lists `id` explicitly, and from any hand-written or migrated ACL carrying `id: true`. Generally: the collapse fires whenever the fields matching a predicate — the primary included — happen to number as many as the entity has non-primary fields, i.e. when a grant covers the primary plus all but one of them. The missing one is added.

## Fix

The collapse now compares against the entity's actual non-primary field set instead of a count, and declines when the grant names the primary explicitly — `read: true` re-parses as every field except the primary, so it cannot stand in for a grant that says otherwise. A grant covering exactly the non-primary fields still collapses, which is the shape a definition round trip produces.

## Tests

Two cases in `tsDefinitionGenerator.test.ts`:

- a grant naming the primary is not widened — **verified to fail against the unfixed generator** (1 fail / 10 pass), so it pins the regression rather than describing it;
- a grant covering every non-primary field still collapses — a guard against over-correction; it passes either way by design.

## Verification

`bun test --conditions=typescript packages/schema-utils/tests` → 115 pass / 0 fail. `tsc --build packages/schema-utils/tests` → clean. dprint and biome clean.

Not verified: no e2e, and no consumer of the generator exists in this repo — it is public API from `@contember/schema-utils`, so the blast radius is external tooling.

## Note

Unrelated to the ACL `through` work on `feat/acl-through-scope`, but it touches the same file. Merging this first and rebasing that branch is the simpler order; the collapse fix then applies to the `through` bucket too, since both buckets go through `getMatchingOperations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WyFtUkwCxBvEH5S6Y9FA3
