### PR TITLE
fix: backport fixes from main to v2.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # full clone so extract-version can read `git tag -l`; fetch-tags
+          # collides with the tag-ref checkout on tag-triggered runs.
+          fetch-depth: 0
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -47,6 +51,10 @@ jobs:
         image: [cli, engine]
     steps:
       - uses: actions/checkout@v4
+        with:
+          # full clone so extract-version can read `git tag -l`; fetch-tags
+          # collides with the tag-ref checkout on tag-triggered runs.
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/packages/engine-content-api/src/acl/PredicatesInjector.ts
+++ b/packages/engine-content-api/src/acl/PredicatesInjector.ts
@@ -57,15 +57,7 @@ export class PredicatesInjector {
 		if (shouldSimplify) {
 			predicatesWhere = { [entity.primary]: { always: true } }
 		} else {
-			const rawPredicate = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
-			// Process the predicate to inject nested entity predicates
-			predicatesWhere = this.injectPredicatesToPredicate(
-				rawPredicate,
-				entity,
-				isBackReferenceContext ?? false,
-				ancestorPath ?? [],
-				isQueryRoot,
-			)
+			predicatesWhere = this.predicateFactory.create(entity, Acl.Operation.read, fieldNames, relationContext, isQueryRoot)
 		}
 
 		const and = [where, predicatesWhere].filter(it => Object.keys(it).length > 0)
@@ -76,101 +68,6 @@ export class PredicatesInjector {
 			return and[0]
 		}
 		return { and: and }
-	}
-
-	/**
-	 * Processes a predicate and injects nested entity predicates for any relation traversals.
-	 * This ensures that when a predicate like { department: { company: { name: 'Acme' } } }
-	 * is used, the predicates of Department and Company are also applied.
-	 */
-	private injectPredicatesToPredicate(
-		where: Input.OptionalWhere,
-		entity: Model.Entity,
-		isBackReferenceContext: boolean,
-		ancestorPath: readonly Model.AnyRelationContext[],
-		isQueryRoot?: boolean,
-	): Input.OptionalWhere {
-		const resultWhere: Writable<Input.OptionalWhere> = {}
-
-		if (where.and) {
-			resultWhere.and = where.and
-				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
-		}
-		if (where.or) {
-			resultWhere.or = where.or
-				.filter((it): it is Input.Where => !!it)
-				.map(it => this.injectPredicatesToPredicate(it, entity, isBackReferenceContext, ancestorPath, isQueryRoot))
-		}
-		if (where.not) {
-			resultWhere.not = this.injectPredicatesToPredicate(where.not, entity, isBackReferenceContext, ancestorPath, isQueryRoot)
-		}
-
-		const fields = Object.keys(where).filter(it => !['and', 'or', 'not'].includes(it))
-
-		for (const field of fields) {
-			resultWhere[field] = acceptFieldVisitor(this.schema, entity, field, {
-				visitColumn: () => where[field],
-				visitRelation: context => {
-					const relationWhere = where[field] as Input.OptionalWhere | null
-					if (relationWhere === null) {
-						return null
-					}
-
-					// Check if this relation is a back-reference to somewhere in our ancestor path
-					const isBackReference = this.findBackReferencedAncestor(
-						ancestorPath,
-						context.relation.name,
-						context.entity.name,
-					) !== undefined
-					const nestedIsBackReferenceContext = isBackReference || isBackReferenceContext
-					const nestedAncestorPath: readonly Model.AnyRelationContext[] = [...ancestorPath, context]
-
-					// Recursively process the nested where (always do this to handle deeper nesting)
-					const processedNestedWhere = this.injectPredicatesToPredicate(
-						relationWhere,
-						context.targetEntity,
-						nestedIsBackReferenceContext,
-						nestedAncestorPath,
-						isQueryRoot,
-					)
-
-					// Check if we should simplify the target entity's predicate
-					const shouldSimplifyNested = nestedIsBackReferenceContext
-						&& this.findBackReferencedAncestor(nestedAncestorPath, context.relation.name, context.entity.name) !== undefined
-
-					// Get target entity's predicate (simplified if back-reference)
-					const targetPredicate = shouldSimplifyNested
-						? { [context.targetEntity.primary]: { always: true } }
-						: this.predicateFactory.create(context.targetEntity, Acl.Operation.read, undefined, context, isQueryRoot)
-
-					// Optimization: avoid duplicate { id: always } when both are simplified
-					const primaryKey = context.targetEntity.primary
-					const nestedIsAlwaysTrue = Object.keys(processedNestedWhere).length === 1
-						&& (processedNestedWhere as Record<string, unknown>)[primaryKey] !== undefined
-						&& (processedNestedWhere as Record<string, Record<string, unknown>>)[primaryKey]?.always === true
-					const targetIsAlwaysTrue = Object.keys(targetPredicate).length === 1
-						&& (targetPredicate as Record<string, unknown>)[primaryKey] !== undefined
-						&& (targetPredicate as Record<string, Record<string, unknown>>)[primaryKey]?.always === true
-
-					if (nestedIsAlwaysTrue && targetIsAlwaysTrue) {
-						return processedNestedWhere
-					}
-
-					// Combine the processed nested where with target entity's predicate
-					const parts = [processedNestedWhere, targetPredicate].filter(it => Object.keys(it).length > 0)
-					if (parts.length === 0) {
-						return {}
-					}
-					if (parts.length === 1) {
-						return parts[0]
-					}
-					return { and: parts }
-				},
-			})
-		}
-
-		return resultWhere
 	}
 
 	private injectToWhere(

--- a/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
+++ b/packages/engine-content-api/tests/cases/unit/predicatesInjector.test.ts
@@ -700,27 +700,13 @@ describe('predicates injector - multi-level back-reference', () => {
 
 	it('should NOT simplify when filtering via non-ancestor relation', () => {
 		// If we query Employee directly (not through Company->Department chain)
-		// the predicate should NOT be simplified AND nested predicates should be applied
+		// the predicate should NOT be simplified — it is applied verbatim.
+		// Relation hops inside the predicate are the author's rule (as-definer semantics),
+		// so Department's/Company's own read predicates are NOT re-applied inside it.
 		const injected = injector.inject(schema.model.entities.Employee, {})
 
-		// Full predicate with nested entity predicates applied:
-		// - Employee predicate: { department: { company: { isActive: true } } }
-		// - Department predicate: { company: { isActive: true } } is added
-		// - Company predicate: { isActive: true } is added inside company traversal
 		assert.deepStrictEqual(injected, {
-			department: {
-				and: [
-					{
-						company: {
-							and: [
-								{ isActive: { eq: true } }, // from Employee predicate
-								{ isActive: { eq: true } }, // Company's own predicate
-							],
-						},
-					},
-					{ company: { isActive: { eq: true } } }, // Department's predicate
-				],
-			},
+			department: { company: { isActive: { eq: true } } },
 		})
 	})
 
@@ -864,21 +850,13 @@ describe('predicates injector - subsidiary edge case', () => {
 	it('should correctly handle predicate when Company in predicate is NOT in path', () => {
 		// Query Department directly (not through Company chain)
 		// Department's predicate: { company: { isActive: true } }
-		// Since we didn't traverse through Company, the predicate MUST be fully applied
-		// AND Company's own predicate should also be applied
+		// Since we didn't traverse through Company, the predicate MUST be fully applied —
+		// verbatim, without re-applying Company's own predicate inside it (as-definer semantics)
 
 		const injected = injector.inject(schema.model.entities.Department, {})
 
-		// Full predicate with nested Company predicate:
-		// - Department predicate: { company: { isActive: true } }
-		// - Company predicate: { isActive: true } is also added when traversing company
 		assert.deepStrictEqual(injected, {
-			company: {
-				and: [
-					{ isActive: { eq: true } }, // from Department predicate
-					{ isActive: { eq: true } }, // Company's own predicate
-				],
-			},
+			company: { isActive: { eq: true } },
 		})
 	})
 
@@ -1012,8 +990,8 @@ describe('predicates injector - SECURITY: inconsistent predicates must NOT be si
 		// Company predicate: { isActive: true } - verified when querying Company
 		// Employee predicate: { department: { company: { name: 'Acme' } } } - checks DIFFERENT field!
 		//
-		// SECURITY: The name='Acme' condition MUST be preserved (not simplified).
-		// But Department and Company predicates CAN be simplified because we came through them.
+		// SECURITY: The name='Acme' condition MUST be preserved (not simplified) —
+		// Employee itself is not a back-reference, so its predicate is applied verbatim.
 
 		const companyDepartmentsRelation = acceptFieldVisitor(schema.model, schema.model.entities.Company, 'departments', {
 			visitColumn: () => {
@@ -1032,50 +1010,20 @@ describe('predicates injector - SECURITY: inconsistent predicates must NOT be si
 
 		const injected = injector.inject(schema.model.entities.Employee, {}, departmentEmployeesRelation, ancestorPath)
 
-		// The name='Acme' condition is preserved (not simplified)
-		// Department's predicate is simplified to { id: always } (we came from Department)
-		// Company's predicate is simplified to { id: always } (we came through Company)
 		assert.deepStrictEqual(injected, {
-			department: {
-				and: [
-					{
-						company: {
-							and: [
-								{ name: { eq: 'Acme' } },
-								{ id: { always: true } }, // Company predicate simplified
-							],
-						},
-					},
-					{ id: { always: true } }, // Department predicate simplified
-				],
-			},
+			department: { company: { name: { eq: 'Acme' } } },
 		})
 	})
 
-	it('direct Employee query: ALL nested predicates MUST be applied (no ancestor path)', () => {
-		// Query Employee DIRECTLY (not through Company -> Department path)
-		// In this case, neither Company nor Department was verified at any parent level.
-		// So BOTH Department's and Company's predicates MUST be applied.
+	it('direct Employee query: predicate is applied verbatim (as-definer, no nested re-application)', () => {
+		// Query Employee DIRECTLY (not through Company -> Department path).
+		// The predicate is the author's rule: its relation hops are NOT additionally
+		// guarded by Department's/Company's own read predicates (as-definer semantics).
 
 		const injected = injector.inject(schema.model.entities.Employee, {})
 
-		// Employee's condition (name='Acme') is preserved
-		// Department's predicate { company: { isActive: true } } is applied
-		// Company's predicate { isActive: true } is applied inside the traversal
 		assert.deepStrictEqual(injected, {
-			department: {
-				and: [
-					{
-						company: {
-							and: [
-								{ name: { eq: 'Acme' } },
-								{ isActive: { eq: true } }, // Company predicate
-							],
-						},
-					},
-					{ company: { isActive: { eq: true } } }, // Department predicate
-				],
-			},
+			department: { company: { name: { eq: 'Acme' } } },
 		})
 	})
 

--- a/scripts/npm-publish/run.sh
+++ b/scripts/npm-publish/run.sh
@@ -4,6 +4,14 @@ set -e
 for dir in packages/*; do
   if [ -f "$dir/package.json" ]; then
     if ! grep -q '"private": true' "$dir/package.json"; then
+      name=$(node -p "require('./$dir/package.json').name")
+      version=$(node -p "require('./$dir/package.json').version")
+      # Let a re-run finish a partially published release instead of dying on the
+      # first EPUBLISHCONFLICT. A failed `npm view` (404, network) publishes anyway.
+      if npm view "$name@$version" version >/dev/null 2>&1; then
+        echo "Skipping $name@$version, already on the registry."
+        continue
+      fi
       (cd "$dir" && npm publish "$(bun pm pack | grep '\.tgz$')" --tag "$NPM_TAG" --access public --provenance)
     fi
   fi

--- a/scripts/tag-version/bump-version.ts
+++ b/scripts/tag-version/bump-version.ts
@@ -24,6 +24,29 @@ import glob from 'fast-glob'
 			throw e
 		}
 	}))
+
+	// bun#18906: a version-only bump leaves the workspace package versions recorded
+	// in bun.lock stale. `bun pm pack` (publish runs with --frozen-lockfile)
+	// substitutes `workspace:*` deps from those stale lockfile versions, so the
+	// published packages would pin their internal @contember/* deps at the previous
+	// release — causing duplicate-package breakage downstream. Patch the workspace
+	// versions in place to match the bump (no re-resolve, so transitive deps don't
+	// drift). Workspace entries are the only `{ "name", "version" }` objects in the
+	// lockfile (external packages use an array shape), so a "version line directly
+	// after a name line" rewrite is safe.
+	const lockPath = `${cwd}/bun.lock`
+	try {
+		const lockLines = (await fs.readFile(lockPath, 'utf8')).split('\n')
+		for (let i = 1; i < lockLines.length; i++) {
+			if (/^\s*"name":\s*"/.test(lockLines[i - 1]) && /^\s*"version":\s*"/.test(lockLines[i])) {
+				lockLines[i] = lockLines[i].replace(/("version":\s*")[^"]*(")/, `$1${version}$2`)
+			}
+		}
+		await fs.writeFile(lockPath, lockLines.join('\n'), 'utf8')
+	} catch (e) {
+		console.error('failed to patch bun.lock workspace versions')
+		throw e
+	}
 })().catch(e => {
 	console.error(e)
 	process.exit(1)


### PR DESCRIPTION
Backport of fixes from `main` to the `v2.1` line, for 2.1.0-rc.3:

- `fix(engine-content-api): stop re-applying entity read predicates inside ACL predicates` (#952) — fixes the multi-role ACL predicate explosion introduced in 2.1.0-alpha.31 (4.9 MB SQL / "too many range table entries" / OOM on a production project; see #952 for details and measurements).

Release-tooling picks so rc.3 does not repeat rc.2's publish anomalies:

- `ci: use fetch-depth 0 in publish checkout` — rc.2's shallow checkout made extract-version see only the pushed tag, so it published as npm dist-tag `next` (demoting 2.2.0-alpha.5) and repointed the floating `2-rc` docker tags.
- `fix(release): sync bun.lock workspace versions on bump (bun#18906)` — rc.2 shipped npm packages with internal `@contember/*` deps pinned at 2.1.0-beta.1.
- `ci: skip already-published versions when publishing to npm` — makes a partially-failed publish run re-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTEqJqi47KTrMhQHjqiv1o
