### PR TITLE
feat(database): optional TCP keep-alive for connections

### DIFF
--- a/docs/src/content/docs/reference/engine/configuration/database.mdx
+++ b/docs/src/content/docs/reference/engine/configuration/database.mdx
@@ -42,6 +42,24 @@ These map directly onto PostgreSQL / `node-postgres` settings and are applied to
 `statement_timeout` and `lock_timeout` are **disabled by default in PostgreSQL** (a value of `0` means "no limit"). Setting `statementTimeoutMs` / `lockTimeoutMs` is a good way to bound worst-case query and lock-wait time. Contember explicitly disables both (`SET LOCAL statement_timeout = 0`, `lock_timeout = 0`) for long-running data [export/import](/reference/engine/content/transfer) operations, so those are never killed by your configured limits.
 :::
 
+## TCP keep-alive
+
+:::note[Available since 2.2]
+:::
+
+Off by default. When enabled, the OS periodically probes the connection's socket, so a connection the peer silently dropped — a connection pooler, a load balancer, or a NAT idle timeout — surfaces as an error instead of failing the next query that uses it.
+
+| Option | Maps to | Description | Default |
+|---|---|---|---|
+| `keepAlive` | `keepAlive` | Enable TCP keep-alive on the connection socket. | `false` |
+| `keepAliveInitialDelayMs` | `keepAliveInitialDelayMillis` | Idle time before the first probe. Only applies when `keepAlive` is on. | `0` (OS default idle) |
+
+The probe interval and count after the first probe are OS-level settings (`net.ipv4.tcp_keepalive_intvl` / `_probes` on Linux), not Contember ones — on stock Linux that is another ~11 minutes before the socket is declared dead.
+
+:::note
+Idle **pooled** connections are already disposed after `pool.idleTimeoutMs` (default `10000`), which is far shorter than the OS probe cycle, so keep-alive rarely changes anything for them. It matters for connections that stay checked out while quiet — most notably the `LISTEN` connection the [actions](/reference/engine/actions/overview) dispatcher holds open — or when you have raised `pool.idleTimeoutMs` substantially.
+:::
+
 ## Connection pool
 
 Contember manages its own connection pool. All pool options are optional and live under `pool`.
