### PR TITLE
fix(tenant-api): qualify the IdP re-validation claim with the tenant schema

### DIFF
--- a/packages/engine-tenant-api/src/model/commands/idp/ClaimIdpRevalidationCommand.ts
+++ b/packages/engine-tenant-api/src/model/commands/idp/ClaimIdpRevalidationCommand.ts
@@ -1,3 +1,4 @@
+import { UpdateBuilder } from '@contember/database'
 import { Command } from '../Command.js'
 
 /**
@@ -17,12 +18,12 @@ export class ClaimIdpRevalidationCommand implements Command<boolean> {
 	}
 
 	async execute({ db }: Command.Args): Promise<boolean> {
-		const result = await db.query(
-			`UPDATE "idp_session"
-			 SET "last_validated_at" = now()
-			 WHERE "id" = ? AND "last_validated_at" <= now() - ?::interval`,
-			[this.id, this.interval],
-		)
-		return (result.rowCount ?? 0) > 0
+		const qb = UpdateBuilder.create()
+			.table('idp_session')
+			.where({ id: this.id })
+			.where(expr => expr.raw('"last_validated_at" <= now() - ?::interval', this.interval))
+			.values({ last_validated_at: expr => expr.raw('now()') })
+
+		return (await qb.execute(db)) > 0
 	}
 }

--- a/packages/engine-tenant-api/tests/cases/unit/idp/claimIdpRevalidation.test.ts
+++ b/packages/engine-tenant-api/tests/cases/unit/idp/claimIdpRevalidation.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'bun:test'
+import { createConnectionMock, type ExpectedQuery } from '@contember/database-tester'
+import { DatabaseContext, type Providers } from '../../../../src/index.js'
+import { ClaimIdpRevalidationCommand } from '../../../../src/model/commands/idp/ClaimIdpRevalidationCommand.js'
+
+const providers: Providers = {
+	bcrypt: async value => value,
+	bcryptCompare: async () => true,
+	now: () => new Date('2026-05-26T12:00:00Z'),
+	randomBytes: async length => Buffer.alloc(length),
+	uuid: () => '00000000-0000-0000-0000-000000000000',
+	decrypt: async value => ({ value, needsReEncrypt: false }),
+	encrypt: async value => ({ value, version: 1 }),
+	encryptionEnabled: true,
+	hash: value => Buffer.from(value.toString()),
+}
+
+const execute = async (expectedQuery: ExpectedQuery): Promise<boolean> => {
+	const expectedQueries = [expectedQuery]
+	const connection = createConnectionMock(expectedQueries)
+	const db = new DatabaseContext(connection.createClient('tenant', { module: 'tenant' }), providers)
+
+	const claimed = await db.commandBus.execute(new ClaimIdpRevalidationCommand('idp-session-1', '30 seconds'))
+
+	expect(expectedQueries).toHaveLength(0)
+	return claimed
+}
+
+// The table must be schema-qualified: the tenant schema is not on the connection's search_path,
+// so an unqualified name makes the claim fail on every request, and the caller treats that as
+// "somebody else holds the claim" — re-validation then never runs at all.
+test('the claim is issued against the qualified tenant table', async () => {
+	const claimed = await execute({
+		sql: 'update "tenant"."idp_session" set "last_validated_at" = now() where "id" = ? and "last_validated_at" <= now() - ?::interval',
+		parameters: ['idp-session-1', '30 seconds'],
+		response: { rowCount: 1 },
+	})
+
+	expect(claimed).toBe(true)
+})
+
+test('a session still inside the throttle window is not claimed', async () => {
+	const claimed = await execute({
+		sql: 'update "tenant"."idp_session" set "last_validated_at" = now() where "id" = ? and "last_validated_at" <= now() - ?::interval',
+		parameters: ['idp-session-1', '30 seconds'],
+		response: { rowCount: 0 },
+	})
+
+	expect(claimed).toBe(false)
+})


### PR DESCRIPTION
## What happens

On a deployment running `2.2.0-alpha.6`, Postgres logged this continuously, hundreds of times an hour, while every request answered `200`:

```
ERROR:  relation "idp_session" does not exist at character 8
STATEMENT:  UPDATE "idp_session" SET "last_validated_at" = now()
            WHERE "id" = $1 AND "last_validated_at" <= now() - $2::interval
```

## Cause

`ClaimIdpRevalidationCommand` built its statement as a raw string with an unqualified table name, so it resolved through `search_path` — which does not carry the tenant schema. It was the only raw statement in the repository that named a table without qualifying it (see the audit below).

The neighbouring `IdpSessionByApiKeyQuery` goes through `SelectBuilder`, which compiles against `db.schema`, so the lookup kept working and only the claim failed.

## Why it is not just noise

`IdpSessionRevalidator.revalidate()` wraps the claim in a `catch` that treats a failure as transient and returns `'valid'`. The failure is not transient — the claim can never succeed — so:

- continuous re-validation never runs; a session revoked or a user disabled at the IdP stays usable until the session key expires on its own,
- the SWR / blocking refresh path never rotates a token,
- nothing is logged and no request fails, so the only visible trace is in the database log.

Still working, because it is checked before the claim: revocation on a disabled identity provider (`providerDisabledAt`).

## Fix

Rebuilt on `UpdateBuilder`, matching `DisableApiKeyCommand` and the rest of the package. Same SQL, same single-flight semantics, now schema-qualified.

## Audit of the other raw statements

Every `.query()` call with literal SQL across all packages was checked. All others are either schema-agnostic (`SAVEPOINT`, `LISTEN`, `SET CONSTRAINTS`, advisory locks, `pg_catalog` lookups, `CREATE DATABASE`) or already interpolate a schema explicitly — `ConstraintHelper`, `RefreshViewResolver`, `ProjectTruncateExecutor`, `ImportExecutor`, `ExportExecutor`, `CreateStageCommand`, `ProjectMigrator`. The migrations runner sets `search_path` itself. This command was the only offender.

## Test

`tests/cases/unit/idp/claimIdpRevalidation.test.ts` asserts the compiled SQL through `createConnectionMock`, and fails against the previous implementation. The existing revalidator tests could not catch this: they stub the command bus, so no SQL is ever compiled.

Verified: `bun test packages/engine-tenant-api` (519 pass), `tsc --build`, `biome lint`, `dprint check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdDexVWQBSmEzycdCJ4mLD