### PR TITLE
fix(engine-content-api): stop re-applying entity read predicates inside ACL predicates

### DIFF
--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -57,15 +57,7 @@ export class PredicatesInjector {
 		if (shouldSimplify) {
 			predicatesWhere = { [entity.primary]: { always: true } }
 		} else {
-			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
-			// Process the predicate to inject nested entity predicates
-			predicatesWhere = this.injectPredicatesToPredicate(
-				rawPredicate,
-				entity,
-				isBackReferenceContext ?? false,
-				ancestorPath ?? [],
-				isQueryRoot,
-			)
+			predicatesWhere = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
 		}
 
 		const and = [where, predicatesWhere].filter(it => Object.keys(it).length > 0)
@@ -76,101 +68,6 @@ export class PredicatesInjector {
 			return and[0]
 		}
 		return { and: and }
-	}
-
-	/**
-	 * Processes a predicate and injects nested entity predicates for any relation traversals.
-	 * This ensures that when a predicate like { department: { company: { name: 'Acme' } } }
-	 * is used, the predicates of Department and Company are also applied.
-	 */
-	private injectPredicatesToPredicate(
-		where: Input.OptionalWhere,
-		entity: Model.Entity,
-		isBackReferenceContext: boolean,
-		ancestorPath: readonly Model.AnyRelationContext[],
-		isQueryRoot?: boolean,
-	): Input.OptionalWhere {
-		const resultWhere: Writable<Input.OptionalWhere> = {}
-
-		if (where.and) {
-			resultWhere.and = where.and
-				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
-		}
-		if (where.or) {
-			resultWhere.or = where.or
-				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
-		}
-		if (where.not) {
-			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath, isQueryRoot)
-		}
-
-		const fields = Object.keys(where).filter(it => !['and', 'or', 'not'].includes(it))
-
-		for (const field of fields) {
-			resultWhere[field] = acceptFieldVisitor(this.schema, entity, field, {
-				visitColumn: () => where[field],
-				visitRelation: context => {
-					const relationWhere = where[field] as Input.OptionalWhere | null
-					if (relationWhere === null) {
-						return null
-					}
-
-					// Check if this relation is a back-reference to somewhere in our ancestor path
-					const isBackReference = this.findBackReferencedAncestor(
-						ancestorPath,
-						context.relation.name,
-						context.entity.name,
-					) !== undefined
-					const nestedIsBackReferenceContext = isBackReference || isBackReferenceContext
-					const nestedAncestorPath: readonly Model.AnyRelationContext[] = [...ancestorPath, context]
-
-					// Recursively process the nested where (always do this to handle deeper nesting)
-					const processedNestedWhere = this.injectPredicatesToPredicate(
-						relationWhere,
-						context.targetEntity,
-						nestedIsBackReferenceContext,
-						nestedAncestorPath,
-						isQueryRoot,
-					)
-
-					// Check if we should simplify the target entity's predicate
-					const shouldSimplifyNested = nestedIsBackReferenceContext
-						&& this.findBackReferencedAncestor(nestedAncestorPath, context.relation.name, context.entity.name) !== undefined
-
-					// Get target entity's predicate (simplified if back-reference)
-					const targetPredicate = shouldSimplifyNested
-						? { [context.targetEntity.primary]: { always: true } }
-						: this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, isQueryRoot)
-
-					// Optimization: avoid duplicate { id: always } when both are simplified
-					const primaryKey = context.targetEntity.primary
-					const nestedIsAlwaysTrue = Object.keys(processedNestedWhere).length === 1
-						&& (processedNestedWhere as Record<string, unknown>)[primaryKey] !== undefined
-						&& (processedNestedWhere as Record<string, Record<string, unknown>>)[primaryKey]?.always === true
-					const targetIsAlwaysTrue = Object.keys(targetPredicate).length === 1
-						&& (targetPredicate as Record<string, unknown>)[primaryKey] !== undefined
-						&& (targetPredicate as Record<string, Record<string, unknown>>)[primaryKey]?.always === true
-
-					if (nestedIsAlwaysTrue && targetIsAlwaysTrue) {
-						return processedNestedWhere
-					}
-
-					// Combine the processed nested where with target entity's predicate
-					const parts = [processedNestedWhere, targetPredicate].filter(it => Object.keys(it).length > 0)
-					if (parts.length === 0) {
-						return {}
-					}
-					if (parts.length === 1) {
-						return parts[0]
-					}
-					return { and: parts }
-				},
-			})
-		}
-
-		return resultWhere
 	}
 
 	private injectToWhere(

--- a/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
@@ -700,27 +700,13 @@ describe('predicates injector - multi-level back-reference', () => {
 
 	it('should NOT simplify when filtering via non-ancestor relation', () => {
 		// If we query Employee directly (not through Company->Department chain)
-		// the predicate should NOT be simplified AND nested predicates should be applied
+		// the predicate should NOT be simplified — it is applied verbatim.
+		// Relation hops inside the predicate are the author's rule (as-definer semantics),
+		// so Department's/Company's own read predicates are NOT re-applied inside it.
 		const injected = injector.inject(schema.model.entities.Employee, {})
 
-		// Full predicate with nested entity predicates applied:
-		// - Employee predicate: { department: { company: { isActive: true } } }
-		// - Department predicate: { company: { isActive: true } } is added
-		// - Company predicate: { isActive: true } is added inside company traversal
 		assert.deepStrictEqual(injected, {
-			department: {
-				and: [
-					{
-						company: {
-							and: [
-								{ isActive: { eq: true } }, // from Employee predicate
-								{ isActive: { eq: true } }, // Company's own predicate
-							],
-						},
-					},
-					{ company: { isActive: { eq: true } } }, // Department's predicate
-				],
-			},
+			department: { company: { isActive: { eq: true } } },
 		})
 	})
 
@@ -864,21 +850,13 @@ describe('predicates injector - subsidiary edge case', () => {
 	it('should correctly handle predicate when Company in predicate is NOT in path', () => {
 		// Query Department directly (not through Company chain)
 		// Department's predicate: { company: { isActive: true } }
-		// Since we didn't traverse through Company, the predicate MUST be fully applied
-		// AND Company's own predicate should also be applied
+		// Since we didn't traverse through Company, the predicate MUST be fully applied —
+		// verbatim, without re-applying Company's own predicate inside it (as-definer semantics)
 
 		const injected = injector.inject(schema.model.entities.Department, {})
 
-		// Full predicate with nested Company predicate:
-		// - Department predicate: { company: { isActive: true } }
-		// - Company predicate: { isActive: true } is also added when traversing company
 		assert.deepStrictEqual(injected, {
-			company: {
-				and: [
-					{ isActive: { eq: true } }, // from Department predicate
-					{ isActive: { eq: true } }, // Company's own predicate
-				],
-			},
+			company: { isActive: { eq: true } },
 		})
 	})
 
@@ -1012,8 +990,8 @@ describe('predicates injector - SECURITY: inconsistent predicates must NOT be si
 		// Company predicate: { isActive: true } - verified when querying Company
 		// Employee predicate: { department: { company: { name: 'Acme' } } } - checks DIFFERENT field!
 		//
-		// SECURITY: The name='Acme' condition MUST be preserved (not simplified).
-		// But Department and Company predicates CAN be simplified because we came through them.
+		// SECURITY: The name='Acme' condition MUST be preserved (not simplified) —
+		// Employee itself is not a back-reference, so its predicate is applied verbatim.
 
 		const companyDepartmentsRelation = acceptFieldVisitor(schema.model, schema.model.entities.Company, 'departments', {
 			visitColumn: () => {
@@ -1032,50 +1010,20 @@ describe('predicates injector - SECURITY: inconsistent predicates must NOT be si
 
 		const injected = injector.inject(schema.model.entities.Employee, {}, departmentEmployeesRelation, ancestorPath)
 
-		// The name='Acme' condition is preserved (not simplified)
-		// Department's predicate is simplified to { id: always } (we came from Department)
-		// Company's predicate is simplified to { id: always } (we came through Company)
 		assert.deepStrictEqual(injected, {
-			department: {
-				and: [
-					{
-						company: {
-							and: [
-								{ name: { eq: 'Acme' } },
-								{ id: { always: true } }, // Company predicate simplified
-							],
-						},
-					},
-					{ id: { always: true } }, // Department predicate simplified
-				],
-			},
+			department: { company: { name: { eq: 'Acme' } } },
 		})
 	})
 
-	it('direct Employee query: ALL nested predicates MUST be applied (no ancestor path)', () => {
-		// Query Employee DIRECTLY (not through Company -> Department path)
-		// In this case, neither Company nor Department was verified at any parent level.
-		// So BOTH Department's and Company's predicates MUST be applied.
+	it('direct Employee query: predicate is applied verbatim (as-definer, no nested re-application)', () => {
+		// Query Employee DIRECTLY (not through Company -> Department path).
+		// The predicate is the author's rule: its relation hops are NOT additionally
+		// guarded by Department's/Company's own read predicates (as-definer semantics).
 
 		const injected = injector.inject(schema.model.entities.Employee, {})
 
-		// Employee's condition (name='Acme') is preserved
-		// Department's predicate { company: { isActive: true } } is applied
-		// Company's predicate { isActive: true } is applied inside the traversal
 		assert.deepStrictEqual(injected, {
-			department: {
-				and: [
-					{
-						company: {
-							and: [
-								{ name: { eq: 'Acme' } },
-								{ isActive: { eq: true } }, // Company predicate
-							],
-						},
-					},
-					{ company: { isActive: { eq: true } } }, // Department predicate
-				],
-			},
+			department: { company: { name: { eq: 'Acme' } } },
 		})
 	})
 


### PR DESCRIPTION
## Summary

Removes the "ACL closure" behavior introduced in #830 alongside back-reference predicate elimination: every relation hop **inside** an entity's read predicate was additionally guarded by the target entity's own read predicate. ACL predicates are emitted **verbatim** again (as-definer semantics), matching every stable release before 2.1.0-alpha.31. The rest of #830 — ancestor-path tracking and elimination of predicates for back-referenced entities — stays intact.

## Why

**Production impact.** On a production project, a list query for an identity with two worker roles generated **4.9 MB of SQL** (~9000 left joins, ~4500 exists subqueries). PostgreSQL rejected it with `too many range table entries` or died in OOM after ~100 s, taking down unrelated tenants on the shared cluster. Each single role alone stayed under 100 kB — the per-role predicates are OR-merged at every nesting level, so the re-application grows the where-tree multiplicatively with predicate depth.

| roles | injected where-tree | after optimizer |
|---|---|---|
| role A | 24 kB | 11 kB |
| role B | 537 kB | 6 kB |
| role A + role B | 941 kB | **422 kB → 4.9 MB SQL, query fails** |
| role A + role B (this PR) | 41 kB | **21 kB → 184 kB SQL, ~3.5 s** |

**Semantics.** Re-applying entity predicates inside predicates is conceptually problematic:

- A predicate **is** the access rule authored by the schema author. Guarding its own hops second-guesses the author and silently hides rows whenever a predicate traverses an entity the role cannot read at all (common pattern: content visible when `{ site: { published: true } }` while the role has no access to the site entity itself).
- It is not well-defined on cyclic ACL configurations — a fixpoint is required, and any cycle fallback voids the very invariant the closure is meant to provide.
- User-controlled surfaces (filters, orderBy) remain ACL-guarded as before; this change affects only the contents of ACL predicates themselves.

The wider read-path hardening (orderBy value oracles, isNull absence, cell-level predicate preservation, relation extensions) continues in #923, which will be rebased on top of this.

## Testing

- `predicatesInjector` unit tests updated to pin the as-definer semantics (4 tests asserted the closure output; they now document verbatim emission and why).
- `predicateElimination` integration tests (the #830 headline feature) pass unchanged, 8/8.
- Full `bun test packages` — no regressions vs `main` baseline.
- End-to-end verified against a copy of the affected production database: the failing query returns the correct row count with SQL byte-identical to 2.1.0-alpha.30 (the last release without the closure).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTEqJqi47KTrMhQHjqiv1o
