### PR TITLE
feat(actions): supply a variable from the engine environment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -119,6 +119,7 @@
       "version": "2.2.0-alpha.3",
       "dependencies": {
         "chalk": "catalog:",
+        "chalk-table": "catalog:",
       },
       "devDependencies": {
         "@types/js-yaml": "catalog:",
@@ -258,6 +259,7 @@
         "prom-client": "catalog:",
       },
       "devDependencies": {
+        "@contember/database-tester": "workspace:*",
         "@types/bun": "catalog:",
         "@types/ws": "catalog:",
         "graphql": "catalog:",

--- a/docs/src/content/docs/reference/engine/actions/managing.mdx
+++ b/docs/src/content/docs/reference/engine/actions/managing.mdx
@@ -14,7 +14,7 @@ You must include a Bearer token in Authorization header. To view and setup varia
 Variables are dynamic values that can be used to customize the behavior of your Actions. These variables can be referenced in your Actions' configurations using double curly brackets `{{}}`, e.g. `{{baseUrl}}`.
 
 ### Retrieving Variables:
-To retrieve the variables defined for your Contember project, you can make a GraphQL query to the `variables` field. This will provide you with a list of variables, including their names and current values. 
+To retrieve the variables defined for your Contember project, you can make a GraphQL query to the `variables` field. This will provide you with a list of variables, including their names, current values and where each value comes from. 
 
 Example:
 
@@ -23,9 +23,12 @@ query {
   variables {
     name
     value
+    source
   }
 }
 ```
+
+`source` is `DATABASE` for a value stored in the project database and `ENVIRONMENT` for a value supplied by the engine environment.
 
 ### Updating Variables
 
@@ -67,6 +70,19 @@ The `mode` field in the `SetVariablesArgs` input of `setVariables` mutation allo
 	- When `mode` is set to `APPEND_ONLY_MISSING`, the new variable values provided in the mutation will be appended to the existing variables only if they do not already exist.
 	- Existing variables that are not included in the mutation will retain their current values.
 	- If a variable is included in the mutation and it already exists, its value will not be updated.
+
+### Variables from the environment
+
+A value can also come from the engine environment instead of the project database, so a secret is delivered by the same mechanism as every other secret the engine holds and survives a database restore unchanged.
+
+The engine reads a variable named `apiKey` for a project `my-project` from:
+
+1. `MY_PROJECT_ACTIONS_VARIABLE_apiKey`
+2. `DEFAULT_ACTIONS_VARIABLE_apiKey`, shared by every project
+
+The project part of the name follows the same rule as `%project.env.*%` in the server configuration: the project slug uppercased, with dashes replaced by underscores. An empty value counts as unset. Because the name after the prefix is taken literally, name such a variable the way you name an environment variable — `{{API_KEY}}` read from `MY_PROJECT_ACTIONS_VARIABLE_API_KEY`.
+
+A variable supplied this way overrides a stored row of the same name and is read-only: it is reported with `source: ENVIRONMENT` and `setVariables` refuses to write it, so exactly one place owns the value.
 
 
 ## Event queries

--- a/docs/src/content/docs/reference/engine/actions/managing.mdx
+++ b/docs/src/content/docs/reference/engine/actions/managing.mdx
@@ -29,6 +29,7 @@ query {
 ```
 
 `source` is `DATABASE` for a value stored in the project database and `ENVIRONMENT` for a value supplied by the engine environment.
+`value` is `null` for an `ENVIRONMENT` variable — that value is never returned, it stays where the operator put it.
 
 ### Updating Variables
 
@@ -75,14 +76,14 @@ The `mode` field in the `SetVariablesArgs` input of `setVariables` mutation allo
 
 A value can also come from the engine environment instead of the project database, so a secret is delivered by the same mechanism as every other secret the engine holds and survives a database restore unchanged.
 
-The engine reads a variable named `apiKey` for a project `my-project` from:
+The engine reads a variable named `API_KEY` for a project `my-project` from:
 
-1. `MY_PROJECT_ACTIONS_VARIABLE_apiKey`
-2. `DEFAULT_ACTIONS_VARIABLE_apiKey`, shared by every project
+1. `MY_PROJECT_ACTIONS_VARIABLE_API_KEY`
+2. `DEFAULT_ACTIONS_VARIABLE_API_KEY`, shared by every project
 
-The project part of the name follows the same rule as `%project.env.*%` in the server configuration: the project slug uppercased, with dashes replaced by underscores. An empty value counts as unset. Because the name after the prefix is taken literally, name such a variable the way you name an environment variable — `{{API_KEY}}` read from `MY_PROJECT_ACTIONS_VARIABLE_API_KEY`.
+The project part of the name follows the same rule as `%project.env.*%` in the server configuration: the project slug uppercased, with dashes replaced by underscores. An empty value counts as unset. Because the name after the prefix is taken literally, `{{API_KEY}}` and `{{apiKey}}` are two different variables — name such a variable the way you name an environment variable.
 
-A variable supplied this way overrides a stored row of the same name and is read-only: it is reported with `source: ENVIRONMENT` and `setVariables` refuses to write it, so exactly one place owns the value.
+A variable supplied this way overrides a stored row of the same name and is neither readable nor writable through the API: it is reported with `source: ENVIRONMENT` and a `null` value, and `setVariables` refuses to write it. The value therefore has exactly one owner, the secret store it came from, and reading the project's variables does not hand it back out.
 
 
 ## Event queries

--- a/packages/cli/src/commands/actions/ActionsListVariablesCommand.ts
+++ b/packages/cli/src/commands/actions/ActionsListVariablesCommand.ts
@@ -27,7 +27,9 @@ export class ActionsListVariablesCommand extends Command<Args, Options> {
 		output.table(
 			[
 				{ field: 'name', name: 'Name' },
-				{ field: 'value', name: 'Value' },
+				// an environment value is not returned by the API, so there is nothing to print but its absence
+				{ field: 'value', name: 'Value', format: value => value ?? '<not readable>' },
+				{ field: 'source', name: 'Source', format: source => source === 'ENVIRONMENT' ? 'Environment (read-only)' : 'Database' },
 			],
 			result,
 			'name',

--- a/packages/cli/src/lib/actions/ActionsClient.ts
+++ b/packages/cli/src/lib/actions/ActionsClient.ts
@@ -18,15 +18,16 @@ export class ActionsClient {
 		return new ActionsClient(graphqlClient)
 	}
 
-	public async listVariables(): Promise<{ name: string; value: string }[]> {
+	public async listVariables(): Promise<Variable[]> {
 		const query = `query {
   variables {
   	name
   	value
+  	source
   }
 }`
 		const result = await this.execute<{
-			variables: Array<{ name: string; value: string }>
+			variables: Array<Variable>
 		}>(query)
 		return result.variables
 	}
@@ -113,6 +114,11 @@ export class ActionsClient {
 
 /** The subset of ActionsClient commands depend on — structural, so tests can pass a plain fake without a cast. */
 export type ActionsApi = Pick<ActionsClient, 'listVariables' | 'setVariables' | 'listFailedEvents' | 'retryEvent' | 'stopEvent' | 'getEvent'>
+
+export type VariableSource = 'DATABASE' | 'ENVIRONMENT'
+
+/** An `ENVIRONMENT` value is not returned by the API — it stays in the operator's secret store. */
+export type Variable = { name: string; value: string | null; source: VariableSource }
 
 export type SetVariablesMode = 'MERGE' | 'SET' | 'APPEND_ONLY_MISSING'
 

--- a/packages/cli/tests/cases/unit/actions.test.ts
+++ b/packages/cli/tests/cases/unit/actions.test.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import { CliError, ExitCode, Output, OutputStream, renderCliError } from '@contember/cli-common'
 import { GraphQlClient } from '@contember/graphql-client'
 import { RemoteProjectResolver } from '../../../src/lib/project/RemoteProjectResolver.js'
-import { ActionsApi, ActionsClient, Event } from '../../../src/lib/actions/ActionsClient.js'
+import { ActionsApi, ActionsClient, Event, Variable } from '../../../src/lib/actions/ActionsClient.js'
 import { ActionsClientResolver, resolveActionsClient } from '../../../src/lib/actions/resolveActionsClient.js'
 import { runActionMutationBatch } from '../../../src/lib/actions/runActionMutationBatch.js'
 import { ActionsListFailedEventsCommand } from '../../../src/commands/actions/ActionsListFailedEventsCommand.js'
@@ -159,7 +159,10 @@ describe('actions failed-events', () => {
 })
 
 describe('actions list-variables', () => {
-	const variables = [{ name: 'a', value: '1' }, { name: 'b', value: '2' }]
+	const variables: Variable[] = [
+		{ name: 'a', value: '1', source: 'DATABASE' },
+		{ name: 'b', value: null, source: 'ENVIRONMENT' },
+	]
 
 	test('--json prints the raw variable array', async () => {
 		const command = new ActionsListVariablesCommand(remoteProjectResolver, resolverFor(fakeApi({ listVariables: async () => variables })))
@@ -179,6 +182,18 @@ describe('actions list-variables', () => {
 
 		expect(code).toBe(ExitCode.Success)
 		expect(stdout.lines).toStrictEqual(['a', 'b'])
+	})
+
+	test('names the source and does not invent a value for an environment variable', async () => {
+		const command = new ActionsListVariablesCommand(remoteProjectResolver, resolverFor(fakeApi({ listVariables: async () => variables })))
+		const { output, stdout } = createTestOutput()
+
+		const code = await command.run([], output)
+
+		expect(code).toBe(ExitCode.Success)
+		expect(stdout.text).toContain('Database')
+		expect(stdout.text).toContain('Environment (read-only)')
+		expect(stdout.text).toContain('<not readable>')
 	})
 })
 

--- a/packages/engine-actions/CLAUDE.md
+++ b/packages/engine-actions/CLAUDE.md
@@ -41,9 +41,11 @@ States: `created` → `processing` → `succeed` | `retrying` → `failed` | `st
 - the engine environment — `<PROJECT>_ACTIONS_VARIABLE_<NAME>`, falling back to `DEFAULT_ACTIONS_VARIABLE_<NAME>`,
   with the project part built by `projectNameToEnvName` (the same convention as `%project.env.X%`)
 
-An environment value overrides a row of the same name, is reported as `source: ENVIRONMENT` and `setVariables`
-rejects it, so exactly one writer owns each value. The env map reaches `VariablesManager` as the master
-container's `env` service; the project slug comes from `ProjectDispatcher` (worker) or `ActionsContext` (API).
+An environment value overrides a row of the same name and is neither readable nor writable through the API:
+`listVariables` reports it as `source: ENVIRONMENT` with a `null` value and `setVariables` rejects it, so its
+only owner is the secret store it came from. Only `fetchVariables` (dispatch) ever sees it. The env map reaches
+`VariablesManager` as the master container's `env` service; the project slug comes from `ProjectDispatcher`
+(worker) or `ActionsContext` (API).
 
 ## GraphQL API (mounted at `/actions/:projectSlug`)
 

--- a/packages/engine-actions/CLAUDE.md
+++ b/packages/engine-actions/CLAUDE.md
@@ -33,6 +33,18 @@ States: `created` → `processing` → `succeed` | `retrying` → `failed` | `st
 - Response: optional `{ failures: [{ eventId, error }] }`
 - Payload wrapped in meta envelope (eventId, transactionId, identity, timestamps, retries)
 
+## Variables
+
+`{{name}}` in a target's URL or headers, resolved at dispatch time from two sources:
+
+- rows in `actions_variable`, written by the `setVariables` mutation
+- the engine environment — `<PROJECT>_ACTIONS_VARIABLE_<NAME>`, falling back to `DEFAULT_ACTIONS_VARIABLE_<NAME>`,
+  with the project part built by `projectNameToEnvName` (the same convention as `%project.env.X%`)
+
+An environment value overrides a row of the same name, is reported as `source: ENVIRONMENT` and `setVariables`
+rejects it, so exactly one writer owns each value. The env map reaches `VariablesManager` as the master
+container's `env` service; the project slug comes from `ProjectDispatcher` (worker) or `ActionsContext` (API).
+
 ## GraphQL API (mounted at `/actions/:projectSlug`)
 
 Mutations: `processBatch`, `retryEvent`, `stopEvent`, `setVariables` (MERGE/SET/APPEND_ONLY_MISSING)

--- a/packages/engine-actions/package.json
+++ b/packages/engine-actions/package.json
@@ -41,6 +41,7 @@
     "prom-client": "catalog:"
   },
   "devDependencies": {
+    "@contember/database-tester": "workspace:*",
     "@types/bun": "catalog:",
     "@types/ws": "catalog:",
     "graphql": "catalog:"

--- a/packages/engine-actions/src/dispatch/EventDispatcher.ts
+++ b/packages/engine-actions/src/dispatch/EventDispatcher.ts
@@ -10,6 +10,7 @@ type ProcessBatchArgs = {
 	db: DatabaseContext
 	contentSchemaResolver: ContentSchemaResolver
 	logger: Logger
+	project: { slug: string }
 }
 
 type ProcessBatchResult = {
@@ -32,7 +33,7 @@ export class EventDispatcher {
 	) {
 	}
 
-	async processBatch({ db, contentSchemaResolver, logger }: ProcessBatchArgs): Promise<ProcessBatchResult> {
+	async processBatch({ db, contentSchemaResolver, logger, project }: ProcessBatchArgs): Promise<ProcessBatchResult> {
 		const schema = (await contentSchemaResolver.getSchema({ db, normalize: true })).schema
 		const batchId = Math.random().toString().substring(2)
 		const batchLogger = logger.child({ loc: 'Actions.EventDispatcher', batchId })
@@ -55,7 +56,7 @@ export class EventDispatcher {
 			batchLogger.debug('Processing started', {
 				events: batch.events.map(it => it.id),
 			})
-			const variables = await this.variablesManager.fetchVariables(db)
+			const variables = await this.variablesManager.fetchVariables(db, project.slug)
 			const handledEvents = await handler.handle({ target, events, logger: batchLogger, variables })
 			const { succeeded, retried, failed } = await this.eventsRepository.persistProcessed(db.client, handledEvents, batchLogger)
 			batchLogger.debug('Processing done', { succeed: succeeded, failed })

--- a/packages/engine-actions/src/dispatch/ProjectDispatcher.ts
+++ b/packages/engine-actions/src/dispatch/ProjectDispatcher.ts
@@ -83,6 +83,7 @@ export class ProjectDispatcher implements Runnable {
 								db,
 								contentSchemaResolver: this.contentSchemaResolver,
 								logger,
+								project: { slug: this.projectSlug },
 							})
 							const terminalFailed = failedAfterAttempt + failedUnknownTarget
 							this.metrics.succeeded(succeeded)

--- a/packages/engine-actions/src/graphql/resolvers/mutation/SetVariablesMutationResolver.ts
+++ b/packages/engine-actions/src/graphql/resolvers/mutation/SetVariablesMutationResolver.ts
@@ -12,7 +12,7 @@ export class SetVariablesMutationResolver implements MutationResolvers<ActionsCo
 	async setVariables(parent: unknown, { args }: MutationSetVariablesArgs, ctx: ActionsContext) {
 		await ctx.requireAccess(ActionsAuthorizationActions.VARIABLES_SET)
 
-		await this.variablesManager.setVariables(ctx.db, args)
+		await this.variablesManager.setVariables(ctx.db, args, ctx.project.slug)
 
 		return {
 			ok: true,

--- a/packages/engine-actions/src/graphql/resolvers/query/VariablesQueryResolver.ts
+++ b/packages/engine-actions/src/graphql/resolvers/query/VariablesQueryResolver.ts
@@ -12,9 +12,6 @@ export class VariablesQueryResolver implements QueryResolvers<ActionsContext> {
 	async variables(parent: unknown, args: unknown, ctx: ActionsContext) {
 		await ctx.requireAccess(ActionsAuthorizationActions.VARIABLES_VIEW)
 
-		return Object.entries(await this.variablesManager.fetchVariables(ctx.db)).map(([name, value]) => ({
-			name,
-			value,
-		}))
+		return await this.variablesManager.listVariables(ctx.db, ctx.project.slug)
 	}
 }

--- a/packages/engine-actions/src/graphql/schema/actions.graphql.ts
+++ b/packages/engine-actions/src/graphql/schema/actions.graphql.ts
@@ -100,6 +100,17 @@ export const schema: DocumentNode = gql`
     type Variable {
         name: String!
         value: String!
+        source: VariableSource!
     }
+
+	"""
+	Where the value comes from.
+	- DATABASE is stored in the project database and can be changed with setVariables
+	- ENVIRONMENT is supplied by the engine environment, overrides a stored value of the same name and is read-only
+	"""
+	enum VariableSource {
+		DATABASE
+		ENVIRONMENT
+	}
 
 `

--- a/packages/engine-actions/src/graphql/schema/actions.graphql.ts
+++ b/packages/engine-actions/src/graphql/schema/actions.graphql.ts
@@ -99,14 +99,15 @@ export const schema: DocumentNode = gql`
 
     type Variable {
         name: String!
-        value: String!
+        """Null when the value is not readable, which is every ENVIRONMENT one."""
+        value: String
         source: VariableSource!
     }
 
 	"""
 	Where the value comes from.
-	- DATABASE is stored in the project database and can be changed with setVariables
-	- ENVIRONMENT is supplied by the engine environment, overrides a stored value of the same name and is read-only
+	- DATABASE is stored in the project database, readable and writable with setVariables
+	- ENVIRONMENT is supplied by the engine environment, overrides a stored value of the same name, and is neither readable nor writable
 	"""
 	enum VariableSource {
 		DATABASE

--- a/packages/engine-actions/src/graphql/schema/index.ts
+++ b/packages/engine-actions/src/graphql/schema/index.ts
@@ -137,7 +137,8 @@ export type Variable = {
 	readonly __typename?: 'Variable'
 	readonly name: Scalars['String']['output']
 	readonly source: VariableSource
-	readonly value: Scalars['String']['output']
+	/** Null when the value is not readable, which is every ENVIRONMENT one. */
+	readonly value?: Maybe<Scalars['String']['output']>
 }
 
 export type VariableInput = {
@@ -147,8 +148,8 @@ export type VariableInput = {
 
 /**
  * Where the value comes from.
- * - DATABASE is stored in the project database and can be changed with setVariables
- * - ENVIRONMENT is supplied by the engine environment, overrides a stored value of the same name and is read-only
+ * - DATABASE is stored in the project database, readable and writable with setVariables
+ * - ENVIRONMENT is supplied by the engine environment, overrides a stored value of the same name, and is neither readable nor writable
  */
 export type VariableSource =
 	| 'DATABASE'
@@ -346,7 +347,7 @@ export interface UUIDScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 export type VariableResolvers<ContextType = any, ParentType extends ResolversParentTypes['Variable'] = ResolversParentTypes['Variable']> = {
 	name?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	source?: Resolver<ResolversTypes['VariableSource'], ParentType, ContextType>
-	value?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }
 

--- a/packages/engine-actions/src/graphql/schema/index.ts
+++ b/packages/engine-actions/src/graphql/schema/index.ts
@@ -136,6 +136,7 @@ export type StopEventResponse = {
 export type Variable = {
 	readonly __typename?: 'Variable'
 	readonly name: Scalars['String']['output']
+	readonly source: VariableSource
 	readonly value: Scalars['String']['output']
 }
 
@@ -143,6 +144,15 @@ export type VariableInput = {
 	readonly name: Scalars['String']['input']
 	readonly value: Scalars['String']['input']
 }
+
+/**
+ * Where the value comes from.
+ * - DATABASE is stored in the project database and can be changed with setVariables
+ * - ENVIRONMENT is supplied by the engine environment, overrides a stored value of the same name and is read-only
+ */
+export type VariableSource =
+	| 'DATABASE'
+	| 'ENVIRONMENT'
 
 export type ResolverTypeWrapper<T> = Promise<T> | T
 
@@ -231,6 +241,7 @@ export type ResolversTypes = {
 	UUID: ResolverTypeWrapper<Scalars['UUID']['output']>
 	Variable: ResolverTypeWrapper<Variable>
 	VariableInput: VariableInput
+	VariableSource: VariableSource
 }
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -334,6 +345,7 @@ export interface UUIDScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 
 export type VariableResolvers<ContextType = any, ParentType extends ResolversParentTypes['Variable'] = ResolversParentTypes['Variable']> = {
 	name?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+	source?: Resolver<ResolversTypes['VariableSource'], ParentType, ContextType>
 	value?: Resolver<ResolversTypes['String'], ParentType, ContextType>
 	__isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>
 }

--- a/packages/engine-actions/src/index.ts
+++ b/packages/engine-actions/src/index.ts
@@ -68,8 +68,8 @@ export default class ActionsPlugin implements Plugin {
 					this.actionsMetrics = metrics
 					return metrics
 				})
-				.addService('actions_variableManager', () => {
-					return new VariablesManager()
+				.addService('actions_variableManager', ({ env }) => {
+					return new VariablesManager(env)
 				})
 				.addService('actions_eventRepository', () => {
 					return new EventsRepository()

--- a/packages/engine-actions/src/model/VariablesManager.ts
+++ b/packages/engine-actions/src/model/VariablesManager.ts
@@ -1,19 +1,47 @@
 import { DatabaseContext } from '@contember/engine-system-api'
 import { VariablesQuery } from './VariablesQuery.js'
-import { SetVariablesArgs } from '../graphql/schema/index.js'
+import { SetVariablesArgs, Variable } from '../graphql/schema/index.js'
 import { DeleteBuilder } from '@contember/database'
 import { SetVariableCommand } from './SetVariableCommand.js'
+import { Env, projectNameToEnvName } from '@contember/engine-http'
+import { UserInputError } from '@contember/graphql-utils'
 
 export type VariablesMap = Record<string, string>
 
+/** Between the project (or DEFAULT) prefix and the variable name: `MY_PROJECT_ACTIONS_VARIABLE_API_KEY`. */
+const ENV_NAME_INFIX = '_ACTIONS_VARIABLE_'
+
 export class VariablesManager {
-	public async fetchVariables(db: DatabaseContext): Promise<VariablesMap> {
-		return Object.fromEntries((await db.queryHandler.fetch(new VariablesQuery())).map(it => [it.name, it.value]))
+	constructor(
+		private readonly env: Env,
+	) {
 	}
 
-	public async setVariables(db: DatabaseContext, args: SetVariablesArgs) {
+	/** Values for dispatch. A variable supplied by the environment shadows a stored row of the same name. */
+	public async fetchVariables(db: DatabaseContext, projectSlug: string): Promise<VariablesMap> {
+		return { ...await this.fetchStoredVariables(db), ...this.fetchEnvVariables(projectSlug) }
+	}
+
+	public async listVariables(db: DatabaseContext, projectSlug: string): Promise<Variable[]> {
+		const envVariables = this.fetchEnvVariables(projectSlug)
+		const stored = await this.fetchStoredVariables(db)
+		return [
+			...Object.entries(stored)
+				.filter(([name]) => !(name in envVariables))
+				.map(([name, value]): Variable => ({ name, value, source: 'DATABASE' })),
+			...Object.entries(envVariables).map(([name, value]): Variable => ({ name, value, source: 'ENVIRONMENT' })),
+		]
+	}
+
+	public async setVariables(db: DatabaseContext, args: SetVariablesArgs, projectSlug: string) {
+		const envVariables = this.fetchEnvVariables(projectSlug)
+		const readOnly = args.variables.map(it => it.name).filter(it => it in envVariables)
+		if (readOnly.length > 0) {
+			throw new UserInputError(`Variables supplied by the environment are read-only: ${readOnly.join(', ')}`)
+		}
+
 		return await db.transaction(async db => {
-			const current = await this.fetchVariables(db)
+			const current = await this.fetchStoredVariables(db)
 			const mode = args.mode ?? 'MERGE'
 			const inputVariables = Object.fromEntries(args.variables.map(it => [it.name, it.value]))
 
@@ -45,5 +73,25 @@ export class VariablesManager {
 				await db.commandBus.execute(new SetVariableCommand(name, value))
 			}
 		})
+	}
+
+	private async fetchStoredVariables(db: DatabaseContext): Promise<VariablesMap> {
+		return Object.fromEntries((await db.queryHandler.fetch(new VariablesQuery())).map(it => [it.name, it.value]))
+	}
+
+	private fetchEnvVariables(projectSlug: string): VariablesMap {
+		// the project prefix is read last, so it overrides the shared DEFAULT_ one
+		const prefixes = [`DEFAULT${ENV_NAME_INFIX}`, projectNameToEnvName(projectSlug) + ENV_NAME_INFIX]
+		const result: VariablesMap = {}
+		for (const prefix of prefixes) {
+			for (const [name, value] of Object.entries(this.env)) {
+				// an empty value counts as unset, the same as the `||` fallback of the config parameter resolver
+				if (!name.startsWith(prefix) || name.length === prefix.length || value === '') {
+					continue
+				}
+				result[name.slice(prefix.length)] = value
+			}
+		}
+		return result
 	}
 }

--- a/packages/engine-actions/src/model/VariablesManager.ts
+++ b/packages/engine-actions/src/model/VariablesManager.ts
@@ -12,6 +12,9 @@ export type VariablesMap = Record<string, string>
 const ENV_NAME_INFIX = '_ACTIONS_VARIABLE_'
 
 export class VariablesManager {
+	/** The environment does not change while the process runs, so each project resolves its prefixes once. */
+	private readonly envVariablesCache = new Map<string, VariablesMap>()
+
 	constructor(
 		private readonly env: Env,
 	) {
@@ -22,20 +25,24 @@ export class VariablesManager {
 		return { ...await this.fetchStoredVariables(db), ...this.fetchEnvVariables(projectSlug) }
 	}
 
+	/**
+	 * The listing is an inventory, not a way to read secrets: an environment value stays in the operator's
+	 * secret store and is reported as a name with no value.
+	 */
 	public async listVariables(db: DatabaseContext, projectSlug: string): Promise<Variable[]> {
 		const envVariables = this.fetchEnvVariables(projectSlug)
 		const stored = await this.fetchStoredVariables(db)
 		return [
 			...Object.entries(stored)
-				.filter(([name]) => !(name in envVariables))
+				.filter(([name]) => !Object.hasOwn(envVariables, name))
 				.map(([name, value]): Variable => ({ name, value, source: 'DATABASE' })),
-			...Object.entries(envVariables).map(([name, value]): Variable => ({ name, value, source: 'ENVIRONMENT' })),
-		]
+			...Object.keys(envVariables).map((name): Variable => ({ name, value: null, source: 'ENVIRONMENT' })),
+		].sort((a, b) => a.name.localeCompare(b.name))
 	}
 
 	public async setVariables(db: DatabaseContext, args: SetVariablesArgs, projectSlug: string) {
 		const envVariables = this.fetchEnvVariables(projectSlug)
-		const readOnly = args.variables.map(it => it.name).filter(it => it in envVariables)
+		const readOnly = args.variables.map(it => it.name).filter(it => Object.hasOwn(envVariables, it))
 		if (readOnly.length > 0) {
 			throw new UserInputError(`Variables supplied by the environment are read-only: ${readOnly.join(', ')}`)
 		}
@@ -58,7 +65,7 @@ export class VariablesManager {
 					break
 			}
 
-			const toDelete = Object.keys(current).filter(it => !(it in newVariables))
+			const toDelete = Object.keys(current).filter(it => !Object.hasOwn(newVariables, it))
 			if (toDelete.length > 0) {
 				await DeleteBuilder.create()
 					.from('actions_variable')
@@ -80,6 +87,10 @@ export class VariablesManager {
 	}
 
 	private fetchEnvVariables(projectSlug: string): VariablesMap {
+		const cached = this.envVariablesCache.get(projectSlug)
+		if (cached !== undefined) {
+			return cached
+		}
 		// the project prefix is read last, so it overrides the shared DEFAULT_ one
 		const prefixes = [`DEFAULT${ENV_NAME_INFIX}`, projectNameToEnvName(projectSlug) + ENV_NAME_INFIX]
 		const result: VariablesMap = {}
@@ -92,6 +103,7 @@ export class VariablesManager {
 				result[name.slice(prefix.length)] = value
 			}
 		}
+		this.envVariablesCache.set(projectSlug, result)
 		return result
 	}
 }

--- a/packages/engine-actions/tests/cases/unit/variablesManager.test.ts
+++ b/packages/engine-actions/tests/cases/unit/variablesManager.test.ts
@@ -68,13 +68,32 @@ describe('variables from the environment', () => {
 		expect(await manager.fetchVariables(db, 'my-project')).toEqual({ API_KEY: 'from-db', baseUrl: 'http://localhost' })
 	})
 
-	test('listing reports where each value comes from', async () => {
+	test('listing reports where each value comes from, sorted by name', async () => {
 		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
 		const db = createDb([selectVariables([{ name: 'API_KEY', value: 'from-db' }, { name: 'baseUrl', value: 'http://localhost' }])])
 
 		expect(await manager.listVariables(db, 'my-project')).toEqual([
+			{ name: 'API_KEY', value: null, source: 'ENVIRONMENT' },
 			{ name: 'baseUrl', value: 'http://localhost', source: 'DATABASE' },
-			{ name: 'API_KEY', value: 'from-env', source: 'ENVIRONMENT' },
+		])
+	})
+
+	test('listing never returns an environment value, not even the one it shadows', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb([selectVariables([{ name: 'API_KEY', value: 'from-db' }])])
+
+		const listed = JSON.stringify(await manager.listVariables(db, 'my-project'))
+		expect(listed).not.toContain('from-env')
+		expect(listed).not.toContain('from-db')
+	})
+
+	test('a stored variable named after an Object prototype member is still listed and writable', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb([selectVariables([{ name: 'toString', value: 'from-db' }])])
+
+		expect(await manager.listVariables(db, 'my-project')).toEqual([
+			{ name: 'API_KEY', value: null, source: 'ENVIRONMENT' },
+			{ name: 'toString', value: 'from-db', source: 'DATABASE' },
 		])
 	})
 })
@@ -87,6 +106,21 @@ describe('setVariables', () => {
 		await expect(manager.setVariables(db, { variables: [{ name: 'API_KEY', value: 'attempted' }] }, 'my-project')).rejects.toThrow(
 			'Variables supplied by the environment are read-only: API_KEY',
 		)
+	})
+
+	test('does not mistake an Object prototype member for an environment variable', async () => {
+		const manager = new VariablesManager({})
+		const db = createDb(transaction(
+			selectVariables([]),
+			{
+				sql:
+					'insert into "system"."actions_variable" ("id", "name", "value") values (?, ?, ?) on conflict ("name") do update set "value" = ?, "updated_at" = NOW()',
+				parameters: [testUuid(1), 'toString', 'plain', 'plain'],
+				response: { rowCount: 1 },
+			},
+		))
+
+		await manager.setVariables(db, { variables: [{ name: 'toString', value: 'plain' }] }, 'my-project')
 	})
 
 	test('writes a variable the environment does not supply', async () => {

--- a/packages/engine-actions/tests/cases/unit/variablesManager.test.ts
+++ b/packages/engine-actions/tests/cases/unit/variablesManager.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+import { createConnectionMock, ExpectedQuery } from '@contember/database-tester'
+import { DatabaseContext, DatabaseContextFactory } from '@contember/engine-system-api'
+import { VariablesManager } from '../../../src/model/VariablesManager.js'
+import { testUuid } from '../../src/uuid.js'
+
+const selectVariables = (rows: { name: string; value: string }[]): ExpectedQuery => ({
+	sql: 'select * from "system"."actions_variable"',
+	parameters: [],
+	response: { rows },
+})
+
+const transaction = (...queries: ExpectedQuery[]): ExpectedQuery[] => [
+	{ sql: 'BEGIN;', response: { rowCount: 1 } },
+	{ sql: 'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ', response: { rowCount: 1 } },
+	...queries,
+	{ sql: 'COMMIT;', response: { rowCount: 1 } },
+]
+
+const createDb = (queries: ExpectedQuery[]): DatabaseContext =>
+	new DatabaseContextFactory('system', { uuid: () => testUuid(1) }).create(createConnectionMock(queries))
+
+describe('variables from the environment', () => {
+	test('a project-scoped env variable overrides a stored row', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb([selectVariables([{ name: 'API_KEY', value: 'from-db' }])])
+
+		expect(await manager.fetchVariables(db, 'my-project')).toEqual({ API_KEY: 'from-env' })
+	})
+
+	test('a project-scoped env variable works without any stored row', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb([selectVariables([])])
+
+		expect(await manager.fetchVariables(db, 'my-project')).toEqual({ API_KEY: 'from-env' })
+	})
+
+	test('the shared DEFAULT_ value applies to every project, the project-scoped one wins', async () => {
+		const manager = new VariablesManager({
+			DEFAULT_ACTIONS_VARIABLE_API_KEY: 'shared',
+			DEFAULT_ACTIONS_VARIABLE_BASE_URL: 'https://example.com',
+			MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'mine',
+		})
+		const db = createDb([selectVariables([])])
+
+		expect(await manager.fetchVariables(db, 'my-project')).toEqual({
+			API_KEY: 'mine',
+			BASE_URL: 'https://example.com',
+		})
+	})
+
+	test('another project and unrelated env variables are ignored', async () => {
+		const manager = new VariablesManager({
+			OTHER_ACTIONS_VARIABLE_API_KEY: 'not-mine',
+			MY_PROJECT_ACTIONS_VARIABLE_: 'no-name',
+			MY_PROJECT_ACTIONS_VARIABLE_BLANK: '',
+			CONTEMBER_ROOT_TOKEN: 'unrelated',
+		})
+		const db = createDb([selectVariables([{ name: 'API_KEY', value: 'from-db' }])])
+
+		expect(await manager.fetchVariables(db, 'my-project')).toEqual({ API_KEY: 'from-db' })
+	})
+
+	test('a stored variable is unaffected when the environment supplies nothing', async () => {
+		const manager = new VariablesManager({})
+		const db = createDb([selectVariables([{ name: 'API_KEY', value: 'from-db' }, { name: 'baseUrl', value: 'http://localhost' }])])
+
+		expect(await manager.fetchVariables(db, 'my-project')).toEqual({ API_KEY: 'from-db', baseUrl: 'http://localhost' })
+	})
+
+	test('listing reports where each value comes from', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb([selectVariables([{ name: 'API_KEY', value: 'from-db' }, { name: 'baseUrl', value: 'http://localhost' }])])
+
+		expect(await manager.listVariables(db, 'my-project')).toEqual([
+			{ name: 'baseUrl', value: 'http://localhost', source: 'DATABASE' },
+			{ name: 'API_KEY', value: 'from-env', source: 'ENVIRONMENT' },
+		])
+	})
+})
+
+describe('setVariables', () => {
+	test('rejects a name supplied by the environment without touching the database', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb([])
+
+		await expect(manager.setVariables(db, { variables: [{ name: 'API_KEY', value: 'attempted' }] }, 'my-project')).rejects.toThrow(
+			'Variables supplied by the environment are read-only: API_KEY',
+		)
+	})
+
+	test('writes a variable the environment does not supply', async () => {
+		const manager = new VariablesManager({ MY_PROJECT_ACTIONS_VARIABLE_API_KEY: 'from-env' })
+		const db = createDb(transaction(
+			selectVariables([]),
+			{
+				sql:
+					'insert into "system"."actions_variable" ("id", "name", "value") values (?, ?, ?) on conflict ("name") do update set "value" = ?, "updated_at" = NOW()',
+				parameters: [testUuid(1), 'baseUrl', 'http://localhost', 'http://localhost'],
+				response: { rowCount: 1 },
+			},
+		))
+
+		await manager.setVariables(db, { variables: [{ name: 'baseUrl', value: 'http://localhost' }] }, 'my-project')
+	})
+
+	test('SET mode drops the stored rows that are not submitted', async () => {
+		const manager = new VariablesManager({})
+		const db = createDb(transaction(
+			selectVariables([{ name: 'baseUrl', value: 'http://localhost' }, { name: 'stale', value: 'gone' }]),
+			{
+				sql: 'delete from "system"."actions_variable" where "name" in (?)',
+				parameters: ['stale'],
+				response: { rowCount: 1 },
+			},
+		))
+
+		await manager.setVariables(db, { variables: [{ name: 'baseUrl', value: 'http://localhost' }], mode: 'SET' }, 'my-project')
+	})
+})

--- a/packages/engine-http/src/MasterContainer.ts
+++ b/packages/engine-http/src/MasterContainer.ts
@@ -3,7 +3,7 @@ import { SystemContainerFactory } from '@contember/engine-system-api'
 import { TenantContainerFactory } from '@contember/engine-tenant-api'
 import { ModificationHandlerFactory } from '@contember/schema-migrations'
 import { Initializer } from './bootstrap/index.js'
-import { ServerConfig } from './config/config.js'
+import { Env, ServerConfig } from './config/config.js'
 
 import { DatabaseMetadataResolver } from '@contember/database'
 import { ExecutionContainerFactory, GraphQlSchemaBuilderFactory, PermissionFactory } from '@contember/engine-content-api'
@@ -68,6 +68,8 @@ export interface MasterContainerArgs {
 	serverConfig: ServerConfig
 	projectConfigResolver: ProjectConfigResolver
 	tenantConfigResolver: TenantConfigResolver
+	/** The environment the config was resolved from, so a plugin can read its own `<PROJECT>_*` values out of it. */
+	env: Env
 	plugins: Plugin[]
 	logger: Logger
 	version?: string
@@ -92,12 +94,14 @@ export class MasterContainerFactory {
 		plugins,
 		projectConfigResolver,
 		tenantConfigResolver,
+		env,
 		version,
 		logger,
 		processType,
 	}: MasterContainerArgs) {
 		return new Builder({})
 			.addService('serverConfig', () => serverConfig)
+			.addService('env', () => env)
 			.addService('debugMode', () => debugMode)
 			.addService('version', () => version)
 			.addService('processType', () => processType)

--- a/packages/engine-http/src/config/config.ts
+++ b/packages/engine-http/src/config/config.ts
@@ -22,6 +22,7 @@ export async function readConfig<T extends ServerConfig>(
 	serverConfig: T
 	projectConfigResolver: ProjectConfigResolver
 	tenantConfigResolver: TenantConfigResolver
+	env: Env
 }> {
 	const loader = new ConfigLoader()
 	const configs = await Promise.all(
@@ -49,5 +50,6 @@ export async function readConfig<T extends ServerConfig>(
 		serverConfig,
 		projectConfigResolver: createProjectConfigResolver(env, rawConfig, configProcessors),
 		tenantConfigResolver: createTenantConfigResolver(env, rawConfig.tenant),
+		env,
 	}
 }

--- a/packages/engine-http/src/config/projectConfigResolver.ts
+++ b/packages/engine-http/src/config/projectConfigResolver.ts
@@ -77,7 +77,7 @@ const createProjectParametersResolver = (slug: string, env: Env, secrets: Projec
 	throw new UndefinedParameterError(`Parameter "${parts.join('.')}" not found.`)
 }
 
-const projectNameToEnvName = (projectName: string): string => {
+export const projectNameToEnvName = (projectName: string): string => {
 	const envName = projectName.toUpperCase().replace(/-/g, '_')
 	if (envName === 'TENANT') {
 		throw new Error('Forbidden project name')

--- a/packages/engine-http/src/index.ts
+++ b/packages/engine-http/src/index.ts
@@ -3,7 +3,7 @@ import Koa from 'koa'
 
 export * from './config/config.js'
 export * from './config/ConfigProcessor.js'
-export * from './config/projectConfigResolver.js'
+export { projectNameToEnvName } from './config/projectConfigResolver.js'
 export * from './config/tenantConfigResolver.js'
 export * from './common/index.js'
 export * from './content/index.js'

--- a/packages/engine-http/src/index.ts
+++ b/packages/engine-http/src/index.ts
@@ -3,6 +3,7 @@ import Koa from 'koa'
 
 export * from './config/config.js'
 export * from './config/ConfigProcessor.js'
+export * from './config/projectConfigResolver.js'
 export * from './config/tenantConfigResolver.js'
 export * from './common/index.js'
 export * from './content/index.js'

--- a/packages/engine-server/src/start.ts
+++ b/packages/engine-server/src/start.ts
@@ -28,7 +28,7 @@ process.on('warning', message => {
 	const version = await getServerVersion()
 	printStartInfo({ version, isDebug }, logger)
 	const plugins = await loadPlugins()
-	const { serverConfig, projectConfigResolver, tenantConfigResolver } = await resolveServerConfig({ plugins, serverConfigSchema })
+	const { serverConfig, projectConfigResolver, tenantConfigResolver, env } = await resolveServerConfig({ plugins, serverConfigSchema })
 
 	if (process.argv[2] === 'validate') {
 		process.exit(0)
@@ -51,6 +51,7 @@ process.on('warning', message => {
 		serverConfig,
 		projectConfigResolver,
 		tenantConfigResolver,
+		env,
 		plugins,
 		processType,
 		version,

--- a/packages/panel-ui/src/modules/actions/ActionsVariablesPage.tsx
+++ b/packages/panel-ui/src/modules/actions/ActionsVariablesPage.tsx
@@ -121,7 +121,7 @@ const ActionsVariables = () => {
 		<PageStack>
 			<PageHeader
 				title="Variables"
-				description="Values the dispatcher interpolates into a target's URL and headers as {{name}}. Whatever the API returns is shown as it is — it does not mask values."
+				description="Values the dispatcher interpolates into a target's URL and headers as {{name}}. A variable the engine environment supplies overrides a stored one of the same name and cannot be edited here. Whatever the API returns is shown as it is — it does not mask values."
 				actions={
 					<>
 						<Link to={{ pageName: 'actionsQueue', parameters: { project: projectSlug } }}>
@@ -159,6 +159,7 @@ const ActionsVariables = () => {
 											<TableRow>
 												<TableHead>Name</TableHead>
 												<TableHead>Value</TableHead>
+												<TableHead>Source</TableHead>
 												<TableHead />
 											</TableRow>
 										</TableHeader>
@@ -167,17 +168,23 @@ const ActionsVariables = () => {
 												<TableRow key={variable.name}>
 													<TableCell className="font-mono text-xs">{variable.name}</TableCell>
 													<TableCell className="font-mono text-xs break-all">{variable.value}</TableCell>
+													<TableCell className="text-xs text-muted-foreground">
+														{variable.source === 'ENVIRONMENT' ? 'Environment (read-only)' : 'Database'}
+													</TableCell>
 													<TableCell>
 														<div className="flex justify-end">
-															<FormDialog
-																label="Edit"
-																title={`Set ${variable.name}`}
-																description="Takes effect on the next dispatch; events already in flight keep the old value."
-																icon={<PencilIcon className="size-4" />}
-																variant="outline"
-															>
-																{close => <SetVariableForm initial={variable} close={close} onSaved={refresh} />}
-															</FormDialog>
+															{/* An environment value has one writer, the operator's secret store, so the API refuses to set it. */}
+															{variable.source === 'DATABASE' && (
+																<FormDialog
+																	label="Edit"
+																	title={`Set ${variable.name}`}
+																	description="Takes effect on the next dispatch; events already in flight keep the old value."
+																	icon={<PencilIcon className="size-4" />}
+																	variant="outline"
+																>
+																	{close => <SetVariableForm initial={variable} close={close} onSaved={refresh} />}
+																</FormDialog>
+															)}
 														</div>
 													</TableCell>
 												</TableRow>

--- a/packages/panel-ui/src/modules/actions/ActionsVariablesPage.tsx
+++ b/packages/panel-ui/src/modules/actions/ActionsVariablesPage.tsx
@@ -121,7 +121,7 @@ const ActionsVariables = () => {
 		<PageStack>
 			<PageHeader
 				title="Variables"
-				description="Values the dispatcher interpolates into a target's URL and headers as {{name}}. A variable the engine environment supplies overrides a stored one of the same name and cannot be edited here. Whatever the API returns is shown as it is — it does not mask values."
+				description="Values the dispatcher interpolates into a target's URL and headers as {{name}}. A variable the engine environment supplies overrides a stored one of the same name; the API does not return its value and it cannot be edited here. A stored value is shown as it is — it is not masked."
 				actions={
 					<>
 						<Link to={{ pageName: 'actionsQueue', parameters: { project: projectSlug } }}>
@@ -167,7 +167,9 @@ const ActionsVariables = () => {
 											{variables?.map(variable => (
 												<TableRow key={variable.name}>
 													<TableCell className="font-mono text-xs">{variable.name}</TableCell>
-													<TableCell className="font-mono text-xs break-all">{variable.value}</TableCell>
+													<TableCell className="font-mono text-xs break-all">
+														{variable.value ?? <span className="font-sans text-muted-foreground">Not readable — held by the engine environment</span>}
+													</TableCell>
 													<TableCell className="text-xs text-muted-foreground">
 														{variable.source === 'ENVIRONMENT' ? 'Environment (read-only)' : 'Database'}
 													</TableCell>

--- a/scripts/benchmark/src/start-server.ts
+++ b/scripts/benchmark/src/start-server.ts
@@ -4,12 +4,13 @@ import { createContainer, readConfig } from '@contember/engine-http'
 
 import { createLogger, JsonStreamLoggerHandler } from '@contember/logger'
 ;(async () => {
-	const { serverConfig, projectConfigResolver, tenantConfigResolver } = await readConfig()
+	const { serverConfig, projectConfigResolver, tenantConfigResolver, env } = await readConfig()
 	const container = await createContainer({
 		debugMode: false,
 		serverConfig,
 		projectConfigResolver,
 		tenantConfigResolver,
+		env,
 		plugins: [],
 		logger: createLogger(new JsonStreamLoggerHandler(process.stderr)),
 	})


### PR DESCRIPTION
An Actions variable can only live in the project database, written by the `setVariables` mutation. That has three consequences for anyone operating Contember:

1. **It cannot be delivered by the platform's own secret mechanism.** Every other secret an engine holds arrives as an environment variable — from a Kubernetes Secret, a Docker secret, a systemd credential. This one has to be injected by an authenticated API call *after* the engine is running, so the deployment pipeline needs engine credentials just to plant a webhook bearer.
2. **It does not survive a restore.** Restoring a project database from backup silently reverts every variable to its value at snapshot time. Nothing reports it; the next webhook simply presents a stale bearer and the receiver answers 401.
3. **The value therefore exists twice** — in the operator's secret store where the *receiver* reads it, and in the project database where the *sender* reads it — with nothing enforcing that the two are equal.

## What this adds

A variable's value may come from the engine's environment, using the convention the engine already has for `%project.env.X%`:

```
<PROJECT>_ACTIONS_VARIABLE_<NAME>      # per project
DEFAULT_ACTIONS_VARIABLE_<NAME>        # fallback
```

The project part is produced by the existing `projectNameToEnvName`, now exported rather than reimplemented — one implementation of the convention, not a copy.

An env-supplied variable is **read-only and wins**: it overrides a stored row of the same name, and `setVariables` rejects a write to that name before opening a transaction. The point is exactly one writer per value.

Like `%project.env.X%`, the part after the prefix is taken verbatim, so `MY_PROJECT_ACTIONS_VARIABLE_API_KEY` supplies `{{API_KEY}}`, not `{{apiKey}}`. Case-folding was the alternative and cannot round-trip (`webhookToken` ≠ `WEBHOOKTOKEN`), while enumeration is needed for both listing and the write rejection. An empty value counts as unset, matching the `||` fallback in `createProjectParametersResolver`.

## The value stays out of the API

The whole point of the env path is that the operator's store owns the value — so handing it back through `variables` would give it away to anyone allowed to read a project's variables, and a `DEFAULT_ACTIONS_VARIABLE_*` value is shared by every project, so one project's reader could read another's secret.

`Variable.value` is therefore **nullable**, and an `ENVIRONMENT` row reports `null`. The listing stays an inventory — name and source. `fetchVariables` on the dispatch path is unchanged, so the sender still resolves the real value. The panel and `contember actions list-variables` both say the value is not readable rather than printing an empty cell, and the CLI gained the Source column too, so an operator can see why `set-variables` will refuse a name before trying it.

Smaller things in the same area: membership tests use `Object.hasOwn`, so a variable named after an `Object.prototype` member is not mistaken for environment-supplied; `listVariables` sorts by name, the underlying query having no order; and the per-project env lookup is memoized, the environment being fixed for the process lifetime.

## Introspection

`Variable.source: VariableSource!` (`DATABASE` | `ENVIRONMENT`) rather than a bare `readOnly: Boolean!`. The schema already carries an operator-facing enum in this shape (`SetVariablesMode`), and `source` answers the operator's actual next question — "where does this come from" — while read-only is derivable from it. A row shadowed by an env variable is listed once, as `ENVIRONMENT`; `SET` mode still deletes it, which cleans up the duplicate.

## Plumbing, and one breaking change

No global. `readConfig` already builds the env map for the config resolvers; it now returns it, and it becomes an `env` service on the master container beside `serverConfig`. The project slug takes the two paths that already carry it: `ProjectDispatcher` → `EventDispatcher.processBatch`, and `ActionsContext.project.slug` for the API. `engine-http` exports `projectNameToEnvName` by name rather than publishing the whole config module.

**`MasterContainerArgs.env` is required.** Making it optional with a `process.env` fallback would put the global straight back. Anyone constructing a `MasterContainer` directly has to pass it; `engine-server` and the benchmark script are updated here.

`Variable.value` turning nullable is the other breaking change, for any client that reads it.

## Verification

Re-run after rebasing onto `main`:

| Command | Result |
|---|---|
| `bun install --frozen-lockfile` | 653 installs, no changes |
| `bun run pre-build` | pass |
| `bun run ts:build` | pass, 0 errors |
| `bun run lint` (biome) | pass — 3637 files |
| `bun run format:check` (dprint) | pass |
| `bun test --conditions=typescript packages/engine-actions` | 51 pass, 0 fail |
| `bun run test` (monorepo) | 2699 pass, 4 skip, 0 fail |
| `bunx deptective` | no issues, 72 packages |

Tests cover env-over-row precedence, env with no row, the `DEFAULT_` fallback, another project's prefix ignored, `listVariables` sources, that an `ENVIRONMENT` row reports a null value, and that `setVariables` rejects an env name **without issuing a query**. They run against `createConnectionMock` behind a real `DatabaseContextFactory` — no casts, no `any`.

Note that `bun test packages/engine-actions` without `--conditions=typescript` fails to resolve the workspace packages; the repo's own `test` script passes the flag.

Not verified: `test:e2e` (needs a live PostgreSQL, not started) and `bun run build`. Nothing here is DB-schema-affecting.

## Two things a reviewer should look at

- **`bun.lock` gains two lines.** One is the new `@contember/database-tester` devDependency. The other is `chalk-table` for `@contember/cli-common`, declared in its `package.json` since `57c959420` but never written to the lock. That is pre-existing drift; given how a stale lock behaves under `bun pm pack`, writing it looks like the right direction, but it is not this change's business and can be split out on request.
- **`scripts/graphql-codegen/run.sh engine-actions` does not run on `main`** — its Dockerfile copies `package.json` + `bun.lock` and runs `bun install` before copying the repo, so the `graphql-ts-client-codegen` patch file is missing and the install aborts. To regenerate `schema/index.ts` the codegen was run in a scratch directory, diffed before-SDL-change against after, and the delta hand-applied in the file's existing formatting; running the whole output would have rewritten the file with a newer codegen major (the committed one still has `Exact`/`MakeOptional`/`__isTypeOf`). `packages/graphql-client-actions` regenerated cleanly from the new SDL through the normal `pre-build`, which independently confirms the SDL is valid. The broken script is worth its own issue.
