### PR TITLE
feat(s3-plugin): delete objects from the Content API

### DIFF
--- a/docs/src/content/docs/reference/engine/content/s3.mdx
+++ b/docs/src/content/docs/reference/engine/content/s3.mdx
@@ -2,7 +2,7 @@
 title: Storing files on S3
 ---
 
-Beside operations for your data, there are mutations related to S3 compatible storage. Contember itself doesn't store your files, but it can help you with signing URLs for uploading (or reading) those files. 
+Beside operations for your data, there are mutations related to S3 compatible storage. Contember itself doesn't store your files, but it can help you with signing URLs for uploading (or reading) those files, and it can delete them for you. 
 
 ## S3 server
 
@@ -67,23 +67,44 @@ If you store public URL instead of object key, don't worry. Contember will recog
 
 You can also optionally set an expiration of the URL (default 3600 seconds)
 
+## Deleting an object
+
+:::note[Available since 2.2]
+:::
+
+Unlike an upload or a read, a delete moves no bytes through your application, so there is no URL to sign — Contember signs the request and calls the storage itself:
+
+```
+mutation {
+  deleteS3Object(objectKey: "images/5b934fe1-0e30-4761-9e00-d4bfabbddf34.png") {
+    objectKey
+  }
+}
+```
+
+Just like `generateReadUrl`, this mutation accepts a public URL instead of an object key. It requires a `delete` operation in an ACL and it is idempotent — deleting an object which does not exist succeeds. When the storage rejects the request, an error is returned.
+
+:::note
+Deleting an object does not purge a CDN cache. If you delete a file because it must stop being served (e.g. a takedown or an erasure request), purge the cache of your CDN as well.
+:::
 
 ## Configuring S3 ACL
 
-To use S3 functionality, each role in the [ACL schema](/reference/engine/schema/acl) must have defined ACL rules. This is the most simple rule, which allows both operations on any key:
+To use S3 functionality, each role in the [ACL schema](/reference/engine/schema/acl) must have defined ACL rules. This is the most simple rule, which allows all operations on any key:
 ```typescript
 const adminRole = {
   s3: {
     '**': {
       read: true,
       upload: true,
+      delete: true,
     }
   },
   // ... variables, stage, entities...
 }
 ```
 
