### PR TITLE
feat(engine-http): keep serving for a configurable delay after SIGTERM

### DIFF
--- a/docs/src/content/docs/guides/self-hosted-contember.mdx
+++ b/docs/src/content/docs/guides/self-hosted-contember.mdx
@@ -76,6 +76,16 @@ TENANT_MAILER_FROM: "noreply@example.com"
 
 HTTP server should start on the specified port. You can add a load-balancer in front of the app. The container is stateless and therefore horizontally scalable.
 
+#### Graceful shutdown
+
+On `SIGTERM`, the engine stops taking requests and exits as soon as the ones in flight have finished — usually within milliseconds. A load balancer or an orchestrator typically stops routing to a container only some time after it sends that signal, so requests still on their way are refused. Set `CONTEMBER_SHUTDOWN_DELAY_MS` to keep serving normally for that long after `SIGTERM` before shutting down:
+
+```yaml
+CONTEMBER_SHUTDOWN_DELAY_MS: "5000"
+```
+
+This is the in-process equivalent of a Kubernetes `preStop` sleep hook; a few seconds covers endpoint propagation there. Keep it well below `terminationGracePeriodSeconds`, which counts the delay too. `SIGINT` (Ctrl+C) never waits.
+
 After the server is running, use Contember CLI to set up other API tokens and invite users. Deploy the
 `blog` project to this instance with `CONTEMBER_API_URL` and `CONTEMBER_API_TOKEN` set:
 