@@ -142,6 +160,8 @@ Replace `<PREFIX>` below with `DEFAULT`, `TENANT`, or a project slug (`<PROJECT>
 | `queryTimeoutMs` | `<PREFIX>_DB_QUERY_TIMEOUT_MS` | number |
 | `statementTimeoutMs` | `<PREFIX>_DB_STATEMENT_TIMEOUT_MS` | number |
 | `lockTimeoutMs` | `<PREFIX>_DB_LOCK_TIMEOUT_MS` | number |
+| `keepAlive` | `<PREFIX>_DB_KEEP_ALIVE` | bool |
+| `keepAliveInitialDelayMs` | `<PREFIX>_DB_KEEP_ALIVE_INITIAL_DELAY_MS` | number |
 | `pool.maxConnections` | `<PREFIX>_DB_POOL_MAX_CONNECTIONS` | number |
 | `pool.maxConnecting` | `<PREFIX>_DB_POOL_MAX_CONNECTING` | number |
 | `pool.maxIdle` | `<PREFIX>_DB_POOL_MAX_IDLE` | number |
@@ -165,6 +185,8 @@ The read replica uses the same names with a `READ_` segment, for both the connec
 | `read.ssl` | `<PREFIX>_DB_READ_SSL` |
 | `read.statementTimeoutMs` | `<PREFIX>_DB_READ_STATEMENT_TIMEOUT_MS` |
 | `read.lockTimeoutMs` | `<PREFIX>_DB_READ_LOCK_TIMEOUT_MS` |
+| `read.keepAlive` | `<PREFIX>_DB_READ_KEEP_ALIVE` |
+| `read.keepAliveInitialDelayMs` | `<PREFIX>_DB_READ_KEEP_ALIVE_INITIAL_DELAY_MS` |
 | `read.pool.maxConnections` | `<PREFIX>_DB_READ_POOL_MAX_CONNECTIONS` |
 | … | … and the rest, following the same pattern |
 
@@ -192,7 +214,7 @@ BLOG_DB_POOL_MAX_CONNECTIONS=20
 BLOG_DB_READ_HOST=replica.db.example.com
 ```
 
-Boolean variables (`*_SSL`) accept `true`, `on`, or `1` as truthy; anything else is falsy.
+Boolean variables (`*_SSL`, `*_KEEP_ALIVE`) accept `true`, `on`, or `1` as truthy; anything else is falsy.
 
 ## See also
 

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -25,4 +25,19 @@ export interface DatabaseConfig {
 	readonly statementTimeoutMs?: number
 	readonly lockTimeoutMs?: number
 	readonly connectionTimeoutMs?: number
+	/**
+	 * Enable TCP keep-alive on the connection socket (`pg`'s `keepAlive`).
+	 * When a pooled connection is idle and the peer (a connection pooler, load
+	 * balancer or NAT) silently drops it, the socket only surfaces as broken on
+	 * the next use. With keep-alive the OS probes idle connections, so a dead one
+	 * errors out and is discarded by the pool instead of being handed to a query.
+	 * Defaults to `false` (pg default).
+	 */
+	readonly keepAlive?: boolean
+	/**
+	 * Idle time before the first TCP keep-alive probe, in milliseconds
+	 * (`pg`'s `keepAliveInitialDelayMillis`). Only applies when `keepAlive` is
+	 * enabled; the subsequent probe interval and count are controlled by the OS.
+	 */
+	readonly keepAliveInitialDelayMs?: number
 }

--- a/packages/database/src/utils/pgClientFactory.ts
+++ b/packages/database/src/utils/pgClientFactory.ts
@@ -7,12 +7,15 @@ export const createPgClientFactory =
 	({ queryTimeoutMs, statementTimeoutMs, lockTimeoutMs, connectionTimeoutMs, ...config }: DatabaseConfig) => () => {
 		// `lock_timeout` is supported by pg at runtime but missing from the installed @types/pg version,
 		// so it is typed explicitly here.
+		const { keepAlive, keepAliveInitialDelayMs, ...connectionConfig } = config
 		const clientConfig: pg.ClientConfig & { lock_timeout?: number } = {
 			query_timeout: queryTimeoutMs,
 			statement_timeout: statementTimeoutMs,
 			lock_timeout: lockTimeoutMs,
 			connectionTimeoutMillis: connectionTimeoutMs,
-			...config,
+			keepAlive: keepAlive ?? false,
+			keepAliveInitialDelayMillis: keepAliveInitialDelayMs,
+			...connectionConfig,
 		}
 		return new pg.Client(clientConfig)
 	}

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -16,6 +16,8 @@ const dbConfigOptional = {
 	statementTimeoutMs: Typesafe.number,
 	lockTimeoutMs: Typesafe.number,
 	connectionTimeoutMs: Typesafe.number,
+	keepAlive: Typesafe.boolean,
+	keepAliveInitialDelayMs: Typesafe.number,
 	maxConnectionsPerRequest: Typesafe.number,
 	pool: Typesafe.partial({
 		maxConnections: Typesafe.number,

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -5,8 +5,8 @@ const createDbConfigTemplate = (prefix: string) => {
 		statementTimeoutMs: `%?${prefix}_STATEMENT_TIMEOUT_MS::number%`,
 		lockTimeoutMs: `%?${prefix}_LOCK_TIMEOUT_MS::number%`,
 		connectionTimeoutMs: `%?${prefix}_CONNECTION_TIMEOUT_MS::number%`,
-		keepAlive: `%?${prefix}_KEEPALIVE::bool%`,
-		keepAliveInitialDelayMs: `%?${prefix}_KEEPALIVE_INITIAL_DELAY_MS::number%`,
+		keepAlive: `%?${prefix}_KEEP_ALIVE::bool%`,
+		keepAliveInitialDelayMs: `%?${prefix}_KEEP_ALIVE_INITIAL_DELAY_MS::number%`,
 		maxConnectionsPerRequest: `%?${prefix}_MAX_CONNECTIONS_PER_REQUEST::number%`,
 		pool: {
 			maxConnections: `%?${prefix}_POOL_MAX_CONNECTIONS::number%`,

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -5,6 +5,8 @@ const createDbConfigTemplate = (prefix: string) => {
 		statementTimeoutMs: `%?${prefix}_STATEMENT_TIMEOUT_MS::number%`,
 		lockTimeoutMs: `%?${prefix}_LOCK_TIMEOUT_MS::number%`,
 		connectionTimeoutMs: `%?${prefix}_CONNECTION_TIMEOUT_MS::number%`,
+		keepAlive: `%?${prefix}_KEEPALIVE::bool%`,
+		keepAliveInitialDelayMs: `%?${prefix}_KEEPALIVE_INITIAL_DELAY_MS::number%`,
 		maxConnectionsPerRequest: `%?${prefix}_MAX_CONNECTIONS_PER_REQUEST::number%`,
 		pool: {
 			maxConnections: `%?${prefix}_POOL_MAX_CONNECTIONS::number%`,


### PR DESCRIPTION
## Problem

A connection that sits quiet can be dropped by the peer — a connection pooler (e.g. PgBouncer), a load balancer, or a NAT/firewall idle timeout — without the client noticing. The dead socket only surfaces on the *next* query, which then fails.

## Change

Expose `pg`'s native TCP keep-alive as an optional connection setting, so the OS probes the socket and a half-open connection errors out on its own.

- `DatabaseConfig`: two optional fields, `keepAlive` (boolean) and `keepAliveInitialDelayMs` (number).
- `createPgClientFactory`: passes them to `pg.Client` as `keepAlive` / `keepAliveInitialDelayMillis`.
- `configTemplate` + `configSchema`: exposes them via env, per DB and read replica, following the existing naming rule (option name upper-snake-cased):
  - `<PREFIX>_DB_KEEP_ALIVE` (bool)
  - `<PREFIX>_DB_KEEP_ALIVE_INITIAL_DELAY_MS` (number)
  - and the `READ_` variants.

## Where this actually helps

Not on idle **pooled** connections: `pool.idleTimeoutMs` defaults to 10 s, while a stock Linux declares a socket dead only after `keepAliveInitialDelayMs` plus ~11 minutes of probes (`tcp_keepalive_intvl` 75 s × `tcp_keepalive_probes` 9). The pool disposes such a connection long before keep-alive could say anything about it.

It helps for connections that stay checked out while quiet — most notably the `LISTEN` connection the actions dispatcher holds open indefinitely (`packages/database/src/utils/listen.ts`) — and for deployments that have raised `pool.idleTimeoutMs` well above the default. The docs page states this so nobody enables it expecting the pool to self-heal.

## Defaults & compatibility

Off by default — identical to `pg`'s current behaviour, so nothing changes unless explicitly enabled. When enabled, `keepAliveInitialDelayMs` controls the idle time before the first probe; the subsequent probe interval and count remain OS-controlled.

This is a mitigation for silently-dropped connections; it is not a substitute for validating a connection on acquire, which would be a larger change.

## Verification

`bun run --cwd docs build` clean (docs CI is `paths-ignore`d), dprint and Biome clean on the changed source.
