### PR TITLE
ci: pass --allow-publish when configuring trusted publishers

### DIFF
--- a/scripts/npm-trust/run.sh
+++ b/scripts/npm-trust/run.sh
@@ -21,7 +21,7 @@ for dir in packages/*; do
       fi
 
       echo "Setting trusted publisher for $name..."
-      npm trust github "$name" --file="$WORKFLOW" --repository="$REPO" --yes
+      npm trust github "$name" --file="$WORKFLOW" --repository="$REPO" --allow-publish --yes
     fi
   fi
 done


### PR DESCRIPTION
`scripts/npm-trust/run.sh` is dead against npm 11.19 — `npm trust github` now requires an explicit permission flag, so every package in the loop aborts on:

```
npm error At least one permission flag is required (--allow-publish, --allow-stage-publish)
```

The CLI offers `--allow-publish` ("Allow npm publish") and `--allow-stage-publish` ("Allow npm stage publish"). `publish.yaml` runs a plain `npm publish`, so `--allow-publish` is the one that matches.

## Why this surfaced

The v2.2.0-alpha.4 publish failed with a 404 on `PUT @contember/engine-panel`. The workflow publishes purely over OIDC trusted publishing (`id-token: write`, no `NODE_AUTH_TOKEN`), and a trusted publisher is configured per package against a package that already exists — so a package added since the previous release has no way to make its first publish. `@contember/engine-panel` and `@contember/graphql-client-actions` were both new since alpha.3.

Both were bootstrapped with a one-off manual publish and then trusted with `--allow-publish`. On v2.2.0-alpha.5 they published from CI over OIDC along with the other 66 packages, which is what confirms the flag is the right one.

## Note on existing packages

Packages trusted before this show `permissions: ["createPackage"]`, and that is exactly what `--allow-publish` sends — `publish` is only the CLI's human-readable label for the same value:

```
$ npm trust github @contember/authorization --file=publish.yaml \
    --repository=contember/contember --allow-publish --dry-run --json
{ "permissions": ["createPackage"] }
```

So re-running the script does not change the permission of the 68 already-trusted packages; it only makes the command run again.
