### PR TITLE
docs: agent notes for build, CI, e2e, panel and ACL read paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,37 @@ bun --conditions=typescript scripts/dev/seed-local.ts
 - **Scoped packages**: All packages are published as `@contember/{name}`.
 - **Internal deps**: Use `workspace:*` references; external deps are version-centralized via workspace catalog in root `package.json`.
 
+## Generated Artifacts
+
+Several **tracked** files are build output. Never hand-edit them, and never commit their regenerated form.
+
+| Artifact | Produced by | Committed as |
+|---|---|---|
+| `packages/graphql-client-{tenant,system,actions}/src/generated` | `bun run pre-build` (from the tenant/system SDL) | small stubs (2–6 lines each) |
+| `packages/engine-panel/src/generated/assets.ts` | `bun run panel:assets` | 379-byte stub |
+| `packages/engine-{tenant,system}-api/src/schema/index.ts`, `src/migrations/snapshot.ts` | codegen / snapshot scripts | the real file (see the package's CLAUDE.md) |
+| `packages/create/resources/templates/default/admin/lib/` | `assemble-ui-lib.mjs` at pre-build | gitignored, not committed at all |
+
+`scripts/setup.sh` marks the stub files **`assume-unchanged`** (`git ls-files -v` shows a lowercase `h`) so local build output stays out of `git status`. Consequences:
+
+- A **fresh worktree does not have that bit**, so after `pre-build` those files show up as modified. That churn is a build artifact — restore it with `git checkout HEAD -- packages/graphql-client-*/src/generated`.
+- Mid-rebase this bites hard: *any* unstaged change makes `git rebase --continue` abort with `You must edit all merge conflicts and then mark them as resolved` even though nothing is unmerged and no conflict markers exist. Restore the generated files first, then continue.
+- **`git add -f` overrides `assume-unchanged`.** Rewriting history (`git reset` + re-add, squash) therefore commits whatever the working tree holds — after a build that is megabytes of generated client instead of the stub. Tag a backup before any rewrite (`git tag backup/<branch> HEAD`), verify `git diff --stat backup/<branch> HEAD` is empty before pushing, then re-run `bash scripts/setup.sh` to restore the bits.
+
+A bundle entrypoint that imports a generated client must run `pre-build` itself — both `scripts/cli-build/run.sh` and `scripts/server-build/run.sh` do (panel-ui imports the fetchers as values, so a clean checkout would otherwise bundle `undefined`).
+
+## CI
+
+- The `check` job is a **fail-fast matrix** (format, lint, build, test, lint-imports, api-exporter). One failing entry cancels the rest, and `gh pr checks` renders cancelled as `fail`, so a single error looks like five. Read the real conclusions first:
+  ```bash
+  gh run view <runId> --json jobs -q '.jobs[] | [.conclusion, (.name|gsub("\n";" "))] | @tsv'
+  ```
+- **`test-db (12..16)` is the e2e suite**, not unit-test shards — one job per PostgreSQL major, each building the server, starting it, and running `bun run test:e2e`. Also fail-fast. See `e2e/CLAUDE.md`.
+- `snapshot` verifies the committed tenant/system migration snapshots against a replay of the migrations; `migration-order` rejects a new migration whose filename sorts before the newest one on the base branch (pure git). See `packages/engine-tenant-api/CLAUDE.md`.
+- **The workflow triggers on `pull_request`, pushes to `main`, and tags only** (`docs/**`-only PRs are skipped via `paths-ignore`). Pushing a feature branch verifies nothing; open the PR.
+- `lint-imports` runs `bunx deptective`, which catches missing workspace dependencies that `tsc` does not — a transitively reachable import typechecks fine and still fails this job.
+- `api-exporter` compares `build/api/*.api.md`, which `ts:build` and `test` do NOT regenerate. Changing a public surface (including one *generated* from the tenant SDL) leaves the report stale — run `bun run ae:update` and commit the diff.
+
 ## Testing
 
 - **Framework**: `bun test` (Bun's built-in test runner):
@@ -90,8 +121,10 @@ bun --conditions=typescript scripts/dev/seed-local.ts
 
 ## Code Style
 
-- **Formatter**: dprint — tabs, single quotes, 150 char line width.
+- **Formatter**: dprint — tabs, single quotes, 150 char line width. It has no markdown plugin, so `format:check` ignores `.md`/`.mdx`.
 - **Linter**: Biome — recommended ruleset with project-specific overrides.
+- **Import extensions**: relative imports carry an explicit `.js` (`useImportExtensions: error`), directory barrels as `/index.js`. This applies to test files too, which a source-only review easily misses.
+- A nested `biome.json` anywhere inside the repo (e.g. a scratch git worktree checked out under the repo root) breaks repo-wide `bun run lint` with "nested root configuration". Lint your files directly (`bunx biome lint <files>`) until it is removed.
 - **Commits**: Conventional Commits format, e.g. `fix(content-api): handle null in orderBy`.
 
 ## Module-Specific Context

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,26 @@
+# docs
+
+The public documentation at https://docs.contember.com/ — an in-repo static site built with **pletivo** (previously Docusaurus, then Astro Starlight; older notes and file headers still mention those).
+
+- Pages are `.mdx` under `src/content/docs/`, organized as `intro/`, `guides/`, `reference/`, `cloud/`.
+- The tenant API is documented page-per-topic under `reference/engine/tenant/`; the admin-UI and data-binding side under `reference/interface/`.
+- `src/lib/nav.ts` is the navigation tree — leaf `id`s are collection entry ids (the path under `src/content/docs/` without `.mdx`). Folding new operations into an existing page needs no nav change; a **new page** must be added there or it is unreachable.
+
+```bash
+bun run --cwd docs dev        # pletivo dev on :3010
+bun run --cwd docs build      # compiles the site — the only way to catch broken mdx
+bun run --cwd docs typecheck
+```
+
+## Conventions
+
+- **Version-gate new features** with an admonition — `:::note[Available since X.Y]` then `:::`. The `[...]` label is parsed as inline markdown, so backticks work (`reference/engine/schema/columns.mdx` uses them). The current unreleased version is **2.2** (root `package.json`, `2.2.0-alpha.x`), which is what the whole tenant reference is stamped with — match it for new tenant features unless told otherwise.
+- Admonition kinds are `note`, `tip`, `info`, `warning`, `caution`, `danger` (`src/lib/remark-admonitions.ts`). The Docusaurus `:::note Some Title` form (trailing title text) is **not** valid remark-directive syntax — use the bracket form.
+- Canonical shape for a listing/query page: a GraphQL example, a field table, and one line on per-caller visibility (whether a caller without permission gets an empty list or an error). `reference/engine/tenant/sessions.mdx` is the template.
+- Document a **PostgreSQL extension prerequisite** here rather than installing it from a migration — see `packages/schema-migrations/CLAUDE.md`. The trigram operators in `reference/engine/content/queries.mdx` and `reference/engine/schema/columns.mdx` are the pattern.
+
+## CI
+
+**PR CI ignores `docs/**`** (`paths-ignore` in `.github/workflows/build.yaml`), so a docs-only change runs no checks in this repo — build the site locally before pushing. dprint has no markdown plugin either, so `format:check` never looks at `.md`/`.mdx`.
+
+Per-package `CLAUDE.md` files are agent-facing notes and a separate thing from this site; do not move content between them without deciding which audience it is for.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,75 @@
+# e2e
+
+Integration tests that run against a **live engine and PostgreSQL**, not against mocks. In CI this is the `test-db (12..16)` matrix — one job per PostgreSQL major, each building the server, starting it via `start-server.sh` and running `bun run test:e2e`. It is fail-fast, and like the rest of the workflow it runs on `pull_request`, pushes to `main` and tags — never on a plain branch push.
+
+`test-db` is therefore the only place where authorization grants, resolvers and SQL meet for real — a feature covered solely by unit and mocked tests is not covered here.
+
+## Running locally
+
+Bring up the engine (it pulls in postgres; **mailhog is not a dependency** — start it explicitly or the tester fails on `/api/v1/messages`):
+
+```bash
+docker compose up engine mailhog --detach
+```
+
+Resolve the host ports — compose does not necessarily bind the canonical ones:
+
+```bash
+docker compose port engine 4000     # e.g. 0.0.0.0:3001
+docker compose port mailhog 8025    # e.g. 0.0.0.0:3006
+```
+
+Then run a scoped subset:
+
+```bash
+CONTEMBER_API_URL="http://localhost:3001" \
+CONTEMBER_ROOT_TOKEN="0000000000000000000000000000000000000000" \
+CONTEMBER_LOGIN_TOKEN="1111111111111111111111111111111111111111" \
+MAILHOG_URL="http://localhost:3006" \
+NODE_ENV=development \
+bun test --conditions=typescript --no-file-parallelism e2e/cases/tenant/policy.test.ts
+```
+
+- `--conditions=typescript` is required — without it `@contember/*` resolves to a stale `dist`.
+- **`NODE_ENV=development` matters on the *test* process.** Some cases branch on it to pick the expected message (`tenant-member-access.test.ts` expects "You are not allowed to access project X" in dev, "Project X NOT found" otherwise). The compose engine runs in development, CI runs the server in production; a mismatch looks like a regression.
+- The engine runs `bun --watch` over mounted source, so editing or formatting files mid-run restarts it.
+- **A full local `bun run test:e2e` is not realistic on a developer machine.** 64 files run in parallel against one PostgreSQL at its default `max_connections=100`; the engine starts answering `sorry, too many clients already` and dozens of cases fail with `ECONNREFUSED`. Run subsets with `--no-file-parallelism` and leave the full suite to CI.
+- Always capture a **baseline without your new file** before judging failures — a fresh empty tenant DB alone makes a handful of unrelated cases fail (authLog, mfaEnforcement, sessionPolicy, migrations-snapshot).
+- Never pipe a `bun test` run through `head`: SIGPIPE kills it mid-test, its `finally` cleanup never runs, and the leftover scratch dirs and DB rows look like a bug in your test. Redirect to a file.
+
+## When the engine will not boot: migration drift
+
+A persistent local tenant DB records whichever migrations the last branch carried. On a branch that lacks one of them, `checkOrder` aborts the boot with **`Previously executed migration is missing`**. This is drift, not corruption — it recovers on the original branch.
+
+Check what is actually recorded before assuming which migration it is:
+
+```bash
+docker compose exec -T postgres psql -U contember -d tenant -c "select name from tenant.migrations order by name desc limit 10;"
+ls packages/engine-tenant-api/src/migrations/*.ts | xargs -n1 basename | sed 's/\.ts$//' | grep '^20' | sort | tail -10
+```
+
+Do **not** delete or rename the bookkeeping row — real data sits behind it, and renaming just moves the failure (the repo has migrations sorting before the new timestamp).
+
+The clean workaround is a throwaway engine over an empty tenant DB on its own port, so nothing persistent is touched:
+
+```bash
+docker compose exec -T postgres psql -U contember -d postgres -c "CREATE DATABASE e2e_tenant;"
+docker compose run -d -e TENANT_DB_NAME=e2e_tenant -p 3110:4000 --name e2e-engine engine   # no --rm: keep the logs if it dies
+# … run tests against http://localhost:3110 …
+docker rm -f e2e-engine
+docker compose exec -T postgres psql -U contember -d postgres -c "DROP DATABASE IF EXISTS e2e_tenant;"
+```
+
+Stop the compose `engine` first if it is crash-looping — both hold connections. Wiping the volume (`docker compose down -v`) also works, but destroys local data.
+
+## Writing tests
+
+**The `gql` tag in `src/tester.ts` is not a GraphQL parser.** It is `assert.strictEqual(strings.length, 1); return strings[0]`, and exists only so formatters recognize the query. An interpolation makes `strings.length === 2` and throws `AssertionError: 2 !== 1` *before the request is sent* — the stack points at `gql (tester.ts:22)`, which reads like a row-count mismatch.
+
+For dynamic values use GraphQL variables via the tester's `{ variables }` option (see `executeMigrations`), or a static literal when the value is irrelevant (asserting that an entity exposes no update mutation 400s on the unknown field regardless of the id).
+
+Cover DB-serialization concerns here rather than in unit tests — a mapper unit test cannot see how a value lands in PostgreSQL.
+
+## Known flake
+
+`cases/tenant/disablePerson.test.ts` → `disablePerson blocks future signIn with PERSON_DISABLED` fails intermittently on a **single** `test-db` shard while the others pass on identical code. The assertion prints only `body.data`, so the underlying GraphQL error is invisible. Re-run before investigating (`gh run rerun <runId> --failed`). If it ever fails on several shards at once that is real — dump `body.errors` at the assertion; the test signs in during setup, so a sign-in rate limit is the first suspect.

--- a/packages/create/CLAUDE.md
+++ b/packages/create/CLAUDE.md
@@ -1,0 +1,22 @@
+# create
+
+`npm create @contember/…` scaffolder. The project template lives in `resources/templates/default/` — `admin/`, `api/`, `client/`, `docker/` and the compose/config files a new project starts from.
+
+## `admin/lib` is generated, not source
+
+`resources/templates/default/admin/lib/` is **gitignored** (root `.gitignore`) and assembled at pre-build by `resources/templates/default/scripts/assemble-ui-lib.mjs`:
+
+```bash
+bun run --cwd packages/create pre-build     # refresh it after changing a UI package
+```
+
+The script merges `react-ui-lib-base` (flat) + `react-ui-lib-tenant` (into `tenant/`) + `react-ui-lib` (flat), rebuilds the colliding `index.ts` / `form/index.ts` barrels, and rewrites `@contember/react-ui-lib-base` → `~/lib` and `@contember/react-ui-lib-tenant` → `~/lib/tenant`. A generated project owns that tree outright, which is the point — the user customises it freely.
+
+**Why this trips people up:** the output looks byte-identical to the package sources except for the imports, so it reads like a hand-maintained copy that has drifted. It has not — a diff against the packages only tells you which branch was last built. Never mirror files into it by hand and never commit it.
+
+Two consequences:
+
+- **The template is not typechecked by CI** (it has no `node_modules`). To verify template code, temporarily add `customConditions: ["typescript"]` to `admin/tsconfig.json` (it already maps `~/*`) — node resolution then finds the repo-root `node_modules` and the workspace packages' sources. Expect unavoidable errors for `import.meta.env` / `glob`, `index.css` and `@sentry/react`.
+- Because base's dictionary lands at `~/lib/dict` and tenant's at `~/lib/tenant/dict`, template code reading `dict.tenant.*` must import the latter.
+
+Only `admin/app/`, `admin/entrypoint/` and the other tracked template directories are real source.

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -16,6 +16,12 @@ All builders are **immutable** — each method returns a new instance.
 
 Builders compile to `Literal` objects (SQL string + parameters array). The `Compiler` handles schema context, CTE alias tracking, and `__SCHEMA__` placeholder replacement.
 
+## Writing to a jsonb column
+
+`JSON.stringify` the value before passing it to `InsertBuilder.values(...)`. `pg` serializes a JS **object** as JSON (correct for jsonb) but a JS **array** as a PostgreSQL array literal (`{...}`), which corrupts the column — an empty `[]` comes back as `{}`, no longer an array. Stringifying makes pg send text, which the implicit text→jsonb assignment cast parses correctly. `engine-actions`' `EventsRepository` does this for its `log` column.
+
+This is invisible to a mapper unit test; cover a new raw jsonb write with an e2e assertion.
+
 ## Connection Management
 
 - `Connection.create(config)` — pool-based (default 10 connections)

--- a/packages/engine-content-api/CLAUDE.md
+++ b/packages/engine-content-api/CLAUDE.md
@@ -36,6 +36,12 @@ Row-level and field-level security via predicate injection into every SQL operat
 - `PredicatesInjector` — ANDs user predicates with ACL predicates on every query
 - `VariableInjector` — replaces variable references with identity-specific values
 
+### Read-path guarding
+
+- `PredicateFactory.getFieldPredicate(...)` resolves a field's ACL predicate; `getPermissionsForContext(isRoot)` picks the permission set — root-only unless the caller passes `isRoot === false` (nested/relation context), which adds `through: true` permissions (`allPermissions`). An unknown context falls back to the narrower root set, so the two sets can **over-restrict, never leak**.
+- Projection cell-masking happens during JS hydration (`SelectBuilder` maps `row => predicateGetter(row) ? row[alias] : null`), not in SQL. The predicate boolean column is also consumed by relation fetching (`getColumnValues`) and by the hydrator, so moving the mask into the SQL expression is not a local change.
+- **`WhereOptimizer`'s `isLast` handling is deliberately conservative.** The obvious one-line "fix" (`Number(i) === relationPath.length` → `- 1`) drops the has-many `EXISTS` requirement, collapsing `{ articles: { author: { id: { isNull: false } } } }` to `{ id: { always: true } }` — an over-match. Verified empirically; it needs a real optimizer change, not a tweak.
+
 ## GraphQL Schema Building
 
 `GraphQlSchemaBuilderFactory` → `GraphQlSchemaBuilder`:

--- a/packages/engine-panel/CLAUDE.md
+++ b/packages/engine-panel/CLAUDE.md
@@ -1,0 +1,29 @@
+# engine-panel
+
+Serves the management panel (`packages/panel-ui`) **from inside the engine**, so a self-hosted deployment gets one without a separate admin app. Off by default: `CONTEMBER_PANEL_ENABLED`, mount path via `CONTEMBER_PANEL_PATH` (absolute, e.g. `/panel`).
+
+- `PanelPlugin` — wires everything into the HTTP application.
+- `PanelController` / `PanelAssets` — serve the shell and the embedded static assets.
+- `PanelApiController`, `PanelMount`, `PanelAccessCheck` — the panel-scoped API mount and its gate.
+
+## Constraints that shaped it
+
+- **The runtime docker image contains only `dist/start.js`** (`scripts/docker/server-*.dockerfile`), so the UI cannot be a directory of files. Assets are gzipped, base64'd into `src/generated/assets.ts` and bundled. The panel asset build is deliberately **not** a `pre-build` hook (the root `pre-build` fans out to every package, which would tie the CLI image to panel-ui), so `scripts/server-build/run.sh` — which the server dockerfiles run — calls `build:assets` explicitly after `pre-build`.
+- `src/generated/assets.ts` is a **tracked 379-byte stub** rewritten by `bun run panel:assets`, kept out of `git status` by `scripts/setup.sh` (assume-unchanged). See the repo-root CLAUDE.md — committing the regenerated form bakes the whole UI into git history.
+- The payload rides in the binary for every deployment, panel or not. The placeholder measured **+86 kB on a 6.5 MB bundle**; a full admin app (~483 kB gzipped) is the practical ceiling, so modules must stay lazy chunks.
+- **Static assets go through `addInternalRoute`, not `addRoute`** (`PanelPlugin.ts`). A regular route authenticates before dispatch — that would mean a project-group resolve and an API-key DB verification *per file request*.
+- **Relative Vite `base` plus an injected absolute `<base href>`** is what makes the mount path configurable at runtime (`__CONTEMBER_PANEL_BASE__` / `__CONTEMBER_PANEL_CONFIG__` placeholders). Vite then resolves lazy chunks via `import.meta.url`, so route depth cannot break asset URLs.
+- **Project scope is just `ProjectSlugContext` + `StageSlugContext`** swapped under a route. Every client hook builds `${apiBaseUrl}${path}`, so mounting the whole API under `<base>/api` makes tenant, content, system and actions work with no client change. Stage appears in the URL on content routes only.
+- **Plugins reach the panel through `PanelApiMount`**, a service declared in `engine-http` with a no-op default (`DisabledPanelApiMount`) and replaced by `PanelMount` here. `engine-actions` consumes it — the dependency runs plugin → panel, never back. The shell renders on the first request rather than at construction, so a plugin mount registering after the panel's hook still reaches the UI via `pluginApis`.
+
+## Gotchas worth keeping
+
+- **A denied read from a panel-mounted API arrives as HTTP 400, never 403.** `ForbiddenError extends GraphQLError`, and `processErrors` grades a `GraphQLError` 400 before it reaches the 403 branch. 403 belongs to the panel gate alone, which is what `isPanelAccessDenied` relies on.
+- **`__typename` is not selectable through the generated graphql-ts-client fetchers** — `event$.__typename` is `undefined` at runtime although the `.d.ts` declares it. Discriminate a union by a field only one member carries.
+- **`EventsArgs.stage` (system API) does not filter events.** It only picks whose ACL the read is checked against; `EventsQuery` joins `stage_transaction` without constraining on it.
+- **A project `deployer` cannot enter the panel at all** under the default policy (`projectRoles: ['admin']`), so the deployer branch of a module's `isAvailable` is not exercisable without changing `panel.projectRoles`.
+- Query layers are **generated typed clients** (`graphql-client-actions` mirrors `graphql-client-system`), not hand-written query strings and not full `react-client-*` hook packages.
+
+Access control model: the env flag decides availability, the **tenant** `Config.panel { globalRoles, projectRoles }` (stored tenant configuration, resolved by `PanelAccessResolver`) decides who may enter, and the tenant ACL is the actual boundary. Panel login is password + OTP only — IdP redirect URLs and `ConfigPasswordless.url` point at the public-facing app.
+
+Local seeding for panel work: `bun --conditions=typescript scripts/dev/seed-local.ts` (see `e2e/CLAUDE.md` if the engine refuses to boot on migration drift).

--- a/packages/engine-tenant-api/CLAUDE.md
+++ b/packages/engine-tenant-api/CLAUDE.md
@@ -106,3 +106,27 @@ Regenerate (works from any worktree; needs `docker compose up -d postgres` + loc
 The script runs the migrations with local `bun` against the current checkout (so it picks up THIS branch's migrations, not whatever the engine container has mounted), auto-discovers the running postgres container, dumps the schema, and formats the result. Do NOT run migrations inside the `engine` container for this — it mounts the main repo, not your worktree.
 
 Verify the snapshot matches the migrations by bootstrapping two fresh DBs — one with `CONTEMBER_MIGRATIONS_NO_SNAPSHOT=1` (replays migrations), one without (uses the snapshot) — and diffing `pg_dump` of both; they must be schema-identical.
+
+**Migration order is forward-only.** The `migration-order` CI job (`scripts/migrations/check-migration-order.sh`, pure git, no DB) rejects any PR whose new migration filename sorts at or before the newest migration already on the base branch — otherwise a fresh DB and an upgraded DB would replay them in a different relative order. Rebasing an older branch onto a main that has gained a migration is what usually trips it, and `bun test`, `tsc` and a local snapshot regen all stay green. Check with `./scripts/migrations/check-migration-order.sh origin/main`; fix by re-timestamping — `git mv` the file to a current `YYYY-MM-DD-HHMMSS-<name>.ts`, update the import, key and position in `runner.ts`, then regenerate the snapshot. For additive, independent migrations it comes back byte-identical; verify with a zero-diff regen.
+
+**The snapshot script discovers its database by container label** (`docker ps --filter label=com.docker.compose.service=postgres | head -n1`). With more than one compose project running it grabs whichever sorts first and dies on `role "contember" does not exist` — cleanly, with no writes, so it reads as broken tooling rather than the wrong database. Name it explicitly, and serialize concurrent runs because the script uses a fixed `migration_snapshot` database:
+
+```bash
+SNAPSHOT_PG_CONTAINER=contember-oss-postgres-1 ./scripts/create-migrations-snapshot/run.sh tenant
+flock /tmp/contember-tenant-snapshot.lock ./scripts/create-migrations-snapshot/run.sh tenant   # when several jobs may run it at once
+```
+
+## Mocked SQL tests
+
+`tests/cases/integration/mocked/**` assert against **exact** mocked SQL (`ExpectedQuery`). When a shared query changes shape on main, a branch that hard-codes the old SQL fails with `Expected query #1 does not match SQL` — with no textual conflict and no type error, so only `bun test` catches it. This is the classic post-rebase failure here (e.g. the person-by-identity query gaining the `person_mfa` join and the `totp_*` / `email_otp_enabled` / `mfa_grace_until` columns).
+
+Copy the current SQL from the shared helper (`tests/cases/integration/mocked/sql/getPersonByIdentity.ts`) verbatim — whitespace and case are normalized by the `SQL` tag — and update the duplicated response columns. Better still, have such a helper reuse the shared one rather than duplicating it.
+
+## Conventions for new tenant features
+
+- **Audit at the resolver layer.** The one exception is `ApiKeyManager.verifyAndProlong`, a hot path that emits its own events.
+- **`AuthActionType` enum values are added in the migration that wires their call site** (`ALTER TYPE ADD VALUE`), never reserved ahead of use. The auth-log payload column is `event_data`, plain `{ before, after }` JSON.
+- **A new mail template ships its migration and its default template in the same PR.**
+- **MFA TOTP must work without an encryption key.** With no `CONTEMBER_ENCRYPTION_KEY` the version-0 plaintext fallback applies; encryption engages when a key is present, gated by `providers.encryptionEnabled` (from `CryptoWrapper.enabled`).
+- Existing behavior stays unchanged: new capability is gated by config or policy, with defaults matching today.
+- **An SDL change reaches beyond this package.** `graphql-client-tenant` is generated from the SDL at build time and surfaces transitively in `react-client-tenant`, whose `build/api/react-client-tenant.api.md` **is** committed and checked by the `api-exporter` CI job. So adding a field can fail `ae:test` with "You have changed the API signature for this project" while `bun test` and `ts:build` pass — regenerate with `bun run ae:update` (Docker) and commit the diff.

--- a/packages/react-binding/CLAUDE.md
+++ b/packages/react-binding/CLAUDE.md
@@ -55,3 +55,11 @@ React components declare what data they need via `<Field>`, `<HasOne>`, `<HasMan
 3. Executes via ContentClient
 4. Merges response into `TreeStore.persistedData`
 5. Fires `persistSuccess` events, clears dirtiness
+
+### Entity keys migrate on persist — do not cache them
+
+A newly created entity's realm key carries a `C-` prefix that is deliberately replaced with the server id on persist (`OperationsHelpers.changeRealmId` and `TreeAugmenter` in `binding-legacy`). The realm object is re-keyed **in place**, so anything holding the *realm* (the `getAccessor` getter from `EntityKeyContext`) keeps working, while anything holding the *key string* goes stale and blows up with `Trying to retrieve a non-existent entity: key 'C-…'`.
+
+This bites hardest in consumers that cache element trees and never re-render them — Slate editors are the canonical case. **Provide reference entities via the stable `getAccessor` getter, never by storing the key.**
+
+Known limitation, tracked in issue #922: `purgeStaleListenersAfterIdChange` drops `update` / `connectionUpdate` listeners on migrated realms, and because getter identity is stable, consumers inside reference elements never resubscribe — stale UI, no data loss. Relaxing the purge in core needs dedicated persist+listener tests; there is a 2022 revert precedent for doing it carelessly.

--- a/packages/react-client-tenant/CLAUDE.md
+++ b/packages/react-client-tenant/CLAUDE.md
@@ -33,6 +33,8 @@ Each hook defines a fragment with the `TenantApi.x$` / `x$$` fetchers, derives i
 
 ## Public API surface
 
-`react-client-tenant.api.md` (in `build/api`) is checked by the `api-exporter` CI job. After adding/removing exports, regenerate it with `bun run ae:update` and commit the diff.
+`react-client-tenant.api.md` (in `build/api`) is checked by the `api-exporter` CI job. After adding/removing exports, regenerate it with `bun run ae:update` and commit the diff. A change to the **engine's tenant SDL** can shift this surface too, through the generated client — so an SDL-only PR can fail `api-exporter` while `bun test` and `ts:build` pass.
+
+The package has a single `"."` export, so anything missing from the `src/index.ts` barrel is unreachable for consumers.
 
 See [tenant API reference](https://docs.contember.com/reference/engine/tenant/overview) for the underlying operations.

--- a/packages/react-ui-lib-tenant/CLAUDE.md
+++ b/packages/react-ui-lib-tenant/CLAUDE.md
@@ -47,7 +47,7 @@ Two things differ from the listings:
 ## Conventions
 
 - **Data**: `useTenantQueryLoader(useXQuery(), variables)`, then `switch (query.state)` over `loading | refreshing | success | error`. Project-scoped lists read the slug via `useProjectSlug()`.
-- **i18n**: a single static `dict.ts` (no message formatter). Components read `dict.tenant.*`; add new strings there.
+- **i18n**: a single static `dict.ts` (no message formatter). Components read `dict.tenant.*`; add new strings there. `react-ui-lib-base` also exports a `dict`, and `react-ui-lib` star-exports both packages — so this one must be re-exported under a distinct name (`tenantDict`), or ES ambiguity silently drops it.
 - **Error messages**: `dict.tenant.commonErrorMessages` covers the codes any form or action can raise (`UNKNOWN_ERROR`, `FORBIDDEN`). `TenantFormError` falls back to it, so a per-form `errorMessages` map does not have to list them; a one-shot action passes its `onError` code through `actionErrorMessage` (`errors.ts`) instead. Do not paper a denial over with the generic "failed" line — the user cannot retry their way out of one.
 - **UI primitives** come from `@contember/react-ui-lib-base`; icons from `lucide-react`. Styling is Tailwind utility classes inline.
 - **`useTenantQueryLoader` memoizes variables only one level deep** (`useObjectMemo`, plain `!==` per key) — a nested object (e.g. `AuthLogList`'s `filter`) must be `useMemo`'d by the caller, or a new object identity every render defeats the memo and the component refetches in a loop. See `auth-log-list.tsx` / `persons-list.tsx` for the pattern.

--- a/packages/schema-migrations/CLAUDE.md
+++ b/packages/schema-migrations/CLAUDE.md
@@ -40,6 +40,22 @@ interface Migration {
 - **Relation type visitors**: Different SQL for different relation types (ManyHasOne → FK column, ManyHasManyOwning → junction table, inverse → no SQL)
 - **Version tracking**: Format versions control backward-compatible behavior changes
 
+## PostgreSQL extensions
+
+Contember deliberately does **not** run `CREATE EXTENSION` from schema or system migrations. A feature that needs one (the `similar` / `wordSimilar` trigram operators, the `gin_trgm_ops` index `opClass`) only documents the prerequisite; enabling it is a one-off operator task per database.
+
+Extensions typically require superuser, behave differently on managed PostgreSQL, and a failed `CREATE EXTENSION` mid-migration is hard to roll back — auto-installing one could break the migration run itself. Document the requirement in the relevant docs page with a `:::caution[...]` admonition instead (see `docs/CLAUDE.md`).
+
+## View updates
+
+A view whose SQL changed used to drop and recreate its entire dependant cascade, re-emit full entity definitions and re-patch all ACL — a single view change could produce a 50–170 kB migration. Cause: `RemoveViewDiffer` + `CreateViewDiffer` always took the destructive path, and `removeEntity` stripped the entity's ACL for `UpdateAclSchemaDiffer` to add straight back.
+
+`UpdateViewDiffer` (with `isReplaceableViewChange` in `modifications/utils/viewDependencies.ts`, wired into `SchemaDiffer` after `CreateViewDiffer`) now emits a single `updateView` (`CREATE OR REPLACE VIEW`) for SQL-only and view-metadata changes on non-materialized views — no dependant cascade, no ACL re-patch. Materialized views and structural changes still cascade.
+
+**`CREATE OR REPLACE VIEW` is narrower than it looks** (verified on PG16): the new query must produce the same column names, in the same order, with the same types, and may only append at the end. Any deviation is a hard error (SQLSTATE 42P16) and transactional — column reorder, middle insert, and *any* type change including widening (`int`→`bigint`, `varchar(10)`→`varchar(20)`, `text`→`varchar`, `int`→`numeric`) all fail.
+
+`isReplaceableViewChange` compares Contember `fields`, which is **necessary but not sufficient**, because a view's real column types and order come from the SQL body rather than the field metadata. The two residual cases — a SQL column reorder with an unchanged field set, and output-type drift without a matching field-type change — fail loudly at execute time, before any data is touched, never silently; both imply a schema/SQL inconsistency that the old drop-and-recreate masked.
+
 ## Key Files
 
 - `SchemaDiffer.ts` — main differ orchestrator

--- a/scripts/create-package/update-tsconfig.ts
+++ b/scripts/create-package/update-tsconfig.ts
@@ -7,7 +7,8 @@ const tsconfig = join(root, 'tsconfig.json')
 
 const tsconfigJson = JSON.parse(fs.readFileSync(tsconfig, 'utf-8'))
 
-const packages = fs.readdirSync(join(root, 'packages')).map(it => `packages/${it}`)
+// sorted, not readdir order: a clean `tsc --build` follows this order, and `database-tester` must come before the packages whose tests import it
+const packages = fs.readdirSync(join(root, 'packages')).sort().map(it => `packages/${it}`)
 
 const references = packages.filter(p => fs.existsSync(join(root, p, 'package.json'))).map(p => ({ path: './' + p }))
 tsconfigJson.references = references


### PR DESCRIPTION
Agent-facing notes (`CLAUDE.md`) collected while working across the repo, plus one small script fix. Every claim was checked against the code and CI on `main` before committing.

## New notes

- `docs/CLAUDE.md` — pletivo site layout, `nav.ts`, admonition syntax, "PR CI ignores `docs/**`".
- `e2e/CLAUDE.md` — how to run a scoped subset locally, `NODE_ENV` on the test process, migration-drift recovery, the `gql` tag pitfall, the known `disablePerson` flake.
- `packages/create/CLAUDE.md` — `admin/lib` is assembled at pre-build, not source.
- `packages/engine-panel/CLAUDE.md` — embedding constraints, route/auth model, 400-vs-403 behaviour.

## Extended notes

- Root: tracked generated artifacts and the `assume-unchanged` consequences (rebase, history rewrite), CI matrix shape and triggers, import-extension lint, nested `biome.json`.
- `database`: writing arrays to a `jsonb` column.
- `engine-content-api`: read-path guarding as it exists on `main` (`getFieldPredicate`, JS cell-masking, the conservative `WhereOptimizer.isLast`).
- `engine-tenant-api`: `migration-order` CI job, snapshot script container discovery, mocked-SQL post-rebase failures, conventions for new tenant features.
- `react-binding`: entity keys migrate on persist (#922).
- `react-client-tenant`, `react-ui-lib-tenant`, `schema-migrations`: API-surface, `tenantDict` and view-update notes.

## Script

`scripts/create-package/update-tsconfig.ts` sorts the package list instead of relying on `readdir` order, so a clean `tsc --build` orders `database-tester` before the engine packages whose tests import it. The committed root `tsconfig.json` is already in that order, so no regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VFT5bG8Q6aNZFJYozig3V
