### PR TITLE
fix(schema-migrations): quote the collation name when creating a column

### DIFF
--- a/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
+++ b/packages/schema-migrations/src/modifications/columns/CreateColumnModification.ts
@@ -6,6 +6,7 @@ import { isColumn } from '@contember/schema-utils'
 import { createFields } from '../utils/diffUtils.js'
 import { getColumnSqlType } from '../utils/columnUtils.js'
 import { fillSeed, formatSeedExpression } from './columnUtils.js'
+import { wrapIdentifier } from '../../utils/dbHelpers.js'
 
 export class CreateColumnModificationHandler implements ModificationHandler<CreateColumnModificationData> {
 	constructor(private readonly data: CreateColumnModificationData, private readonly schema: Schema) {}
@@ -32,7 +33,7 @@ export class CreateColumnModificationHandler implements ModificationHandler<Crea
 				type: columnType,
 				notNull: !column.nullable && seedExpression === null,
 				sequenceGenerated: column.sequence,
-				collation: column.collation,
+				collation: column.collation !== undefined ? wrapIdentifier(column.collation) : undefined,
 			},
 		})
 

--- a/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
+++ b/packages/schema-migrations/tests/cases/integration/createColumn.test.ts
@@ -229,3 +229,31 @@ describe('create numeric column', () =>
 		],
 		sql: SQL`ALTER TABLE "author" ADD "balance" numeric(20, 9);`,
 	}))
+
+describe('create a column with a collation', () =>
+	testMigrations({
+		original: createSchema({
+			Author: class Author {
+			},
+		}),
+		updated: createSchema({
+			Author: class Author {
+				name = def.stringColumn().collation('und-x-icu')
+			},
+		}),
+		diff: [
+			{
+				modification: 'createColumn',
+				entityName: 'Author',
+				field: {
+					columnName: 'name',
+					name: 'name',
+					nullable: true,
+					type: Model.ColumnType.String,
+					columnType: 'text',
+					collation: 'und-x-icu',
+				},
+			},
+		],
+		sql: SQL`ALTER TABLE "author" ADD "name" text COLLATE "und-x-icu";`,
+	}))


### PR DESCRIPTION
## Problem

`createColumn` passes the collation straight to the migration builder, which interpolates it verbatim into the DDL:

```sql
ALTER TABLE "author" ADD "name" text COLLATE und-x-icu NOT NULL;
                                             ^ syntax error at or near "-"
```

Every ICU collation name contains a hyphen, so adding a new collated column by migration has never worked. `UpdateColumnDefinitionModification` already wraps the name with `wrapIdentifier`; `CreateColumnModification` did not.

The gap stayed hidden because a project that adds a collation to an existing column goes through `updateColumnDefinition`, which is the quoted path. It surfaces when replaying a schema from scratch — the differ emits `createEntity` for the table and `createColumn` for every non-primary column, collation included.

## Fix

Wrap the collation with `wrapIdentifier`, matching the update path.

## Test

New case in `createColumn.test.ts` pinning the emitted DDL. It fails on `main` and passes with the fix; the rest of `schema-migrations` (349 tests) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TH9xxm9uVDVuDYoDwuBJSB