### PR TITLE
fix: complete shutdown with WebSocket workers

### DIFF
--- a/packages/engine-actions/src/graphql/http/ActionsWebsocketControllerFactory.ts
+++ b/packages/engine-actions/src/graphql/http/ActionsWebsocketControllerFactory.ts
@@ -89,19 +89,18 @@ export class ActionsWebsocketControllerFactory {
 
 			const stopAll = (): Promise<void> => {
 				stopAllPromise ??= (async () => {
-					const currentWorkers = workers.map(async it => {
+					// a worker stays tracked until its own end() resolves, so a failed cleanup is not forgotten
+					const results = await Promise.allSettled(workers.map(async it => {
 						await (await it.running).end()
+						workers = workers.filter(worker => worker !== it)
 						send({
 							type: 'workedStopped',
 							workerId: it.id,
 						})
-					})
-					workers = []
-					const results = await Promise.allSettled(currentWorkers)
-					for (const result of results) {
-						if (result.status === 'rejected') {
-							throw result.reason
-						}
+					}))
+					const errors = results.flatMap(it => it.status === 'rejected' ? [it.reason] : [])
+					if (errors.length > 0) {
+						throw new AggregateError(errors, 'Worker cleanup failed')
 					}
 				})().finally(() => {
 					stopAllPromise = undefined

--- a/packages/engine-actions/src/graphql/http/ActionsWebsocketControllerFactory.ts
+++ b/packages/engine-actions/src/graphql/http/ActionsWebsocketControllerFactory.ts
@@ -1,9 +1,7 @@
-import { HttpErrorResponse, WebSocketController } from '@contember/engine-http'
-import { ActionsContextResolver } from './ActionsContextResolver.js'
-import { DispatchWorkerSupervisorFactory } from '../../dispatch/DispatchWorkerSupervisor.js'
+import { HttpErrorResponse, ProjectGroupContainer, WebSocketController } from '@contember/engine-http'
 import * as Typesafe from '@contember/typesafe'
 import { TenantRole } from '@contember/engine-tenant-api'
-import { Running } from '@contember/engine-common'
+import { Runnable, Running } from '@contember/engine-common'
 
 const IncomingMessage = Typesafe.discriminatedUnion(
 	'type',
@@ -41,11 +39,14 @@ const OutgoingMessage = Typesafe.discriminatedUnion(
 
 type OutgoingMessage = ReturnType<typeof OutgoingMessage>
 
+type DispatchWorkerFactory = {
+	create(projectGroup: ProjectGroupContainer): Runnable
+}
+
 export class ActionsWebsocketControllerFactory {
 	constructor(
 		private readonly debug: boolean,
-		private readonly actionsContextResolver: ActionsContextResolver,
-		private readonly dispatchWorkerSupervisorFactory: DispatchWorkerSupervisorFactory,
+		private readonly dispatchWorkerSupervisorFactory: DispatchWorkerFactory,
 	) {
 	}
 
@@ -67,24 +68,45 @@ export class ActionsWebsocketControllerFactory {
 			}
 
 			let workers: { id: string; running: Promise<Running> }[] = []
+			let stopAllPromise: Promise<void> | undefined
+			let connectionClosing = false
 			const abortListener = async () => {
-				send({ type: 'message', message: 'shutting down' })
-				await stopAll()
-				send({ type: 'message', message: 'closing connection' })
-				ws.close(1012) // Service Restart
+				connectionClosing = true
+				try {
+					send({ type: 'message', message: 'shutting down' })
+					await stopAll()
+				} catch (error) {
+					logger.error(error, { message: 'Websocket worker cleanup failed' })
+				} finally {
+					try {
+						send({ type: 'message', message: 'closing connection' })
+					} finally {
+						ws.close(1012) // Service Restart
+					}
+				}
 			}
 			ctx.abortSignal.addEventListener('abort', abortListener)
 
-			const stopAll = async () => {
-				const currentWorkers = workers.map(async it => {
-					await (await it.running).end()
-					send({
-						type: 'workedStopped',
-						workerId: it.id,
+			const stopAll = (): Promise<void> => {
+				stopAllPromise ??= (async () => {
+					const currentWorkers = workers.map(async it => {
+						await (await it.running).end()
+						send({
+							type: 'workedStopped',
+							workerId: it.id,
+						})
 					})
+					workers = []
+					const results = await Promise.allSettled(currentWorkers)
+					for (const result of results) {
+						if (result.status === 'rejected') {
+							throw result.reason
+						}
+					}
+				})().finally(() => {
+					stopAllPromise = undefined
 				})
-				workers = []
-				await Promise.all(currentWorkers)
+				return stopAllPromise
 			}
 			send({ type: 'ready' })
 
@@ -110,27 +132,41 @@ export class ActionsWebsocketControllerFactory {
 
 				switch (data.type) {
 					case 'startWorker':
+						if (connectionClosing || stopAllPromise !== undefined) {
+							send({ type: 'error', message: 'Workers are stopping' })
+							break
+						}
 						const workerId = Math.random().toString().substring(2)
 						const dispatchSupervisor = this.dispatchWorkerSupervisorFactory.create(projectGroup)
-						try {
-							const running = dispatchSupervisor.run({
+						const running = Promise.resolve().then(() =>
+							dispatchSupervisor.run({
 								logger,
 								onError: () => {
 									send({ type: 'workerCrashed', workerId })
 								},
 							})
-							workers.push({ id: workerId, running })
+						)
+						const worker = { id: workerId, running }
+						workers.push(worker)
+						try {
 							await running
-							send({ type: 'workerStarted', workerId })
 						} catch (e) {
+							workers = workers.filter(it => it !== worker)
 							logger.error(e, { message: 'Worker failed to start' })
 							send({ type: 'workerFailedToStart', workerId })
+							break
 						}
+						send({ type: 'workerStarted', workerId })
 						break
 					case 'stopAllWorkers':
 						send({ type: 'message', message: 'stopping' })
-						await stopAll()
-						send({ type: 'message', message: 'all stopped' })
+						try {
+							await stopAll()
+							send({ type: 'message', message: 'all stopped' })
+						} catch (error) {
+							logger.error(error, { message: 'Websocket worker cleanup failed' })
+							send({ type: 'error', message: 'Worker cleanup failed' })
+						}
 						break
 				}
 			})
@@ -139,11 +175,19 @@ export class ActionsWebsocketControllerFactory {
 				ws.ping()
 			}, 5000)
 
-			ws.addEventListener('close', async () => {
-				ctx.abortSignal.removeEventListener('abort', abortListener)
-				clearInterval(pingHandle)
-				await stopAll()
-			})
+			ctx.waitUntil(
+				new Promise<void>(resolve => {
+					ws.addEventListener('close', () => {
+						connectionClosing = true
+						ctx.abortSignal.removeEventListener('abort', abortListener)
+						clearInterval(pingHandle)
+						void stopAll().then(resolve, error => {
+							logger.error(error, { message: 'Websocket worker cleanup failed' })
+							resolve()
+						})
+					})
+				}),
+			)
 		}
 	}
 }

--- a/packages/engine-actions/src/index.ts
+++ b/packages/engine-actions/src/index.ts
@@ -123,7 +123,6 @@ export default class ActionsPlugin implements Plugin {
 						)
 						const actionsWebsocketMiddlewareFactory = new ActionsWebsocketControllerFactory(
 							debugMode,
-							actionsContextResolver,
 							actions_dispatchWorkerSupervisorFactory,
 						)
 						it.addRoute('actions', '/actions/:projectSlug', actionsMiddlewareFactory.create())

--- a/packages/engine-actions/tests/cases/unit/actionsWebsocketController.test.ts
+++ b/packages/engine-actions/tests/cases/unit/actionsWebsocketController.test.ts
@@ -210,6 +210,37 @@ test('shutdown waits for worker cleanup started by a peer disconnect', async () 
 	}
 })
 
+test('a worker whose cleanup fails stays tracked for the next stop', async () => {
+	const worker: Runnable = {
+		run: async () => ({
+			end: (): Promise<void> => Promise.reject(new Error('Worker cleanup failed')),
+		}),
+	}
+	const { client, closed, messages, opened, running } = await listen(() => worker)
+	let applicationClosed = false
+
+	try {
+		await opened
+		await waitFor(() => messages.includes('ready'))
+		client.send(JSON.stringify({ type: 'startWorker' }))
+		await waitFor(() => messages.includes('workerStarted'))
+		client.send(JSON.stringify({ type: 'stopAllWorkers' }))
+		await waitFor(() => messages.filter(it => it === 'error:Worker cleanup failed').length === 1)
+		client.send(JSON.stringify({ type: 'stopAllWorkers' }))
+		await waitFor(() => messages.filter(it => it === 'error:Worker cleanup failed').length === 2)
+		expect(messages).not.toContain('message:all stopped')
+
+		await running.close()
+		applicationClosed = true
+		expect(await closed).toBe(1012)
+	} finally {
+		client.terminate()
+		if (!applicationClosed) {
+			await running.close()
+		}
+	}
+})
+
 test('reports a manual worker cleanup failure without blocking shutdown', async () => {
 	const worker: Runnable = {
 		run: async () => ({

--- a/packages/engine-actions/tests/cases/unit/actionsWebsocketController.test.ts
+++ b/packages/engine-actions/tests/cases/unit/actionsWebsocketController.test.ts
@@ -1,0 +1,239 @@
+import { expect, test } from 'bun:test'
+import { Runnable, Running } from '@contember/engine-common'
+import { Application, Authenticator, ProjectGroupContainer, ProjectGroupResolver, serverConfigSchema } from '@contember/engine-http'
+import { createLogger, TestLoggerHandler } from '@contember/logger'
+import { TenantRole, VerifyResult } from '@contember/engine-tenant-api'
+import { WebSocket } from 'ws'
+import { ActionsWebsocketControllerFactory } from '../../../src/graphql/http/ActionsWebsocketControllerFactory.js'
+
+type Interface<T> = { [P in keyof T]: T[P] }
+
+const createMock = <T>(members: Interface<T>): T => members
+
+const unavailable = (): never => {
+	throw new Error('This service is not available in the actions WebSocket controller test')
+}
+
+const waitFor = async (condition: () => boolean): Promise<void> => {
+	for (let attempt = 0; attempt < 100; attempt++) {
+		if (condition()) {
+			return
+		}
+		await new Promise<void>(resolve => setTimeout(resolve, 1))
+	}
+	throw new Error('Condition was not met')
+}
+
+const listen = async (createWorker: () => Runnable) => {
+	const loggerHandler = new TestLoggerHandler()
+	const logger = createLogger(loggerHandler)
+	const authenticator = createMock<Authenticator>({
+		authenticate: async () => new VerifyResult('identity', 'api-key', [TenantRole.SUPER_ADMIN], null),
+	})
+	const projectGroup: ProjectGroupContainer = {
+		slug: undefined,
+		logger,
+		authenticator,
+		get projectMembershipResolver() {
+			return unavailable()
+		},
+		get projectContainerResolver() {
+			return unavailable()
+		},
+		get projectSchemaResolver() {
+			return unavailable()
+		},
+		get projectInitializer() {
+			return unavailable()
+		},
+		get tenantContainer() {
+			return unavailable()
+		},
+		get tenantGraphQLHandler() {
+			return unavailable()
+		},
+		get systemContainer() {
+			return unavailable()
+		},
+		get systemGraphQLHandler() {
+			return unavailable()
+		},
+	}
+	const projectGroupResolver = createMock<ProjectGroupResolver>({
+		resolveContainer: async () => projectGroup,
+	})
+	const application = new Application(projectGroupResolver, serverConfigSchema({ port: 0 }), false, undefined, logger)
+	application.addWebsocketRoute(
+		'actions',
+		'/actions/_worker',
+		new ActionsWebsocketControllerFactory(false, { create: createWorker }).create(),
+	)
+	const running = await application.listen()
+	const address = running.server.address()
+	if (address === null || typeof address === 'string') {
+		await running.close()
+		throw new Error('The test server did not bind to a TCP port')
+	}
+
+	const messages: string[] = []
+	const client = new WebSocket(`ws://127.0.0.1:${address.port}/actions/_worker`)
+	client.on('message', data => {
+		const message: unknown = JSON.parse(data.toString())
+		if (typeof message === 'object' && message !== null && 'type' in message && typeof message.type === 'string') {
+			const detail = 'message' in message && typeof message.message === 'string' ? `:${message.message}` : ''
+			messages.push(`${message.type}${detail}`)
+		}
+	})
+	const opened = new Promise<void>((resolve, reject) => {
+		client.once('open', () => resolve())
+		client.once('error', reject)
+	})
+	const closed = new Promise<number>(resolve => client.once('close', code => resolve(code)))
+	return { client, closed, loggerHandler, messages, opened, running }
+}
+
+test('a worker startup failure does not block WebSocket shutdown', async () => {
+	const worker: Runnable = {
+		run: (): Promise<Running> => Promise.reject(new Error('Worker startup failed')),
+	}
+	const { client, closed, loggerHandler, messages, opened, running } = await listen(() => worker)
+	let applicationClosed = false
+
+	try {
+		await opened
+		await waitFor(() => messages.includes('ready'))
+		client.send(JSON.stringify({ type: 'startWorker' }))
+		await waitFor(() => messages.includes('workerFailedToStart'))
+
+		await running.close()
+		applicationClosed = true
+		expect(await closed).toBe(1012)
+		expect(loggerHandler.messages.some(it => it.message.startsWith('Websocket worker cleanup failed'))).toBe(false)
+	} finally {
+		client.terminate()
+		if (!applicationClosed) {
+			await running.close()
+		}
+	}
+})
+
+test('shutdown waits for every worker cleanup after one cleanup fails', async () => {
+	let releaseCleanup = () => {}
+	const cleanupReleased = new Promise<void>(resolve => {
+		releaseCleanup = resolve
+	})
+	let cleanupStarted = false
+	const workers: Runnable[] = [
+		{
+			run: async () => ({
+				end: (): Promise<void> => Promise.reject(new Error('Worker cleanup failed')),
+			}),
+		},
+		{
+			run: async () => ({
+				end: async () => {
+					cleanupStarted = true
+					await cleanupReleased
+				},
+			}),
+		},
+	]
+	const { client, closed, loggerHandler, messages, opened, running } = await listen(() => workers.shift() ?? unavailable())
+	let shutdown: Promise<void> | undefined
+
+	try {
+		await opened
+		await waitFor(() => messages.includes('ready'))
+		client.send(JSON.stringify({ type: 'startWorker' }))
+		await waitFor(() => messages.filter(it => it === 'workerStarted').length === 1)
+		client.send(JSON.stringify({ type: 'startWorker' }))
+		await waitFor(() => messages.filter(it => it === 'workerStarted').length === 2)
+
+		let shutdownFinished = false
+		shutdown = running.close().then(() => {
+			shutdownFinished = true
+		})
+		await waitFor(() => cleanupStarted)
+		await new Promise<void>(resolve => setImmediate(resolve))
+		expect(shutdownFinished).toBe(false)
+		expect(messages).not.toContain('message:closing connection')
+		releaseCleanup()
+		await shutdown
+		expect(await closed).toBe(1012)
+		expect(loggerHandler.messages.some(it => it.message.startsWith('Websocket worker cleanup failed'))).toBe(true)
+	} finally {
+		releaseCleanup()
+		shutdown ??= running.close()
+		await shutdown
+		client.terminate()
+	}
+})
+
+test('shutdown waits for worker cleanup started by a peer disconnect', async () => {
+	let releaseCleanup = () => {}
+	const cleanupReleased = new Promise<void>(resolve => {
+		releaseCleanup = resolve
+	})
+	let cleanupStarted = false
+	const worker: Runnable = {
+		run: async () => ({
+			end: async () => {
+				cleanupStarted = true
+				await cleanupReleased
+			},
+		}),
+	}
+	const { client, messages, opened, running } = await listen(() => worker)
+	let shutdown: Promise<void> | undefined
+
+	try {
+		await opened
+		await waitFor(() => messages.includes('ready'))
+		client.send(JSON.stringify({ type: 'startWorker' }))
+		await waitFor(() => messages.includes('workerStarted'))
+		client.close()
+		await waitFor(() => cleanupStarted)
+
+		let shutdownFinished = false
+		shutdown = running.close().then(() => {
+			shutdownFinished = true
+		})
+		await new Promise<void>(resolve => setImmediate(resolve))
+		expect(shutdownFinished).toBe(false)
+		releaseCleanup()
+		await shutdown
+	} finally {
+		releaseCleanup()
+		shutdown ??= running.close()
+		await shutdown
+		client.terminate()
+	}
+})
+
+test('reports a manual worker cleanup failure without blocking shutdown', async () => {
+	const worker: Runnable = {
+		run: async () => ({
+			end: (): Promise<void> => Promise.reject(new Error('Worker cleanup failed')),
+		}),
+	}
+	const { client, closed, messages, opened, running } = await listen(() => worker)
+	let applicationClosed = false
+
+	try {
+		await opened
+		await waitFor(() => messages.includes('ready'))
+		client.send(JSON.stringify({ type: 'startWorker' }))
+		await waitFor(() => messages.includes('workerStarted'))
+		client.send(JSON.stringify({ type: 'stopAllWorkers' }))
+		await waitFor(() => messages.includes('error:Worker cleanup failed'))
+
+		await running.close()
+		applicationClosed = true
+		expect(await closed).toBe(1012)
+	} finally {
+		client.terminate()
+		if (!applicationClosed) {
+			await running.close()
+		}
+	}
+})

--- a/packages/engine-http/src/application/application.ts
+++ b/packages/engine-http/src/application/application.ts
@@ -19,6 +19,8 @@ import { performance } from 'node:perf_hooks'
 import { getClientIP } from '../utils/remoteAddress.js'
 import { isForceHttpOkRequested, shouldForceHttpOk } from './forceHttpOk.js'
 
+const websocketCloseTimeoutMs = 5_000
+
 type Route<C> = { match: RequestMatcher; controller: C; module: string }
 export class Application {
 	private middlewares: KoaMiddleware<any>[] = []
@@ -128,7 +130,7 @@ export class Application {
 		const wsRequests: (Promise<void>)[] = []
 		server.on('upgrade', (req, socket, head) => {
 			if (closing) {
-				socket.destroy()
+				this.sendRawHttpResponse(socket, new HttpErrorResponse(503, 'Server is shutting down'))
 				return
 			}
 			wsRequests.push(this.handleWebsocketRequest(wss, abortController.signal, req, socket, head))
@@ -142,16 +144,22 @@ export class Application {
 			close: async () => {
 				closing = true
 				abortController.abort()
-				await Promise.all(wsRequests)
-				while (activeHttpRequests.size > 0) {
-					await Promise.all(activeHttpRequests)
-				}
-				// Bun does not finish server.close() after a WebSocket upgrade unless all connections are closed first.
-				if (process.versions.bun !== undefined && wsRequests.length > 0) {
+				await Promise.all([...wsRequests, ...activeHttpRequests])
+				if (process.versions.bun !== undefined) {
+					// Bun does not finish server.close() after a WebSocket upgrade unless all connections are closed first.
 					server.closeAllConnections()
+				} else {
+					server.closeIdleConnections()
 				}
 				if (server.listening) {
-					await new Promise<void>((resolve, reject) => server.close(error => error === undefined ? resolve() : reject(error)))
+					await new Promise<void>(resolve =>
+						server.close(error => {
+							if (error) {
+								this.logger.error(error)
+							}
+							resolve()
+						})
+					)
 				}
 			},
 		}
@@ -191,20 +199,23 @@ export class Application {
 			const effectiveClientIp = authResult?.clientIp ?? clientIp
 
 			if (abortSignal.aborted) {
-				socket.destroy()
-				return
+				throw new HttpErrorResponse(503, 'Server is shutting down')
 			}
 			const ws = await new Promise<WebSocket>(resolve =>
 				wss.handleUpgrade(req, socket, head, (ws, request) => {
 					resolve(ws)
 				})
 			)
+			const wsEstablished = performance.now()
+			ws.on('error', e => {
+				requestLogger.error(e, {
+					websocketOpenMs: performance.now() - wsEstablished,
+				})
+			})
 			if (abortSignal.aborted) {
-				ws.close(1012)
-				await new Promise<void>(resolve => ws.once('close', () => resolve()))
+				await this.closeWebsocket(ws)
 				return
 			}
-			const wsEstablished = performance.now()
 			const pendingWork: Promise<void>[] = []
 			webSocketContext = {
 				ws,
@@ -224,11 +235,6 @@ export class Application {
 				ws.close(1012)
 			}
 			requestLogger.debug('Websocket connection established')
-			ws.on('error', e => {
-				requestLogger.error(e, {
-					websocketOpenMs: performance.now() - wsEstablished,
-				})
-			})
 
 			if (ws.readyState !== WebSocket.CLOSED) {
 				await new Promise<void>(resolve => {
@@ -397,6 +403,24 @@ export class Application {
 		if (response.body !== undefined) {
 			ctx.body = response.body
 		}
+	}
+
+	private async closeWebsocket(ws: WebSocket): Promise<void> {
+		if (ws.readyState === WebSocket.CLOSED) {
+			return
+		}
+		ws.close(1012) // Service Restart
+		await new Promise<void>(resolve => {
+			// ws only gives up on the close handshake after 30 s, which outlives a typical shutdown grace period
+			const timeout = setTimeout(() => {
+				ws.terminate()
+				resolve()
+			}, websocketCloseTimeoutMs)
+			ws.once('close', () => {
+				clearTimeout(timeout)
+				resolve()
+			})
+		})
 	}
 
 	private sendRawHttpResponse(socket: Duplex, response: HttpResponse) {

--- a/packages/engine-http/src/application/application.ts
+++ b/packages/engine-http/src/application/application.ts
@@ -75,6 +75,15 @@ export class Application {
 	async listen(): Promise<RunningApplication> {
 		const koa = new Koa()
 		const wss = new WebSocketServer({ noServer: true })
+		let closing = false
+		koa.use(async (ctx, next) => {
+			if (closing) {
+				ctx.status = 503
+				ctx.set('Connection', 'close')
+				return
+			}
+			await next()
+		})
 		for (const middleware of this.middlewares) {
 			koa.use(middleware)
 		}
@@ -92,11 +101,36 @@ export class Application {
 			await this.handleHttpRequest(ctx)
 		})
 
-		const server = http.createServer(koa.callback())
+		const activeHttpRequests = new Set<Promise<void>>()
+		const handleHttpRequest = koa.callback()
+		const server = http.createServer((request, response) => {
+			if (closing) {
+				handleHttpRequest(request, response)
+				return
+			}
+			let resolveRequest = () => {}
+			const completed = new Promise<void>(resolve => {
+				resolveRequest = resolve
+			})
+			activeHttpRequests.add(completed)
+			const complete = () => {
+				response.off('finish', complete)
+				response.off('close', complete)
+				activeHttpRequests.delete(completed)
+				resolveRequest()
+			}
+			response.once('finish', complete)
+			response.once('close', complete)
+			handleHttpRequest(request, response)
+		})
 		const abortController = new AbortController()
 
 		const wsRequests: (Promise<void>)[] = []
 		server.on('upgrade', (req, socket, head) => {
+			if (closing) {
+				socket.destroy()
+				return
+			}
 			wsRequests.push(this.handleWebsocketRequest(wss, abortController.signal, req, socket, head))
 		})
 		await new Promise<void>(resolve => {
@@ -106,9 +140,19 @@ export class Application {
 		return {
 			server,
 			close: async () => {
+				closing = true
 				abortController.abort()
 				await Promise.all(wsRequests)
-				await new Promise(resolve => server.close(resolve))
+				while (activeHttpRequests.size > 0) {
+					await Promise.all(activeHttpRequests)
+				}
+				// Bun does not finish server.close() after a WebSocket upgrade unless all connections are closed first.
+				if (process.versions.bun !== undefined && wsRequests.length > 0) {
+					server.closeAllConnections()
+				}
+				if (server.listening) {
+					await new Promise<void>((resolve, reject) => server.close(error => error === undefined ? resolve() : reject(error)))
+				}
 			},
 		}
 	}
@@ -146,12 +190,22 @@ export class Application {
 
 			const effectiveClientIp = authResult?.clientIp ?? clientIp
 
+			if (abortSignal.aborted) {
+				socket.destroy()
+				return
+			}
 			const ws = await new Promise<WebSocket>(resolve =>
 				wss.handleUpgrade(req, socket, head, (ws, request) => {
 					resolve(ws)
 				})
 			)
+			if (abortSignal.aborted) {
+				ws.close(1012)
+				await new Promise<void>(resolve => ws.once('close', () => resolve()))
+				return
+			}
 			const wsEstablished = performance.now()
+			const pendingWork: Promise<void>[] = []
 			webSocketContext = {
 				ws,
 				abortSignal,
@@ -163,8 +217,12 @@ export class Application {
 				authResult,
 				params: matchedRequest.params,
 				projectGroup: groupContainer,
+				waitUntil: promise => pendingWork.push(promise),
 			}
 			await matchedRequest.controller(webSocketContext)
+			if (abortSignal.aborted && ws.readyState === WebSocket.OPEN) {
+				ws.close(1012)
+			}
 			requestLogger.debug('Websocket connection established')
 			ws.on('error', e => {
 				requestLogger.error(e, {
@@ -172,14 +230,17 @@ export class Application {
 				})
 			})
 
-			return new Promise<void>(resolve => {
-				ws.on('close', () => {
-					requestLogger.debug('Websocket connection closed', {
-						websocketOpenMs: performance.now() - wsEstablished,
+			if (ws.readyState !== WebSocket.CLOSED) {
+				await new Promise<void>(resolve => {
+					ws.on('close', () => {
+						requestLogger.debug('Websocket connection closed', {
+							websocketOpenMs: performance.now() - wsEstablished,
+						})
+						resolve()
 					})
-					resolve()
 				})
-			})
+			}
+			await Promise.allSettled(pendingWork)
 		} catch (e) {
 			if (e instanceof HttpResponse) {
 				this.sendRawHttpResponse(socket, e)
@@ -496,6 +557,7 @@ export type WebSocketContext =
 	& {
 		ws: WebSocket
 		abortSignal: AbortSignal
+		waitUntil(promise: Promise<void>): void
 	}
 
 export type HttpControllerResponse = Promise<HttpErrorResponse | undefined | void> | HttpErrorResponse | undefined | void

--- a/packages/engine-http/tests/cases/unit/applicationShutdown.test.ts
+++ b/packages/engine-http/tests/cases/unit/applicationShutdown.test.ts
@@ -1,0 +1,149 @@
+import { expect, test } from 'bun:test'
+import { VerifyResult } from '@contember/engine-tenant-api'
+import { createLogger, TestLoggerHandler } from '@contember/logger'
+import { Readable } from 'node:stream'
+import { WebSocket } from 'ws'
+import { Application } from '../../../src/application/application.js'
+import { Authenticator } from '../../../src/common/Authorizator.js'
+import { serverConfigSchema } from '../../../src/config/configSchema.js'
+import { ProjectGroupContainer } from '../../../src/projectGroup/ProjectGroupContainer.js'
+import { ProjectGroupResolver } from '../../../src/projectGroup/ProjectGroupResolver.js'
+import { createMock } from '../../utils.js'
+
+const unavailable = (): never => {
+	throw new Error('This service is not available in the application shutdown test')
+}
+
+const createTestApplication = (
+	authenticate: Authenticator['authenticate'] = async () => new VerifyResult('identity', 'api-key', ['member'], null),
+) => {
+	const logger = createLogger(new TestLoggerHandler())
+	const authenticator = createMock<Authenticator>({ authenticate })
+	const projectGroup: ProjectGroupContainer = {
+		slug: undefined,
+		logger,
+		authenticator,
+		get projectMembershipResolver() {
+			return unavailable()
+		},
+		get projectContainerResolver() {
+			return unavailable()
+		},
+		get projectSchemaResolver() {
+			return unavailable()
+		},
+		get projectInitializer() {
+			return unavailable()
+		},
+		get tenantContainer() {
+			return unavailable()
+		},
+		get tenantGraphQLHandler() {
+			return unavailable()
+		},
+		get systemContainer() {
+			return unavailable()
+		},
+		get systemGraphQLHandler() {
+			return unavailable()
+		},
+	}
+	const projectGroupResolver = createMock<ProjectGroupResolver>({
+		resolveContainer: async () => projectGroup,
+	})
+	return new Application(projectGroupResolver, serverConfigSchema({ port: 0 }), false, undefined, logger)
+}
+
+test('waits for an active HTTP stream when shutting down after a WebSocket upgrade', async () => {
+	const application = createTestApplication()
+	let releaseStream = () => {}
+	const streamReleased = new Promise<void>(resolve => {
+		releaseStream = resolve
+	})
+	application.addRoute('transfer', '/stream', context => {
+		context.koa.status = 200
+		context.koa.body = Readable.from((async function*() {
+			yield 'first'
+			await streamReleased
+			yield 'second'
+		})())
+	})
+	let resolveWebsocketCleanup = () => {}
+	const websocketCleanup = new Promise<void>(resolve => {
+		resolveWebsocketCleanup = resolve
+	})
+	application.addWebsocketRoute('actions', '/actions', ({ ws, abortSignal }) => {
+		abortSignal.addEventListener('abort', () => ws.close(1012), { once: true })
+		ws.once('close', resolveWebsocketCleanup)
+	})
+	const running = await application.listen()
+	const address = running.server.address()
+	if (address === null || typeof address === 'string') {
+		await running.close()
+		throw new Error('The test server did not bind to a TCP port')
+	}
+	const client = new WebSocket(`ws://127.0.0.1:${address.port}/actions`)
+	const opened = new Promise<void>((resolve, reject) => {
+		client.once('open', () => resolve())
+		client.once('error', reject)
+	})
+	const clientClosed = new Promise<number>(resolve => client.once('close', code => resolve(code)))
+	let shutdown: Promise<void> | undefined
+	try {
+		await opened
+		const response = await fetch(`http://127.0.0.1:${address.port}/stream`)
+		const responseBody = response.text()
+		let shutdownFinished = false
+		shutdown = running.close().then(() => {
+			shutdownFinished = true
+		})
+		await websocketCleanup
+		await new Promise<void>(resolve => setImmediate(resolve))
+		expect(shutdownFinished).toBe(false)
+		releaseStream()
+		expect(await responseBody).toBe('firstsecond')
+		await shutdown
+		expect(await clientClosed).toBe(1012)
+	} finally {
+		releaseStream()
+		shutdown ??= running.close()
+		await shutdown
+		client.terminate()
+	}
+})
+
+test('rejects a WebSocket upgrade whose authentication finishes during shutdown', async () => {
+	let releaseAuthentication = () => {}
+	const authenticationReleased = new Promise<void>(resolve => {
+		releaseAuthentication = resolve
+	})
+	let authenticationStarted = () => {}
+	const started = new Promise<void>(resolve => {
+		authenticationStarted = resolve
+	})
+	const application = createTestApplication(async () => {
+		authenticationStarted()
+		await authenticationReleased
+		return new VerifyResult('identity', 'api-key', ['member'], null)
+	})
+	let controllerCalled = false
+	application.addWebsocketRoute('actions', '/actions', () => {
+		controllerCalled = true
+	})
+	const running = await application.listen()
+	const address = running.server.address()
+	if (address === null || typeof address === 'string') {
+		await running.close()
+		throw new Error('The test server did not bind to a TCP port')
+	}
+	const client = new WebSocket(`ws://127.0.0.1:${address.port}/actions`)
+	client.on('error', () => {})
+	const clientClosed = new Promise<void>(resolve => client.once('close', () => resolve()))
+
+	await started
+	const shutdown = running.close()
+	releaseAuthentication()
+	await shutdown
+	await clientClosed
+	expect(controllerCalled).toBe(false)
+})


### PR DESCRIPTION
## Summary

- complete application shutdown under Bun after WebSocket upgrades without truncating active HTTP streams
- reject new requests and upgrades while shutdown drains existing work
- wait for WebSocket cleanup registered by controllers
- remove workers that fail to start and await all worker cleanup paths
- report cleanup failures without leaving the WebSocket open or creating unhandled rejections

## Review follow-ups

- **The `error` handler is registered right after the upgrade.** It used to be attached only after the controller returned, so an error while the abort path awaited the close handshake had no listener at all — `ws` emits `'error'` on the instance, which becomes `ERR_UNHANDLED_ERROR` and kills the process mid-drain. That handshake wait is now bounded too; `ws` itself only gives up after 30 s, which outlives a typical grace period.
- **An upgrade rejected by shutdown gets a 503** instead of a socket reset, matching every other rejection in the same handler. Note this only reaches the client on Node: Bun's `node:http` silently swallows every write to the socket handed to the `upgrade` event (verified against Bun 1.3.14 — Node answers, Bun delivers nothing), so `sendRawHttpResponse` there — including the pre-existing 404/500 paths — still behaves as a plain close.
- **The drain waits on WebSocket and HTTP work concurrently** rather than summing the two, which matters against a 30 s `terminationGracePeriodSeconds`. The `while (activeHttpRequests.size > 0)` loop it replaces could never iterate twice, since `closing` already stops new requests from being tracked.
- **Leftover idle connections are closed on Node too**, and Bun's `closeAllConnections()` is no longer gated on having seen an upgrade — a Bun server that never took one had the same hang.
- **`server.close()` errors are logged instead of rejecting.** The rejection introduced here reached `Promise.allSettled` in `listenOnProcessTermination`, which drops the reason, so a failed shutdown was silent.
- **A worker whose cleanup fails stays tracked.** `stopAll()` emptied the list before awaiting, so a worker whose `end()` rejected was forgotten while still running and the next stop reported a clean shutdown. Every cleanup error is now reported, not just the first.

Not changed: moving `server.close()` ahead of the drain — the ordering that would remove the (already negligible) window for a connection accepted between `closeAllConnections()` and `close()`. Under Bun the close callback then never fires and four of these tests hang, so the listening socket stays open until the drain finishes.

## Tests

- `bun test --conditions=typescript packages/engine-http/tests/cases/unit packages/engine-actions/tests/cases/unit` — 135 pass
- `bunx tsc --build packages/engine-http/tests/tsconfig.json packages/engine-actions/tests/tsconfig.json`
- targeted Biome and dprint checks

`a worker whose cleanup fails stays tracked for the next stop` is new and was confirmed to fail against the previous `stopAll()`.
