### PR TITLE
fix(binding-legacy): let execution errors on a hasMany row reach the accessor

### DIFF
--- a/packages/binding-legacy/src/core/AccessorErrorManager.ts
+++ b/packages/binding-legacy/src/core/AccessorErrorManager.ts
@@ -199,9 +199,8 @@ export class AccessorErrorManager {
 				childState = state.children.get(childKey)!
 			}
 
-			if (childError.nodeType === 'iNode') {
-				this.setEntityStateErrors(childState as EntityRealmState, childError)
-			}
+			// Also handles leaf errors, i.e. execution errors whose path ends at the list item itself (e.g. NotFoundOrDenied).
+			this.setEntityStateErrors(childState as EntityRealmState, childError)
 		}
 	}
 

--- a/packages/binding-legacy/src/core/ErrorsPreprocessor.ts
+++ b/packages/binding-legacy/src/core/ErrorsPreprocessor.ts
@@ -113,7 +113,7 @@ class ErrorsPreprocessor {
 					} else {
 						this.rejectCorruptData()
 					}
-				} else if ('index' in path) {
+				} else if ('index' in pathNode) {
 					if (currentNode.nodeType === 'iNode') {
 						const alias = pathNode.alias
 

--- a/packages/react-binding/tests/cases/unit/core/accessorErrors.test.tsx
+++ b/packages/react-binding/tests/cases/unit/core/accessorErrors.test.tsx
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { c, createSchema } from '@contember/schema-definition'
+import { ErrorAccessor, ErrorPersistResult, isErrorPersistResult } from '@contember/binding-legacy'
+import { ValidationError } from '@contember/client'
+import { EntitySubTree, Field, HasMany, HasOne } from '../../../../src/index.js'
+import { convertModelToAdminSchema } from '../../../lib/convertModelToAdminSchema.js'
+import { BindingHarness, createBindingHarness, MutationErrorFixture, MutationFailure } from '../../../lib/harness/index.js'
+
+namespace ErrorModel {
+	export class Article {
+		title = c.stringColumn()
+		author = c.manyHasOne(Author)
+		blocks = c.oneHasMany(Block, 'article')
+	}
+
+	export class Author {
+		name = c.stringColumn()
+	}
+
+	export class Block {
+		article = c.manyHasOne(Article, 'blocks').notNull()
+		order = c.intColumn().notNull()
+		content = c.stringColumn()
+	}
+}
+
+const schema = convertModelToAdminSchema(createSchema(ErrorModel).model)
+const articleId = 'aaaaaaaa-0000-0000-0000-000000000001'
+const authorId = 'cccccccc-0000-0000-0000-000000000001'
+const firstBlockId = 'bbbbbbbb-0000-0000-0000-000000000001'
+const secondBlockId = 'bbbbbbbb-0000-0000-0000-000000000002'
+const absentBlockId = 'bbbbbbbb-0000-0000-0000-000000000009'
+
+let harness: BindingHarness | undefined
+
+afterEach(() => {
+	harness?.unmount()
+	harness = undefined
+})
+
+const mountArticle = async () => {
+	harness = await createBindingHarness({
+		schema,
+		data: {
+			article: {
+				id: articleId,
+				title: 'Hello',
+				author: { id: authorId, name: 'Jane' },
+				blocks: [
+					{ id: firstBlockId, order: 0, content: 'first' },
+					{ id: secondBlockId, order: 1, content: 'second' },
+				],
+			},
+		},
+		node: (
+			<EntitySubTree entity={`Article(id = '${articleId}')`} alias="article">
+				<Field field="title" />
+				<HasOne field="author">
+					<Field field="name" />
+				</HasOne>
+				<HasMany field="blocks" orderBy="order">
+					<Field field="order" />
+					<Field field="content" />
+				</HasMany>
+			</EntitySubTree>
+		),
+	})
+	return harness
+}
+
+const article = (harness: BindingHarness) => harness.getEntity('article')
+const author = (harness: BindingHarness) => article(harness).getEntity('author')
+const blocks = (harness: BindingHarness) => article(harness).getEntityList({ field: 'blocks', orderBy: 'order' })
+const row = (harness: BindingHarness, id: string) => blocks(harness).getChildEntityById(id)
+
+/** The message of every error sitting on an accessor, execution and validation alike. */
+const messagesOn = (holder: { readonly errors: ErrorAccessor | undefined }) =>
+	holder.errors?.errors.map(error => error.type === 'execution' ? error.developerMessage : error.message)
+
+type ErrorPath = ValidationError['path']
+
+/** The path the engine reports for a list item: the relation, then the index carrying the alias the binding sent. */
+const rowPath = (id: string, ...rest: ErrorPath): ErrorPath => [
+	{ field: 'blocks' },
+	{ index: 0, alias: `_${id.replace(/-/g, '_')}` },
+	...rest,
+]
+
+const executionError = (message: string, path: ErrorPath): MutationErrorFixture => ({ type: 'NotFoundOrDenied', message, paths: [path] })
+const validationError = (message: string, path: ErrorPath): ValidationError => ({ message: { text: message }, path })
+
+/** Dirties the tree, persists it against a response that fails, and hands back the rejection. */
+const persistFailing = async (harness: BindingHarness, failure: Omit<MutationFailure, 'errorMessage'>): Promise<ErrorPersistResult> => {
+	harness.server.failNextMutation({ errorMessage: 'The mutation has failed.', ...failure })
+	await harness.update(() => {
+		article(harness).getField('title').updateValue('Goodbye')
+	})
+
+	let rejection: unknown
+	await harness.persist().then(() => {}, error => {
+		rejection = error
+	})
+	if (!isErrorPersistResult(rejection)) {
+		throw new Error('The persist was expected to fail.')
+	}
+	return rejection
+}
+
+describe('accessor errors', () => {
+	describe('where one execution error lands', () => {
+		it('on the entity the mutation was for', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, { errors: [executionError('on the article', [])] })
+
+			expect(messagesOn(article(harness))).toEqual(['on the article'])
+		})
+
+		it('on a plain field', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, { errors: [executionError('on the title', [{ field: 'title' }])] })
+
+			expect(messagesOn(article(harness).getField('title'))).toEqual(['on the title'])
+			expect(article(harness).errors).toBeUndefined()
+		})
+
+		it('on a has-one relation', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, { errors: [executionError('on the author', [{ field: 'author' }])] })
+
+			expect(messagesOn(author(harness))).toEqual(['on the author'])
+		})
+
+		it('on a field of a has-one relation', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, { errors: [executionError('on the name', [{ field: 'author' }, { field: 'name' }])] })
+
+			expect(messagesOn(author(harness).getField('name'))).toEqual(['on the name'])
+			expect(author(harness).errors).toBeUndefined()
+		})
+
+		it('on the list as a whole', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, { errors: [executionError('on the blocks', [{ field: 'blocks' }])] })
+
+			expect(messagesOn(blocks(harness))).toEqual(['on the blocks'])
+			expect(row(harness, firstBlockId).errors).toBeUndefined()
+		})
+
+		it('on a list row', async () => {
+			const harness = await mountArticle()
+
+			const result = await persistFailing(harness, { errors: [executionError('on the first row', rowPath(firstBlockId))] })
+
+			expect(messagesOn(row(harness, firstBlockId))).toEqual(['on the first row'])
+			expect(row(harness, secondBlockId).errors).toBeUndefined()
+			expect(blocks(harness).errors).toBeUndefined()
+			expect(result.errors).toMatchObject([{ type: 'execution', code: 'NotFoundOrDenied' }])
+		})
+
+		it('on a field of a list row', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, { errors: [executionError('on the first content', rowPath(firstBlockId, { field: 'content' }))] })
+
+			expect(messagesOn(row(harness, firstBlockId).getField('content'))).toEqual(['on the first content'])
+			expect(row(harness, firstBlockId).errors).toBeUndefined()
+		})
+
+		it('nowhere, when it names a row the list does not hold', async () => {
+			const harness = await mountArticle()
+
+			const result = await persistFailing(harness, { errors: [executionError('on a stranger', rowPath(absentBlockId))] })
+
+			expect(result.errors).toEqual([])
+			expect(blocks(harness).errors).toBeUndefined()
+			expect(article(harness).errors).toBeUndefined()
+		})
+	})
+
+	describe('several errors in one response', () => {
+		it('reach every failing row', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, {
+				errors: [
+					executionError('on the first row', rowPath(firstBlockId)),
+					executionError('on the second row', rowPath(secondBlockId)),
+				],
+			})
+
+			expect(messagesOn(row(harness, firstBlockId))).toEqual(['on the first row'])
+			expect(messagesOn(row(harness, secondBlockId))).toEqual(['on the second row'])
+			expect(blocks(harness).errors).toBeUndefined()
+		})
+
+		it('reach every failing field of a row', async () => {
+			const harness = await mountArticle()
+
+			const result = await persistFailing(harness, {
+				errors: [
+					executionError('on the first content', rowPath(firstBlockId, { field: 'content' })),
+					executionError('on the second content', rowPath(secondBlockId, { field: 'content' })),
+				],
+			})
+
+			expect(messagesOn(row(harness, firstBlockId).getField('content'))).toEqual(['on the first content'])
+			expect(messagesOn(row(harness, secondBlockId).getField('content'))).toEqual(['on the second content'])
+			expect(result.errors).toHaveLength(2)
+		})
+
+		it('reach targets of different shapes at once', async () => {
+			const harness = await mountArticle()
+
+			const result = await persistFailing(harness, {
+				errors: [
+					executionError('on the title', [{ field: 'title' }]),
+					executionError('on the first row', rowPath(firstBlockId)),
+					executionError('on the second content', rowPath(secondBlockId, { field: 'content' })),
+				],
+			})
+
+			expect(messagesOn(article(harness).getField('title'))).toEqual(['on the title'])
+			expect(messagesOn(row(harness, firstBlockId))).toEqual(['on the first row'])
+			expect(messagesOn(row(harness, secondBlockId).getField('content'))).toEqual(['on the second content'])
+			expect(result.errors).toHaveLength(3)
+		})
+	})
+
+	describe('validation errors', () => {
+		it('reach the field of the row they name', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, {
+				validation: [validationError('Field is required', rowPath(firstBlockId, { field: 'content' }))],
+			})
+
+			expect(row(harness, firstBlockId).getField('content').errors?.errors).toEqual([
+				{ type: 'validation', code: 'fieldRequired', message: 'Field is required' },
+			])
+		})
+
+		it('reach every failing row of one response', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, {
+				validation: [
+					validationError('Field is required', rowPath(firstBlockId, { field: 'content' })),
+					validationError('Too long', rowPath(secondBlockId, { field: 'content' })),
+				],
+			})
+
+			expect(messagesOn(row(harness, firstBlockId).getField('content'))).toEqual(['Field is required'])
+			expect(row(harness, secondBlockId).getField('content').errors?.errors).toEqual([
+				{ type: 'validation', code: undefined, message: 'Too long' },
+			])
+		})
+
+		it('take precedence over the execution errors of the same response', async () => {
+			const harness = await mountArticle()
+
+			await persistFailing(harness, {
+				errors: [executionError('on the second row', rowPath(secondBlockId))],
+				validation: [validationError('Field is required', rowPath(firstBlockId, { field: 'content' }))],
+			})
+
+			expect(messagesOn(row(harness, firstBlockId).getField('content'))).toEqual(['Field is required'])
+			expect(row(harness, secondBlockId).errors).toBeUndefined()
+		})
+	})
+
+	describe('lifecycle', () => {
+		it('are cleared when the next persist starts, so a retry reaches the server', async () => {
+			const harness = await mountArticle()
+			await persistFailing(harness, { errors: [executionError('on the first row', rowPath(firstBlockId))] })
+
+			const result = await harness.persist()
+
+			expect(result.type).toBe('justSuccess')
+			expect(row(harness, firstBlockId).errors).toBeUndefined()
+			expect(harness.server.requests.filter(it => it.type === 'mutation')).toHaveLength(2)
+		})
+
+		it('are dropped one accessor at a time', async () => {
+			const harness = await mountArticle()
+			await persistFailing(harness, {
+				errors: [
+					executionError('on the first content', rowPath(firstBlockId, { field: 'content' })),
+					executionError('on the second content', rowPath(secondBlockId, { field: 'content' })),
+				],
+			})
+
+			await harness.update(() => {
+				row(harness, firstBlockId).getField('content').clearErrors()
+			})
+
+			expect(row(harness, firstBlockId).getField('content').errors).toBeUndefined()
+			expect(messagesOn(row(harness, secondBlockId).getField('content'))).toEqual(['on the second content'])
+		})
+	})
+})