--- a/packages/engine-http/src/config/configSchema.ts
+++ b/packages/engine-http/src/config/configSchema.ts
@@ -218,6 +218,8 @@ export const serverConfigSchema = Typesafe.partial({
 	monitoringPort: Typesafe.number,
 	workerCount: Typesafe.union(Typesafe.number, Typesafe.string),
 	applicationWorker: Typesafe.string,
+	// How long the engine keeps serving after SIGTERM before it shuts down; unset means at once.
+	shutdownDelayMs: Typesafe.number,
 	test: Typesafe.partial({
 		transactions: Typesafe.boolean,
 		transactionTtlSeconds: Typesafe.number,

--- a/packages/engine-http/src/config/configTemplate.ts
+++ b/packages/engine-http/src/config/configTemplate.ts
@@ -87,6 +87,7 @@ export const configTemplate: any = {
 		monitoringPort: '%?env.CONTEMBER_MONITORING_PORT::number%',
 		workerCount: '%?env.CONTEMBER_WORKER_COUNT::string%',
 		applicationWorker: '%?env.CONTEMBER_APPLICATION_WORKER::string%',
+		shutdownDelayMs: '%?env.CONTEMBER_SHUTDOWN_DELAY_MS::number%',
 		http: {
 			requestBodySize: '%?env.CONTEMBER_HTTP_REQUEST_BODY_SIZE::string%',
 			suppressAccessLog: '%?env.CONTEMBER_HTTP_SUPPRESS_ACCESS_LOG::string%',

--- a/packages/engine-http/src/utils/serverTermination.ts
+++ b/packages/engine-http/src/utils/serverTermination.ts
@@ -7,9 +7,27 @@ const signals = {
 	SIGTERM: 15,
 }
 export type TerminationJob = (args: { signal: keyof typeof signals; code: number }) => Promise<void>
-export const listenOnProcessTermination = (jobs: TerminationJob[], logger: Logger) => {
+
+export interface ProcessTerminationOptions {
+	/**
+	 * How long the process keeps serving after SIGTERM before the jobs run. An orchestrator stops routing to
+	 * a process only some time after signalling it, so draining at once refuses what is still on its way.
+	 * SIGINT and SIGHUP never wait.
+	 */
+	readonly sigtermDelayMs?: number
+}
+
+export const listenOnProcessTermination = (
+	jobs: TerminationJob[],
+	logger: Logger,
+	{ sigtermDelayMs = 0 }: ProcessTerminationOptions = {},
+) => {
 	for (const [signal, code] of Object.entries(signals)) {
 		process.on(signal, async () => {
+			if (signal === 'SIGTERM' && sigtermDelayMs > 0) {
+				logger.info(`Process ${process.pid} received a SIGTERM signal, serving for another ${sigtermDelayMs} ms before terminating`)
+				await new Promise(resolve => setTimeout(resolve, sigtermDelayMs))
+			}
 			logger.info(`Process ${process.pid} received a ${signal} signal, executing ${jobs.length} termination jobs`)
 			await Promise.allSettled(jobs.map(it => it({ signal: signal as keyof typeof signals, code })))
 			logger.info(cluster.isMaster ? `All terminated, exiting` : 'All terminated, exiting a worker')

--- a/packages/engine-http/tests/cases/unit/serverConfig.test.ts
+++ b/packages/engine-http/tests/cases/unit/serverConfig.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test'
+import { readConfig } from '../../../src/config/config.js'
 import { serverConfigSchema } from '../../../src/config/configSchema.js'
 
 const trustedProxies = (val: unknown): unknown => serverConfigSchema({ http: { trustedProxies: val } }).http?.trustedProxies
@@ -67,4 +68,19 @@ test('geoCountryHeader: a string passes through unchanged', () => {
 test('geoCountryHeader: a non-string value throws (fail-fast on misconfiguration)', () => {
 	expect(() => geoCountryHeader(123)).toThrow()
 	expect(() => geoCountryHeader({})).toThrow()
+})
+
+test('shutdownDelayMs: read from CONTEMBER_SHUTDOWN_DELAY_MS', async () => {
+	process.env.CONTEMBER_SHUTDOWN_DELAY_MS = '5000'
+	try {
+		const { serverConfig } = await readConfig()
+		expect(serverConfig.shutdownDelayMs).toBe(5000)
+	} finally {
+		delete process.env.CONTEMBER_SHUTDOWN_DELAY_MS
+	}
+})
+
+test('shutdownDelayMs: undefined when the variable is unset', async () => {
+	const { serverConfig } = await readConfig()
+	expect(serverConfig.shutdownDelayMs).toBeUndefined()
 })

--- a/packages/engine-http/tests/cases/unit/serverTermination.fixture.ts
+++ b/packages/engine-http/tests/cases/unit/serverTermination.fixture.ts
@@ -1,0 +1,13 @@
+import { createLogger, TestLoggerHandler } from '@contember/logger'
+import { listenOnProcessTermination } from '../../../src/utils/serverTermination.js'
+
+// Driven by serverTermination.test.ts: prints READY once it listens for signals, JOBS once the jobs run.
+listenOnProcessTermination(
+	[async () => {
+		console.log('JOBS')
+	}],
+	createLogger(new TestLoggerHandler()),
+	{ sigtermDelayMs: Number(process.argv[2]) },
+)
+setInterval(() => {}, 60_000)
+console.log('READY')

--- a/packages/engine-http/tests/cases/unit/serverTermination.test.ts
+++ b/packages/engine-http/tests/cases/unit/serverTermination.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'bun:test'
+import { join } from 'node:path'
+
+const fixture = join(import.meta.dir, 'serverTermination.fixture.ts')
+
+/** Starts the fixture, sends `signal` once it listens, and measures how long the termination jobs waited. */
+const terminate = async (signal: 'SIGTERM' | 'SIGINT', sigtermDelayMs: number) => {
+	const proc = Bun.spawn(['bun', '--conditions=typescript', fixture, String(sigtermDelayMs)], { stdout: 'pipe', stderr: 'inherit' })
+	const reader = proc.stdout.getReader()
+	const decoder = new TextDecoder()
+	let output = ''
+	const waitFor = async (marker: string): Promise<number> => {
+		while (!output.includes(marker)) {
+			const { done, value } = await reader.read()
+			if (done) {
+				throw new Error(`The fixture exited before printing ${marker}: ${output}`)
+			}
+			output += decoder.decode(value)
+		}
+		return performance.now()
+	}
+	await waitFor('READY')
+	const signalledAt = performance.now()
+	proc.kill(signal)
+	const jobsRanAt = await waitFor('JOBS')
+	return { jobsWaitedMs: jobsRanAt - signalledAt, exitCode: await proc.exited }
+}
+
+test('keeps serving for the configured delay after SIGTERM, then runs the jobs', async () => {
+	const { jobsWaitedMs, exitCode } = await terminate('SIGTERM', 600)
+
+	expect(jobsWaitedMs).toBeGreaterThanOrEqual(590)
+	expect(exitCode).toBe(143)
+})
+
+test('runs the jobs at once on SIGTERM when no delay is configured', async () => {
+	const { jobsWaitedMs, exitCode } = await terminate('SIGTERM', 0)
+
+	expect(jobsWaitedMs).toBeLessThan(400)
+	expect(exitCode).toBe(143)
+})
+
+// Only the orchestrator's stop signal waits: an interactive Ctrl+C must not.
+test('runs the jobs at once on SIGINT even when a delay is configured', async () => {
+	const { jobsWaitedMs, exitCode } = await terminate('SIGINT', 600)
+
+	expect(jobsWaitedMs).toBeLessThan(400)
+	expect(exitCode).toBe(130)
+})

--- a/packages/engine-server/src/start.ts
+++ b/packages/engine-server/src/start.ts
@@ -60,7 +60,10 @@ process.on('warning', message => {
 
 	let initializedProjects: string[] = []
 	const terminationJobs: TerminationJob[] = []
-	listenOnProcessTermination(terminationJobs, logger)
+	// A cluster worker is signalled by the master, which has already served the delay.
+	listenOnProcessTermination(terminationJobs, logger, {
+		sigtermDelayMs: processType === 'clusterWorker' ? 0 : serverConfig.shutdownDelayMs,
+	})
 
 	if (cluster.isMaster) {
 		const monitoringPort = serverConfig.monitoringPort


### PR DESCRIPTION
## Problem

On `SIGTERM` the engine drains correctly: `closing = true`, new requests get `503`, in-flight ones finish, the listener closes, the process exits. On an idle instance that is over in about 2 ms. From a Kubernetes rollout on `v2.2.0-alpha.7`:

```
14:25:16.721  Process 1 received a SIGTERM signal, executing 3 termination jobs
14:25:16.722  API server terminated
14:25:16.723  All terminated, exiting
```

An orchestrator stops routing to a process only some time after it signals it. In Kubernetes, kube-proxy removes the endpoint from each node asynchronously, so for roughly a second new connections still land on the pod: a `503` while the drain runs, `ECONNREFUSED` once the process is gone. A client that reaches the engine through a Service directly, with no retrying proxy in between, sees these as errors on every rollout. We hit exactly that in production.

A better drain cannot fix it: nothing the process can observe says that routing has caught up. Only a fixed wait before the drain starts can, as long as the engine keeps serving normally during it.

## Change

- **`server.shutdownDelayMs` / `CONTEMBER_SHUTDOWN_DELAY_MS`.** On SIGTERM the engine keeps serving normally for this long, then shuts down exactly as before. Unset keeps the current behaviour.
- **SIGTERM only.** That is what orchestrators and `docker stop` send. SIGINT (Ctrl+C) and SIGHUP still stop at once.
- **Cluster mode.** The master serves the delay before it disconnects the workers. A worker is signalled by the master afterwards, so it does not wait a second time.
- **Docs.** New "Graceful shutdown" section in the self-hosting guide.

On Kubernetes, a `preStop: sleep` hook does the same thing from outside. This makes it available where adding one is not an option, or where the engine does not run on Kubernetes.

## Tests

- `serverTermination.test.ts` spawns a real process, sends the signal, and measures when the termination jobs run:
  - SIGTERM with a delay waits for it (exit 143)
  - SIGTERM without a delay runs at once
  - SIGINT never waits (exit 130)

  Each assertion was checked by mutation: never applying the delay fails the first test, and applying it to every signal fails the third.
- `serverConfig.test.ts`: `CONTEMBER_SHUTDOWN_DELAY_MS` resolves to `serverConfig.shutdownDelayMs`, and is `undefined` when unset.
- `bun run ts:build`, `biome lint`, `dprint check` and `bun test packages/engine-http packages/engine-server` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dj6FYmLWyt7CcmQj8u3CG