-In a key you define a glob-like pattern for an S3 object key and in a value you define allowed operations (`read` and `upload`). We use [picomatch](https://github.com/micromatch/picomatch) library for a pattern matching.
+In a key you define a glob-like pattern for an S3 object key and in a value you define allowed operations (`read`, `upload` and `delete`, the last one available since 2.2). We use [picomatch](https://github.com/micromatch/picomatch) library for a pattern matching.
 
 #### Example patterns
 
@@ -97,4 +118,8 @@ Contember will try to find any rule for an object key, which allows given operat
 
 :::note
 `read` option only affects `generateReadUrl` mutation and does not affect upload ACL (`PUBLIC_READ`, `PRIVATE`) nor public read URL in any way.
+:::
+
+:::note
+`delete` is a separate operation — it is not implied by `upload`. Roles `admin` and `contentAdmin` have it enabled for all objects.
 :::

--- a/packages/engine-s3-plugin/src/S3ObjectAuthorizator.ts
+++ b/packages/engine-s3-plugin/src/S3ObjectAuthorizator.ts
@@ -13,16 +13,24 @@ export type S3ObjectReadRule = {
 	matcher?: (key: string) => boolean
 }
 
+export type S3ObjectDeleteRule = {
+	pattern: string
+	matcher?: (key: string) => boolean
+}
+
 export class S3ObjectAuthorizator {
 	private readonly uploadRules: S3ObjectUploadRule[]
 	private readonly readRules: S3ObjectReadRule[]
+	private readonly deleteRules: S3ObjectDeleteRule[]
 
 	constructor(
 		uploadRules: Omit<S3ObjectUploadRule, 'matcher'>[],
 		readRules: Omit<S3ObjectReadRule, 'matcher'>[],
+		deleteRules: Omit<S3ObjectDeleteRule, 'matcher'>[] = [],
 	) {
 		this.uploadRules = uploadRules
 		this.readRules = readRules
+		this.deleteRules = deleteRules
 	}
 
 	public verifyReadAccess({ key }: { key: string }): void {
@@ -35,6 +43,18 @@ export class S3ObjectAuthorizator {
 		}
 
 		throw new ForbiddenError(`Read access forbidden for object key ${key}`)
+	}
+
+	public verifyDeleteAccess({ key }: { key: string }): void {
+		for (const rule of this.deleteRules) {
+			rule.matcher ??= pm(rule.pattern)
+
+			if (rule.matcher(key)) {
+				return
+			}
+		}
+
+		throw new ForbiddenError(`Delete access forbidden for object key ${key}`)
 	}
 
 	public verifyUploadAccess({ key, size }: { key: string; size: number | null }): void {

--- a/packages/engine-s3-plugin/src/S3SchemaContributor.ts
+++ b/packages/engine-s3-plugin/src/S3SchemaContributor.ts
@@ -12,7 +12,7 @@ import { S3Service, S3ServiceFactory } from './S3Service.js'
 import { Project3Config, resolveS3Config, S3Config } from './Config.js'
 import { GraphQLSchemaContributor, GraphQLSchemaContributorContext, Providers } from '@contember/engine-plugins'
 import * as types from './S3SchemaTypes.js'
-import { S3Acl, S3GenerateSignedUploadInput, S3SignedRead, S3SignedUpload } from './S3SchemaTypes.js'
+import { S3Acl, S3DeletedObject, S3GenerateSignedUploadInput, S3SignedRead, S3SignedUpload } from './S3SchemaTypes.js'
 import { S3ObjectAuthorizator } from './S3ObjectAuthorizator.js'
 
 interface Identity {
@@ -30,6 +30,7 @@ export type S3SchemaAcl = Record<
 	{
 		read?: boolean
 		upload?: S3SchemaUploadAcl
+		delete?: boolean
 	}
 >
 
@@ -56,17 +57,23 @@ export class S3SchemaContributor implements GraphQLSchemaContributor {
 		const readRules = rules.filter(([, it]) => it.read).map(([it]) => ({
 			pattern: it,
 		}))
+		const deleteRules = rules.filter(([, it]) => it.delete).map(([it]) => ({
+			pattern: it,
+		}))
 
-		if (uploadRules.length === 0 && readRules.length === 0) {
+		if (uploadRules.length === 0 && readRules.length === 0 && deleteRules.length === 0) {
 			return undefined
 		}
 
-		const authorizator = new S3ObjectAuthorizator(uploadRules, readRules)
+		const authorizator = new S3ObjectAuthorizator(uploadRules, readRules, deleteRules)
 		const uploadMutation = this.createUploadMutation(authorizator)
 		const readMutation = this.createReadMutation(authorizator)
+		const deleteMutation = this.createDeleteMutation(authorizator)
 		const mutation = {
 			generateUploadUrl: uploadMutation as GraphQLFieldConfig<any, any, any>,
 			generateReadUrl: readMutation,
+			// not "deleteObject" — a content mutation for an entity named "Object" would shadow it
+			deleteS3Object: deleteMutation,
 		}
 		return {
 			mutation: new GraphQLObjectType({
@@ -104,6 +111,25 @@ export class S3SchemaContributor implements GraphQLSchemaContributor {
 				return s3.getSignedReadUrl({ objectKey: args.objectKey, expiration: args.expiration ?? null })
 			},
 		} as GraphQLFieldConfig<any, any, any>
+	}
+
+	private createDeleteMutation(authorizator: S3ObjectAuthorizator): GraphQLFieldConfig<any, any, any> {
+		return {
+			type: new GraphQLNonNull(S3DeletedObject),
+			args: {
+				objectKey: {
+					type: new GraphQLNonNull(GraphQLString),
+				},
+			},
+			resolve: async (parent: any, args: { objectKey: string }, ctx: { project: Project3Config }) => {
+				if (!ctx.project.s3) {
+					throw new GraphQLError('S3 is not configured for this project')
+				}
+				const s3Config = resolveS3Config(ctx.project.s3)
+				const s3 = this.s3Factory.create(s3Config, this.providers, authorizator)
+				return await s3.deleteObject({ objectKey: args.objectKey })
+			},
+		}
 	}
 
 	private createUploadMutation(authorizator: S3ObjectAuthorizator): GraphQLFieldConfig<any, any, any> {

--- a/packages/engine-s3-plugin/src/S3SchemaTypes.ts
+++ b/packages/engine-s3-plugin/src/S3SchemaTypes.ts
@@ -44,6 +44,14 @@ export const S3SignedUpload = new GraphQLObjectType({
 	},
 })
 
+export const S3DeletedObject = new GraphQLObjectType({
+	name: 'S3DeletedObject',
+	fields: {
+		objectKey: { type: new GraphQLNonNull(GraphQLString) },
+		bucket: { type: new GraphQLNonNull(GraphQLString) },
+	},
+})
+
 export const S3Acl = new GraphQLEnumType({
 	name: 'S3Acl',
 	values: {

--- a/packages/engine-s3-plugin/src/S3Service.ts
+++ b/packages/engine-s3-plugin/src/S3Service.ts
@@ -23,6 +23,22 @@ type SignedUploadUrl = {
 	method: string
 }
 
+type DeletedObject = {
+	bucket: string
+	objectKey: string
+}
+
+export type S3FetchResponse = {
+	readonly ok: boolean
+	readonly status: number
+	text(): Promise<string>
+}
+
+export type S3Fetch = (url: string, init: { method: string; signal: AbortSignal }) => Promise<S3FetchResponse>
+
+const deleteUrlExpiration = 60
+const deleteTimeoutMs = 10_000
+
 export class S3Service {
 	private readonly publicBaseUrl: string
 
@@ -32,6 +48,7 @@ export class S3Service {
 		public readonly config: S3Config,
 		private readonly providers: Pick<Providers, 'uuid' | 'now'>,
 		private readonly authorizator: S3ObjectAuthorizator,
+		private readonly fetch: S3Fetch = (url, init) => globalThis.fetch(url, init),
 	) {
 		this.publicBaseUrl = resolveS3PublicBaseUrl(config)
 		this.signer = new S3Signer(config, providers)
@@ -97,7 +114,56 @@ export class S3Service {
 
 	public getSignedReadUrl({ objectKey, expiration }: { objectKey: string; expiration: number | null }): SignedReadUrl {
 		const bucket = this.config.bucket
+		const resolved = this.resolveObjectKey(objectKey)
+		this.authorizator.verifyReadAccess({ key: resolved.localObjectKey })
 
+		const url = this.signer.sign({
+			action: 'read',
+			expiration: expiration ?? 3600,
+			key: resolved.objectKey,
+			headers: {},
+		})
+
+		return {
+			bucket,
+			objectKey: resolved.objectKey,
+			url,
+			headers: [],
+			method: 'GET',
+		}
+	}
+
+	/**
+	 * Unlike an upload or a read, a delete carries no payload, so the signed URL never leaves the server.
+	 */
+	public async deleteObject({ objectKey }: { objectKey: string }): Promise<DeletedObject> {
+		const bucket = this.config.bucket
+		const resolved = this.resolveObjectKey(objectKey)
+		this.authorizator.verifyDeleteAccess({ key: resolved.localObjectKey })
+
+		const url = this.signer.sign({
+			action: 'delete',
+			expiration: deleteUrlExpiration,
+			key: resolved.objectKey,
+			headers: {},
+		})
+
+		const response = await this.fetch(url, { method: 'DELETE', signal: AbortSignal.timeout(deleteTimeoutMs) })
+		if (!response.ok) {
+			throw new Error(`Failed to delete an object "${resolved.objectKey}": S3 responded with ${response.status}: ${await response.text()}`)
+		}
+
+		return {
+			bucket,
+			objectKey: resolved.objectKey,
+		}
+	}
+
+	public formatPublicUrl(key: string): string {
+		return `${this.publicBaseUrl}/${key}`
+	}
+
+	private resolveObjectKey(objectKey: string): { objectKey: string; localObjectKey: string } {
 		const publicPrefix = this.formatPublicUrl('')
 		if (objectKey.startsWith(publicPrefix)) {
 			objectKey = objectKey.substring(publicPrefix.length)
@@ -108,26 +174,8 @@ export class S3Service {
 			)
 		}
 		const localObjectKey = this.config.prefix ? objectKey.substring(this.config.prefix.length + 1) : objectKey
-		this.authorizator.verifyReadAccess({ key: localObjectKey })
 
-		const url = this.signer.sign({
-			action: 'read',
-			expiration: expiration ?? 3600,
-			key: objectKey,
-			headers: {},
-		})
-
-		return {
-			bucket,
-			objectKey,
-			url,
-			headers: [],
-			method: 'GET',
-		}
-	}
-
-	public formatPublicUrl(key: string): string {
-		return `${this.publicBaseUrl}/${key}`
+		return { objectKey, localObjectKey }
 	}
 }
 

--- a/packages/engine-s3-plugin/src/S3Signer.ts
+++ b/packages/engine-s3-plugin/src/S3Signer.ts
@@ -4,10 +4,16 @@ import qs from 'qs'
 import { BinaryLike, createHash, createHmac } from 'node:crypto'
 
 interface S3Request {
-	action: 'read' | 'upload'
+	action: 'read' | 'upload' | 'delete'
 	key: string
 	expiration: number
 	headers: Record<string, string>
+}
+
+const methods: Record<S3Request['action'], string> = {
+	read: 'GET',
+	upload: 'PUT',
+	delete: 'DELETE',
 }
 
 const hmac = (secret: BinaryLike, data: BinaryLike) => createHmac('sha256', secret).update(data).digest()
@@ -36,7 +42,7 @@ export class S3Signer {
 		const queryString = this.getQueryParams(request, nowFormatted)
 		const path = uris.basePath + '/' + request.key
 		const lines = [
-			request.action === 'read' ? 'GET' : 'PUT',
+			methods[request.action],
 			path,
 			queryString,
 			this.getSignedHeaders(request),

--- a/packages/engine-s3-plugin/tests/cases/authorizator.test.ts
+++ b/packages/engine-s3-plugin/tests/cases/authorizator.test.ts
@@ -13,6 +13,17 @@ test('required upload pattern', () => {
 	expect(() => authorizator.verifyUploadAccess({ key: 'lorem.jpg', size: null })).toThrow('Upload access forbidden for object key lorem.jpg')
 })
 
+test('required delete pattern', () => {
+	const authorizator = new S3ObjectAuthorizator([], [], [{ pattern: 'foo/**' }])
+	expect(() => authorizator.verifyDeleteAccess({ key: 'foo/lorem.jpg' })).not.toThrow()
+	expect(() => authorizator.verifyDeleteAccess({ key: 'lorem.jpg' })).toThrow('Delete access forbidden for object key lorem.jpg')
+})
+
+test('delete is not implied by upload nor read', () => {
+	const authorizator = new S3ObjectAuthorizator([{ pattern: '**' }], [{ pattern: '**' }])
+	expect(() => authorizator.verifyDeleteAccess({ key: 'foo/lorem.jpg' })).toThrow('Delete access forbidden for object key foo/lorem.jpg')
+})
+
 test('max upload size', () => {
 	const authorizator = new S3ObjectAuthorizator([{ pattern: '**', maxSize: 1024 }], [])
 	expect(() => authorizator.verifyUploadAccess({ key: 'lorem.jpg', size: 1000 })).not.toThrow()

--- a/packages/engine-s3-plugin/tests/cases/signRequest.test.ts
+++ b/packages/engine-s3-plugin/tests/cases/signRequest.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from 'bun:test'
-import { S3ObjectAuthorizator, S3Service } from '../../src/index.js'
+import { S3Fetch, S3ObjectAuthorizator, S3Service } from '../../src/index.js'
 
 const mocked = new Date('2021-07-02T17:22Z')
 const constantUuid = '9fce3907-ff2b-45bb-b4ce-eff5527dd315'
-const createS3Service = (bucket: string, prefix = '') =>
+const createS3Service = (bucket: string, prefix = '', fetch?: S3Fetch) =>
 	new S3Service(
 		{
 			bucket,
@@ -18,8 +18,19 @@ const createS3Service = (bucket: string, prefix = '') =>
 			uuid: () => constantUuid,
 			now: () => mocked,
 		},
-		new S3ObjectAuthorizator([{ pattern: '**' }], [{ pattern: '**' }]),
+		new S3ObjectAuthorizator([{ pattern: '**' }], [{ pattern: '**' }], [{ pattern: '**' }]),
+		fetch,
 	)
+
+const createFetchMock = (response: { ok: boolean; status: number; body?: string } = { ok: true, status: 204 }) => {
+	const calls: { url: string; method: string }[] = []
+	const fetch: S3Fetch = async (url, init) => {
+		calls.push({ url, method: init.method })
+		return { ...response, text: async () => response.body ?? '' }
+	}
+
+	return { calls, fetch }
+}
 
 test('sign s3 request', () => {
 	const service = createS3Service('test')
@@ -70,6 +81,57 @@ test('sign upload #2', () => {
 	})
 	expect(signed.url).toEqual(
 		'https://test.s3.eu-central-1.amazonaws.com/foo/9fce3907-ff2b-45bb-b4ce-eff5527dd315bar.jpeg?Cache-Control=immutable&Content-Type=image%2Fjpeg&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20210702%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210702T172200Z&X-Amz-Expires=1800&X-Amz-Signature=979a93bca65a98ce6b2bf97d2bf2afe7d5f2fa805f7d596187675416c86a3bd5&X-Amz-SignedHeaders=cache-control%3Bcontent-disposition%3Bhost%3Bx-amz-acl&x-amz-acl=public-read',
+	)
+})
+
+test('delete object', async () => {
+	const { calls, fetch } = createFetchMock()
+	const service = createS3Service('test', '', fetch)
+	const deleted = await service.deleteObject({ objectKey: 'foo.jpg' })
+	expect(deleted).toEqual({ bucket: 'test', objectKey: 'foo.jpg' })
+	expect(calls).toEqual([{
+		method: 'DELETE',
+		url:
+			'https://test.s3.eu-central-1.amazonaws.com/foo.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test%2F20210702%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20210702T172200Z&X-Amz-Expires=60&X-Amz-Signature=441f2003478d8dc8761b6c4c48c6c0805a36d1f088138a5b89d6bea365922663&X-Amz-SignedHeaders=host',
+	}])
+})
+
+test('delete object - public url is accepted', async () => {
+	const { calls, fetch } = createFetchMock()
+	const service = createS3Service('test', 'lorem', fetch)
+	const deleted = await service.deleteObject({
+		objectKey: 'https://test.s3.eu-central-1.amazonaws.com/lorem/foo.jpg',
+	})
+	expect(deleted.objectKey).toEqual('lorem/foo.jpg')
+	expect(calls.length).toEqual(1)
+})
+
+test('delete object - project prefix is enforced', async () => {
+	const { calls, fetch } = createFetchMock()
+	const service = createS3Service('test', 'lorem', fetch)
+	await expect(service.deleteObject({ objectKey: 'ipsum/foo.jpg' })).rejects.toThrow(
+		'Given object key "ipsum/foo.jpg" does not start with a project prefix "lorem"',
+	)
+	expect(calls.length).toEqual(0)
+})
+
+test('delete object - acl is verified', async () => {
+	const { calls, fetch } = createFetchMock()
+	const service = new S3Service(
+		{ bucket: 'test', region: 'eu-central-1', credentials: { key: 'test', secret: 'abcd' }, prefix: '' },
+		{ uuid: () => constantUuid, now: () => mocked },
+		new S3ObjectAuthorizator([{ pattern: '**' }], [{ pattern: '**' }], [{ pattern: 'foo/**' }]),
+		fetch,
+	)
+	await expect(service.deleteObject({ objectKey: 'bar/foo.jpg' })).rejects.toThrow('Delete access forbidden for object key bar/foo.jpg')
+	expect(calls.length).toEqual(0)
+})
+
+test('delete object - s3 failure', async () => {
+	const { fetch } = createFetchMock({ ok: false, status: 403, body: '<Error>AccessDenied</Error>' })
+	const service = createS3Service('test', '', fetch)
+	await expect(service.deleteObject({ objectKey: 'foo.jpg' })).rejects.toThrow(
+		'Failed to delete an object "foo.jpg": S3 responded with 403: <Error>AccessDenied</Error>',
 	)
 })
 

--- a/packages/schema-utils/src/schemaNormalizer.ts
+++ b/packages/schema-utils/src/schemaNormalizer.ts
@@ -19,6 +19,7 @@ export const normalizeSchema = <S extends Schema>(schema: S): S => {
 						'**': {
 							upload: true,
 							read: true,
+							delete: true,
 						},
 					},
 					content: {
@@ -43,6 +44,7 @@ export const normalizeSchema = <S extends Schema>(schema: S): S => {
 						'**': {
 							upload: true,
 							read: true,
+							delete: true,
 						},
 					},
 					content: {


### PR DESCRIPTION
Closes #942.

> **Partly superseded on `main`.** Two follow-up commits changed what this PR merged:
>
> - `0082dcc8a` — the project-prefix guard compared with a bare `startsWith`, so the separator was not part of the comparison and a project prefixed `blog` also accepted keys under `blog-staging`. Pre-existing, but `deleteS3Object` turned it from a leaked read URL into cross-project deletion.
> - `63cdad715` — `delete` is now **opt-in**: `admin` and `content_admin` do *not* get it, contrary to the "What this adds" section below.

## Why not a presigned delete URL

The issue proposed `generateDeleteUrl`, which is consistent with `generateUploadUrl` / `generateReadUrl`. Those two exist because bytes have to travel through the client: an upload PUTs a body, a read GETs one. A delete has neither, so the only thing a client would do with a signed URL is a single `fetch` — which the engine can do itself.

Doing it server-side is also strictly safer and cheaper:

- the ACL is checked at the moment of the delete, instead of handing out a bearer token for an irreversible operation that stays valid for the whole expiration window (and leaks through logs, error reporting, proxies),
- no `DELETE` needed in the bucket CORS configuration,
- one round trip, and S3 failures are handled in one place.

## What this adds

```graphql
mutation {
  deleteS3Object(objectKey: "images/5b934fe1-0e30-4761-9e00-d4bfabbddf34.png") {
    objectKey
  }
}
```

Like `generateReadUrl`, it accepts a public URL instead of an object key, and it enforces the project prefix. It is idempotent — S3 answers `204` for a key that does not exist.

ACL gets a third operation, which is **not** implied by `upload`:

```ts
s3: { 'imgs/**': { read: true, upload: true, delete: true } }
```

`admin` and `contentAdmin` get `delete: true` on `**`, next to the `upload`/`read` they already have.

### Naming

`deleteS3Object`, not `deleteObject`: `GraphQlSchemaBuilder` merges entity mutations *over* the plugin ones, so a project with an entity named `Object` would silently shadow the plugin's mutation. `deleteS3Object` keeps it out of that namespace.

## Not included

- **Overwriting an object in place** (option 2 in the issue). `getSignedUploadUrl` sends `Cache-Control: immutable`, so overwriting a key is semantically broken — CDNs and browsers keep serving the old bytes. The UUID key plus immutable caching is a deliberate pair; delete + fresh upload is the correct sequence. A caller-supplied `objectKey` would also allow overwriting other entities' files.
- **Batch delete.** Not worth the API surface: S3's multi-delete (`POST ?delete`) needs a signed body and `Content-MD5`, which the current query-string signer does not do, so a batch mutation would just be N parallel `DELETE`s that a client can issue itself.
- **CDN purge.** Out of the plugin's reach — a deleted object can still be served from a CDN cache until it expires. Documented as a note on the takedown/erasure use case.

## Verification

- Unit tests: signed `DELETE` URL, public-URL input, project-prefix enforcement, ACL denial, and the S3-failure path. The expected signature in the fixture was cross-checked against an independent SigV4 implementation with `DELETE` as the canonical verb.
- Manually against the dev stack's SeaweedFS (`chrislusf/seaweedfs:4.42`, the same image and identity config as `docker-compose.yaml`): upload → `200`, read → `200`, delete → read returns `404`, second delete succeeds, and a key outside the ACL pattern is rejected before any request is made.

There is no e2e coverage for S3 in this repo (the e2e project has no S3 configuration), so this change adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmaSmTgZ9tVZSjnm92it4k