--- a/packages/react-binding/tests/cases/unit/core/persist.test.tsx
+++ b/packages/react-binding/tests/cases/unit/core/persist.test.tsx
@@ -23,6 +23,9 @@ const articleId = 'aaaaaaaa-0000-0000-0000-000000000001'
 const firstBlockId = 'bbbbbbbb-0000-0000-0000-000000000001'
 const secondBlockId = 'bbbbbbbb-0000-0000-0000-000000000002'
 
+/** The alias the binding puts on a list item in a mutation, and which the engine echoes back in the error path. */
+const aliasOf = (id: string) => `_${id.replace(/-/g, '_')}`
+
 const articleData = {
 	id: articleId,
 	title: 'Hello',
@@ -177,11 +180,11 @@ describe('persist', () => {
 		const harness = await mountArticle()
 
 		harness.server.failNextMutation({
-			errorMessage: `Execution has failed:\nop_1.blocks.0(_${firstBlockId.replace(/-/g, '_')}): NotFoundOrDenied`,
+			errorMessage: `Execution has failed:\nop_1.blocks.0(${aliasOf(firstBlockId)}): NotFoundOrDenied`,
 			errors: [{
 				type: 'NotFoundOrDenied',
 				message: 'NotFoundOrDenied',
-				paths: [[{ field: 'blocks' }, { index: 0, alias: `_${firstBlockId.replace(/-/g, '_')}` }]],
+				paths: [[{ field: 'blocks' }, { index: 0, alias: aliasOf(firstBlockId) }]],
 			}],
 		})
 		await harness.update(() => {
@@ -196,6 +199,57 @@ describe('persist', () => {
 			{ type: 'execution', code: 'NotFoundOrDenied' },
 		])
 		expect(blocksOf(harness).getChildEntityById(secondBlockId).errors).toBeUndefined()
+	})
+
+	it('gives every failing row of one response its own error', async () => {
+		const harness = await mountArticle()
+
+		harness.server.failNextMutation({
+			errorMessage: 'Execution has failed.',
+			errors: [
+				{ type: 'NotFoundOrDenied', message: 'first row', paths: [[{ field: 'blocks' }, { index: 0, alias: aliasOf(firstBlockId) }]] },
+				{ type: 'NotFoundOrDenied', message: 'second row', paths: [[{ field: 'blocks' }, { index: 1, alias: aliasOf(secondBlockId) }]] },
+			],
+		})
+		await harness.update(() => {
+			blocksOf(harness).getChildEntityById(firstBlockId).getField('content').updateValue('changed')
+		})
+
+		await expect(harness.persist()).rejects.toMatchObject({ type: 'invalidInput' })
+		expect(blocksOf(harness).getChildEntityById(firstBlockId).errors?.errors).toMatchObject([{ developerMessage: 'first row' }])
+		expect(blocksOf(harness).getChildEntityById(secondBlockId).errors?.errors).toMatchObject([{ developerMessage: 'second row' }])
+		expect(blocksOf(harness).errors).toBeUndefined()
+	})
+
+	it('gives every failing field of one response its own error', async () => {
+		const harness = await mountArticle()
+
+		harness.server.failNextMutation({
+			errorMessage: 'Execution has failed.',
+			errors: [
+				{
+					type: 'InvalidDataInput',
+					message: 'first content',
+					paths: [[{ field: 'blocks' }, { index: 0, alias: aliasOf(firstBlockId) }, { field: 'content' }]],
+				},
+				{
+					type: 'InvalidDataInput',
+					message: 'second content',
+					paths: [[{ field: 'blocks' }, { index: 1, alias: aliasOf(secondBlockId) }, { field: 'content' }]],
+				},
+			],
+		})
+		await harness.update(() => {
+			blocksOf(harness).getChildEntityById(firstBlockId).getField('content').updateValue('changed')
+		})
+
+		await expect(harness.persist()).rejects.toMatchObject({
+			type: 'invalidInput',
+			errors: [{ developerMessage: 'first content' }, { developerMessage: 'second content' }],
+		})
+		const contentOf = (id: string) => blocksOf(harness).getChildEntityById(id).getField('content').errors?.errors
+		expect(contentOf(firstBlockId)).toMatchObject([{ developerMessage: 'first content' }])
+		expect(contentOf(secondBlockId)).toMatchObject([{ developerMessage: 'second content' }])
 	})
 
 	it('keeps the persistError event quiet when the caller asks for silent errors', async () => {

--- a/packages/react-binding/tests/cases/unit/core/persist.test.tsx
+++ b/packages/react-binding/tests/cases/unit/core/persist.test.tsx
@@ -173,6 +173,31 @@ describe('persist', () => {
 		expect(seenErrors).toHaveLength(1)
 	})
 
+	it('attaches an execution error ending at a list item to that item', async () => {
+		const harness = await mountArticle()
+
+		harness.server.failNextMutation({
+			errorMessage: `Execution has failed:\nop_1.blocks.0(_${firstBlockId.replace(/-/g, '_')}): NotFoundOrDenied`,
+			errors: [{
+				type: 'NotFoundOrDenied',
+				message: 'NotFoundOrDenied',
+				paths: [[{ field: 'blocks' }, { index: 0, alias: `_${firstBlockId.replace(/-/g, '_')}` }]],
+			}],
+		})
+		await harness.update(() => {
+			blocksOf(harness).getChildEntityById(firstBlockId).getField('content').updateValue('changed')
+		})
+
+		await expect(harness.persist()).rejects.toMatchObject({
+			type: 'invalidInput',
+			errors: [{ type: 'execution', code: 'NotFoundOrDenied' }],
+		})
+		expect(blocksOf(harness).getChildEntityById(firstBlockId).errors?.errors).toMatchObject([
+			{ type: 'execution', code: 'NotFoundOrDenied' },
+		])
+		expect(blocksOf(harness).getChildEntityById(secondBlockId).errors).toBeUndefined()
+	})
+
 	it('keeps the persistError event quiet when the caller asks for silent errors', async () => {
 		const harness = await mountArticle()
 		const seenErrors: ErrorPersistResult[] = []

--- a/packages/react-binding/tests/cases/unit/core/persist.test.tsx
+++ b/packages/react-binding/tests/cases/unit/core/persist.test.tsx
@@ -23,9 +23,6 @@ const articleId = 'aaaaaaaa-0000-0000-0000-000000000001'
 const firstBlockId = 'bbbbbbbb-0000-0000-0000-000000000001'
 const secondBlockId = 'bbbbbbbb-0000-0000-0000-000000000002'
 
-/** The alias the binding puts on a list item in a mutation, and which the engine echoes back in the error path. */
-const aliasOf = (id: string) => `_${id.replace(/-/g, '_')}`
-
 const articleData = {
 	id: articleId,
 	title: 'Hello',
@@ -174,82 +171,6 @@ describe('persist', () => {
 
 		await expect(harness.persist()).rejects.toMatchObject({ type: 'invalidInput' })
 		expect(seenErrors).toHaveLength(1)
-	})
-
-	it('attaches an execution error ending at a list item to that item', async () => {
-		const harness = await mountArticle()
-
-		harness.server.failNextMutation({
-			errorMessage: `Execution has failed:\nop_1.blocks.0(${aliasOf(firstBlockId)}): NotFoundOrDenied`,
-			errors: [{
-				type: 'NotFoundOrDenied',
-				message: 'NotFoundOrDenied',
-				paths: [[{ field: 'blocks' }, { index: 0, alias: aliasOf(firstBlockId) }]],
-			}],
-		})
-		await harness.update(() => {
-			blocksOf(harness).getChildEntityById(firstBlockId).getField('content').updateValue('changed')
-		})
-
-		await expect(harness.persist()).rejects.toMatchObject({
-			type: 'invalidInput',
-			errors: [{ type: 'execution', code: 'NotFoundOrDenied' }],
-		})
-		expect(blocksOf(harness).getChildEntityById(firstBlockId).errors?.errors).toMatchObject([
-			{ type: 'execution', code: 'NotFoundOrDenied' },
-		])
-		expect(blocksOf(harness).getChildEntityById(secondBlockId).errors).toBeUndefined()
-	})
-
-	it('gives every failing row of one response its own error', async () => {
-		const harness = await mountArticle()
-
-		harness.server.failNextMutation({
-			errorMessage: 'Execution has failed.',
-			errors: [
-				{ type: 'NotFoundOrDenied', message: 'first row', paths: [[{ field: 'blocks' }, { index: 0, alias: aliasOf(firstBlockId) }]] },
-				{ type: 'NotFoundOrDenied', message: 'second row', paths: [[{ field: 'blocks' }, { index: 1, alias: aliasOf(secondBlockId) }]] },
-			],
-		})
-		await harness.update(() => {
-			blocksOf(harness).getChildEntityById(firstBlockId).getField('content').updateValue('changed')
-		})
-
-		await expect(harness.persist()).rejects.toMatchObject({ type: 'invalidInput' })
-		expect(blocksOf(harness).getChildEntityById(firstBlockId).errors?.errors).toMatchObject([{ developerMessage: 'first row' }])
-		expect(blocksOf(harness).getChildEntityById(secondBlockId).errors?.errors).toMatchObject([{ developerMessage: 'second row' }])
-		expect(blocksOf(harness).errors).toBeUndefined()
-	})
-
-	it('gives every failing field of one response its own error', async () => {
-		const harness = await mountArticle()
-
-		harness.server.failNextMutation({
-			errorMessage: 'Execution has failed.',
-			errors: [
-				{
-					type: 'InvalidDataInput',
-					message: 'first content',
-					paths: [[{ field: 'blocks' }, { index: 0, alias: aliasOf(firstBlockId) }, { field: 'content' }]],
-				},
-				{
-					type: 'InvalidDataInput',
-					message: 'second content',
-					paths: [[{ field: 'blocks' }, { index: 1, alias: aliasOf(secondBlockId) }, { field: 'content' }]],
-				},
-			],
-		})
-		await harness.update(() => {
-			blocksOf(harness).getChildEntityById(firstBlockId).getField('content').updateValue('changed')
-		})
-
-		await expect(harness.persist()).rejects.toMatchObject({
-			type: 'invalidInput',
-			errors: [{ developerMessage: 'first content' }, { developerMessage: 'second content' }],
-		})
-		const contentOf = (id: string) => blocksOf(harness).getChildEntityById(id).getField('content').errors?.errors
-		expect(contentOf(firstBlockId)).toMatchObject([{ developerMessage: 'first content' }])
-		expect(contentOf(secondBlockId)).toMatchObject([{ developerMessage: 'second content' }])
 	})
 
 	it('keeps the persistError event quiet when the caller asks for silent errors', async () => {

--- a/packages/react-binding/tests/lib/harness/FakeContentApi.ts
+++ b/packages/react-binding/tests/lib/harness/FakeContentApi.ts
@@ -12,7 +12,7 @@ import {
 	TreeStore,
 } from '@contember/binding-legacy'
 import { MutationGenerator, SubMutationOperation } from '@contember/binding-legacy'
-import { ContentQueryBuilder } from '@contember/client'
+import { ContentQueryBuilder, MutationError, Result, ValidationError } from '@contember/client'
 import { GraphQlClient } from '@contember/graphql-client'
 import { WireConnection, wireConnection, WireEntity, WireValue } from './wireData.js'
 
@@ -28,9 +28,15 @@ export interface RecordedRequest {
 	variables: Record<string, unknown>
 }
 
+/** A {@link MutationError} as it travels over the wire, where the code is a plain string rather than an enum member. */
+export type MutationErrorFixture = Omit<MutationError, 'type'> & { readonly type: `${Result.ExecutionErrorType}` }
+
 export interface MutationFailure {
 	errorMessage: string
-	errors?: unknown[]
+	/** Execution errors, i.e. what the engine reports when the write itself is refused. */
+	errors?: MutationErrorFixture[]
+	/** Validation errors. The engine reports these instead of running the mutation, so they take precedence. */
+	validation?: ValidationError[]
 }
 
 /**
@@ -126,7 +132,7 @@ export class FakeContentApi {
 					ok: false,
 					errorMessage: failure.errorMessage,
 					errors: failure.errors ?? [],
-					validation: null,
+					validation: this.validationResult(failure),
 					node: null,
 				}
 		}
@@ -135,9 +141,13 @@ export class FakeContentApi {
 			ok: failure === undefined,
 			errorMessage: failure?.errorMessage ?? null,
 			errors: failure?.errors ?? [],
-			validation: null,
+			validation: failure === undefined ? null : this.validationResult(failure),
 			...results,
 		}
+	}
+
+	private validationResult(failure: MutationFailure) {
+		return failure.validation === undefined ? null : { valid: false, errors: failure.validation }
 	}
 
 	private nodeForOperation(operation: SubMutationOperation): WireEntity | null {

--- a/packages/react-binding/tests/lib/harness/createBindingHarness.tsx
+++ b/packages/react-binding/tests/lib/harness/createBindingHarness.tsx
@@ -22,7 +22,7 @@ export interface BindingHarnessOptions {
 	node: ReactNode
 	/** What the content API answers the initial query with, keyed by sub-tree alias. */
 	data?: SubTreeFixtures
-	/** The binding debug-logs every query it sends. Turn this on when a test needs to see them. */
+	/** The binding debug-logs every query it sends and every error it receives. Turn this on to see them. */
 	logRequests?: boolean
 }
 
@@ -62,16 +62,19 @@ export const createBindingHarness = async (
 		server.setData(data)
 	}
 
+	// The binding debug-logs its queries and dumps a console.table of every error it receives.
 	const quietly = async (operation: () => Promise<void>) => {
 		if (logRequests) {
 			return await operation()
 		}
-		const debug = console.debug
+		const { debug, table } = console
 		console.debug = () => {}
+		console.table = () => {}
 		try {
 			await operation()
 		} finally {
 			console.debug = debug
+			console.table = table
 		}
 	}
 


### PR DESCRIPTION
Fixes #925.

Two independent defects kept an execution or validation error from reaching the accessor of a `hasMany` row. They produce the same symptom — `getErrors()` comes back empty (or short), the persist promise rejects with `{ type: 'invalidInput', errors: [] }`, and the raw `errorMessage` string is all the application has left to work with.

## 1. A leaf error at a list item was dropped (the reported issue)

`AccessorErrorManager.setEntityListStateErrors` walked the list's children but only recursed into `iNode` children, so an error node that is a **leaf** at the list item itself fell through and attached nowhere.

That leaf is exactly what `ErrorsPreprocessor` produces for an entity-level execution error on a nested `hasMany` — `NotFoundOrDenied`, `ForeignKeyConstraintViolation`, … — whose path ends at the item (`[{ field: 'blocks' }, { index: 0, alias: '_<id>' }]`).

Validation errors escaped it: their paths always continue into a field, so the child node is an `iNode`.

`setEntityStateErrors` already handles a leaf node — it calls `addSeveralErrors` and returns. So the guard simply goes away and the list delegates unconditionally, rather than growing an `else` branch that repeats what the callee does.

## 2. Every error after the first skipped index path nodes

`ErrorsPreprocessor.getErrorNode` tested `'index' in path` — the whole path array rather than the node it was looking at. An array has no `index` property, so the test never held, the branch never ran, index nodes were skipped and the walk carried a stale current node into the rest of the path. `getRootNode`, 50 lines below, gets the same test right (`'index' in pathNode`).

Only the first error of a response escaped it, because that one is built by `getRootNode`. From the second error on, one whose path runs through a `hasMany` landed:

| shape of the path | before | after |
|---|---|---|
| ends at the row | on the whole list, not the row | on the row |
| continues into a field | on no accessor at all, and not even in the persist result's `errors` | on that row's field |

Two rows of a repeater failing at once is the everyday case, so this one bites more often than the first.

## Tests

`packages/react-binding/tests/cases/unit/core/accessorErrors.test.tsx` is new, and covers the whole question of where an error ends up. Every case drives the real binding against the fake content API: the read query goes out, an edit generates a real mutation, and the failing response really lands back in the tree.

- **where one execution error lands** — on the entity itself, on a plain field, on a has-one and on its field, on the list, on a row, on a row's field, and nowhere at all when it names a row the list does not hold;
- **several errors in one response** — every failing row, every failing field of a row, and a response mixing all three target shapes;
- **validation errors** — reaching the field of the row they name (including the `fieldRequired` code), reaching every failing row of one response, and taking precedence over execution errors of the same response;
- **lifecycle** — errors clear when the next persist starts, so a retry reaches the server, and they clear one accessor at a time.

Eight of the sixteen fail without one of the two fixes; the rest pin down the behaviour around them so the next edit to this walk cannot quietly move an error somewhere else.

Two supporting changes to the harness: the fake content API can now answer with validation errors, and the harness silences the binding's `console.table` error dump the same way it already silences its query logging.